### PR TITLE
Take createBuckets out of stages

### DIFF
--- a/smt/pkg/db/mdbx.go
+++ b/smt/pkg/db/mdbx.go
@@ -4,12 +4,13 @@ import (
 	"math/big"
 
 	"fmt"
+	"strings"
+
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/ethdb"
 	"github.com/ledgerwatch/erigon/ethdb/olddb"
 	"github.com/ledgerwatch/erigon/smt/pkg/utils"
 	"github.com/ledgerwatch/log/v3"
-	"strings"
 )
 
 type SmtDbTx interface {
@@ -32,26 +33,30 @@ type EriDb struct {
 	tx   SmtDbTx
 }
 
-func NewEriDb(tx kv.RwTx) (*EriDb, error) {
+func CreateEriDbBuckets(tx kv.RwTx) error {
 	err := tx.CreateBucket(TableSmt)
 	if err != nil {
-		return &EriDb{}, err
+		return err
 	}
 
 	err = tx.CreateBucket(TableLastRoot)
 	if err != nil {
-		return &EriDb{}, err
+		return err
 	}
 
 	err = tx.CreateBucket(TableAccountValues)
 	if err != nil {
-		return &EriDb{}, err
+		return err
 	}
 
+	return nil
+}
+
+func NewEriDb(tx kv.RwTx) *EriDb {
 	return &EriDb{
 		kvTx: tx,
 		tx:   tx,
-	}, nil
+	}
 }
 
 func (m *EriDb) OpenBatch(quitCh <-chan struct{}) {

--- a/smt/pkg/db/mdbx_test.go
+++ b/smt/pkg/db/mdbx_test.go
@@ -2,17 +2,18 @@ package db
 
 import (
 	"context"
+	"math/big"
+	"testing"
+
 	"github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon/smt/pkg/utils"
 	"github.com/stretchr/testify/assert"
-	"math/big"
-	"testing"
 )
 
 func TestEriDb(t *testing.T) {
 	dbi, _ := mdbx.NewTemporaryMdbx()
 	tx, _ := dbi.BeginRw(context.Background())
-	db, _ := NewEriDb(tx)
+	db := NewEriDb(tx)
 
 	// The key and value we're going to test
 	key := utils.NodeKey{1, 2, 3, 4}
@@ -32,7 +33,7 @@ func TestEriDb(t *testing.T) {
 func TestEriDbBatch(t *testing.T) {
 	dbi, _ := mdbx.NewTemporaryMdbx()
 	tx, _ := dbi.BeginRw(context.Background())
-	db, _ := NewEriDb(tx)
+	db := NewEriDb(tx)
 
 	// The key and value we're going to test
 	key := utils.NodeKey{1, 2, 3, 4}

--- a/smt/pkg/smt/entity_storage_mdbx_test.go
+++ b/smt/pkg/smt/entity_storage_mdbx_test.go
@@ -208,7 +208,7 @@ func runGenesisTestMdbx(tb testing.TB, filename string) {
 	if err != nil {
 		tb.Fatal("Failed to open db: ", err)
 	}
-	sdb, _ := db2.NewEriDb(tx)
+	sdb := db2.NewEriDb(tx)
 
 	smt := NewSMT(sdb)
 
@@ -306,6 +306,6 @@ func getTempMdbx() (*db2.EriDb, kv.RwDB, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	sdb, _ := db2.NewEriDb(tx)
+	sdb := db2.NewEriDb(tx)
 	return sdb, dbi, nil
 }

--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
-	"github.com/ledgerwatch/log/v3"
 
 	dstypes "github.com/ledgerwatch/erigon/zk/datastream/types"
 	"github.com/ledgerwatch/erigon/zk/types"
@@ -39,44 +38,39 @@ func NewHermezDb(tx kv.RwTx) (*HermezDb, error) {
 	db := &HermezDb{tx: tx}
 	db.HermezDbReader = NewHermezDbReader(tx)
 
-	err := db.CreateBuckets()
-	if err != nil {
-		log.Warn("failed to create buckets", "err", err)
-	}
-
 	return db, nil
 }
 
-func (db *HermezDb) CreateBuckets() error {
-	err := db.tx.CreateBucket(L1VERIFICATIONS)
+func CreateHermezBuckets(tx kv.RwTx) error {
+	err := tx.CreateBucket(L1VERIFICATIONS)
 	if err != nil {
 		return err
 	}
-	err = db.tx.CreateBucket(L1SEQUENCES)
+	err = tx.CreateBucket(L1SEQUENCES)
 	if err != nil {
 		return err
 	}
-	err = db.tx.CreateBucket(FORKIDS)
+	err = tx.CreateBucket(FORKIDS)
 	if err != nil {
 		return err
 	}
-	err = db.tx.CreateBucket(BLOCKBATCHES)
+	err = tx.CreateBucket(BLOCKBATCHES)
 	if err != nil {
 		return err
 	}
-	err = db.tx.CreateBucket(GLOBAL_EXIT_ROOTS)
+	err = tx.CreateBucket(GLOBAL_EXIT_ROOTS)
 	if err != nil {
 		return err
 	}
-	err = db.tx.CreateBucket(GLOBAL_EXIT_ROOTS_BATCHES)
+	err = tx.CreateBucket(GLOBAL_EXIT_ROOTS_BATCHES)
 	if err != nil {
 		return err
 	}
-	err = db.tx.CreateBucket(TX_PRICE_PERCENTAGE)
+	err = tx.CreateBucket(TX_PRICE_PERCENTAGE)
 	if err != nil {
 		return err
 	}
-	err = db.tx.CreateBucket(STATE_ROOTS)
+	err = tx.CreateBucket(STATE_ROOTS)
 	if err != nil {
 		return err
 	}

--- a/zk/stages/stage_interhashes.go
+++ b/zk/stages/stage_interhashes.go
@@ -116,10 +116,7 @@ func SpawnZkIntermediateHashesStage(s *sync_stages.StageState, u sync_stages.Unw
 
 	shouldRegenerate := to > s.BlockNumber && to-s.BlockNumber > cfg.zk.RebuildTreeAfter
 
-	eridb, err := db2.NewEriDb(tx)
-	if err != nil {
-		return trie.EmptyRoot, err
-	}
+	eridb := db2.NewEriDb(tx)
 	smt := smt.NewSMT(eridb)
 
 	if s.BlockNumber == 0 || shouldRegenerate {
@@ -453,10 +450,7 @@ func unwindZkSMT(logPrefix string, from, to uint64, db kv.RwTx, cfg ZkInterHashe
 	log.Info(fmt.Sprintf("[%s] Unwind trie hashes started", logPrefix))
 	defer log.Info(fmt.Sprintf("[%s] Unwind ended", logPrefix))
 
-	eridb, err := db2.NewEriDb(db)
-	if err != nil {
-		return trie.EmptyRoot, err
-	}
+	eridb := db2.NewEriDb(db)
 	dbSmt := smt.NewSMT(eridb)
 
 	log.Info(fmt.Sprintf("[%s]", logPrefix), "last root", libcommon.BigToHash(dbSmt.LastRoot()))


### PR DESCRIPTION
We encountered a kv buckets map concurrent read/write, which was ocuring sparsely. This is an attempt to fix it. 

The only place we were writing to the buckets map was in CreateBuckets for erigonDb and hermezDb. Those are brought out of the stages cycles.