### PR TITLE
Include global exit root changes in witness

### DIFF
--- a/core/state/trie_db.go
+++ b/core/state/trie_db.go
@@ -802,6 +802,13 @@ func (tsw *TrieStateWriter) WriteAccountStorage(address common.Address, incarnat
 	return nil
 }
 
+func (tsw *TrieStateWriter) WriteChangeSets() error {
+	return nil
+}
+func (tsw *TrieStateWriter) WriteHistory() error {
+	return nil
+}
+
 func (tds *TrieDbState) makeBlockWitnessForPrefix(prefix []byte, trace bool, rl trie.RetainDecider, isBinary bool) (*trie.Witness, error) {
 	tds.tMu.Lock()
 	defer tds.tMu.Unlock()


### PR DESCRIPTION
Previously, changes in global exit root are not captured in witness. This commit fixes it. It also removed some duplicated code of block execution by reusing `core.ExecuteBlockEphemerally`.