### PR TITLE
Add zero tracer

### DIFF
--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -118,6 +118,8 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		txns = append(txns, borTx)
 	}
 
+	cumulativeGas := uint64(0)
+
 	for idx, txn := range txns {
 		stream.WriteObjectStart()
 		stream.WriteObjectField("result")
@@ -141,9 +143,12 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		}
 
 		txCtx := evmtypes.TxContext{
-			TxHash:   txn.Hash(),
-			Origin:   msg.From(),
-			GasPrice: msg.GasPrice(),
+			TxHash:            txn.Hash(),
+			Origin:            msg.From(),
+			GasPrice:          msg.GasPrice(),
+			Txn:               txn,
+			CumulativeGasUsed: &cumulativeGas,
+			BlockNum:          block.NumberU64(),
 		}
 
 		if borTx != nil && idx == len(txns)-1 {

--- a/core/types/trace.go
+++ b/core/types/trace.go
@@ -1,0 +1,56 @@
+// Trace types for sending proof information to a zk prover as defined in https://github.com/0xPolygonZero/proof-protocol-decoder.
+package types
+
+import (
+	"github.com/holiman/uint256"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+)
+
+type HexBytes []byte
+
+func (b HexBytes) MarshalText() ([]byte, error) {
+	return hexutility.Bytes(b[:]).MarshalText()
+}
+
+type ContractCodeUsage struct {
+	Read  *libcommon.Hash `json:"read,omitempty"`
+	Write HexBytes        `json:"write,omitempty"`
+}
+
+type TxnTrace struct {
+	Balance        *uint256.Int                    `json:"balance,omitempty"`
+	Nonce          *uint256.Int                    `json:"nonce,omitempty"`
+	StorageRead    []libcommon.Hash                `json:"storage_read,omitempty"`
+	StorageWritten map[libcommon.Hash]*uint256.Int `json:"storage_written,omitempty"`
+	CodeUsage      *ContractCodeUsage              `json:"code_usage,omitempty"`
+	SelfDestructed *bool                           `json:"self_destructed,omitempty"`
+	StorageReadMap map[libcommon.Hash]struct{}     `json:"-"`
+}
+
+type TxnMeta struct {
+	ByteCode           HexBytes `json:"byte_code,omitempty"`
+	NewTxnTrieNode     HexBytes `json:"new_txn_trie_node_byte,omitempty"`
+	NewReceiptTrieNode HexBytes `json:"new_receipt_trie_node_byte,omitempty"`
+	GasUsed            uint64   `json:"gas_used,omitempty"`
+}
+
+type TxnInfo struct {
+	Traces map[libcommon.Address]*TxnTrace `json:"traces,omitempty"`
+	Meta   TxnMeta                         `json:"meta,omitempty"`
+}
+
+type BlockUsedCodeHashes []libcommon.Hash
+
+type CombinedPreImages struct {
+	Compact HexBytes `json:"compact,omitempty"`
+}
+
+type TriePreImage struct {
+	Combined CombinedPreImages `json:"combined,omitempty"`
+}
+
+type BlockTrace struct {
+	TriePreImage TriePreImage `json:"trie_pre_images,omitempty"`
+	TxnInfo      []TxnInfo    `json:"txn_info,omitempty"`
+}

--- a/core/vm/evmtypes/evmtypes.go
+++ b/core/vm/evmtypes/evmtypes.go
@@ -37,10 +37,13 @@ type BlockContext struct {
 // All fields can change between transactions.
 type TxContext struct {
 	// Message information
-	TxHash     libcommon.Hash
-	Origin     libcommon.Address // Provides information for ORIGIN
-	GasPrice   *uint256.Int      // Provides information for GASPRICE
-	DataHashes []libcommon.Hash  // Provides versioned data hashes for DATAHASH
+	TxHash            libcommon.Hash
+	Origin            libcommon.Address // Provides information for ORIGIN
+	GasPrice          *uint256.Int      // Provides information for GASPRICE
+	DataHashes        []libcommon.Hash  // Provides versioned data hashes for DATAHASH
+	Txn               types.Transaction
+	CumulativeGasUsed *uint64
+	BlockNum          uint64
 }
 
 type (
@@ -101,4 +104,5 @@ type IntraBlockState interface {
 	Snapshot() int
 
 	AddLog(*types.Log)
+	GetLogs(hash libcommon.Hash) []*types.Log
 }

--- a/eth/tracers/native/zero.go
+++ b/eth/tracers/native/zero.go
@@ -1,0 +1,357 @@
+package native
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"sync/atomic"
+
+	"github.com/holiman/uint256"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/core/vm"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/eth/tracers"
+	"github.com/ledgerwatch/log/v3"
+)
+
+var emptyCodeHash = crypto.Keccak256(nil)
+
+//go:generate go run github.com/fjl/gencodec -type account -field-override accountMarshaling -out gen_account_json.go
+
+func init() {
+	register("zeroTracer", newZeroTracer)
+}
+
+type zeroTracer struct {
+	noopTracer  // stub struct to mock not used interface methods
+	env         vm.VMInterface
+	tx          types.TxnInfo
+	gasLimit    uint64      // Amount of gas bought for the whole tx
+	interrupt   atomic.Bool // Atomic flag to signal execution interruption
+	reason      error       // Textual reason for the interruption
+	ctx         *tracers.Context
+	to          *libcommon.Address
+	txStatus    uint64
+	addrOpCodes map[libcommon.Address]map[vm.OpCode]struct{}
+}
+
+func newZeroTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Tracer, error) {
+	return &zeroTracer{
+		tx: types.TxnInfo{
+			Traces: make(map[libcommon.Address]*types.TxnTrace),
+		},
+		ctx:         ctx,
+		addrOpCodes: make(map[libcommon.Address]map[vm.OpCode]struct{}),
+	}, nil
+}
+
+// CaptureStart implements the EVMLogger interface to initialize the tracing operation.
+func (t *zeroTracer) CaptureStart(env vm.VMInterface, from libcommon.Address, to libcommon.Address, precompile, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	t.to = &to
+	t.env = env
+
+	t.addAccountToTrace(from)
+	t.addAccountToTrace(to)
+	t.addAccountToTrace(env.Context().Coinbase)
+
+	if code != nil {
+		t.addOpCodeToAccount(to, vm.CALL)
+	}
+
+	// The recipient balance includes the value transferred.
+	toBal := new(big.Int).Sub(t.tx.Traces[to].Balance.ToBig(), value.ToBig())
+	t.tx.Traces[to].Balance = uint256.MustFromBig(toBal)
+
+	// The sender balance is after reducing: value and gasLimit.
+	// We need to re-add them to get the pre-tx balance.
+	fromBal := new(big.Int).Set(t.tx.Traces[from].Balance.ToBig())
+	gasPrice := env.TxContext().GasPrice
+	consumedGas := new(big.Int).Mul(gasPrice.ToBig(), new(big.Int).SetUint64(t.gasLimit))
+	fromBal.Add(fromBal, new(big.Int).Add(value.ToBig(), consumedGas))
+	t.tx.Traces[from].Balance = uint256.MustFromBig(fromBal)
+	if t.tx.Traces[from].Nonce.Cmp(uint256.NewInt(0)) > 0 {
+		t.tx.Traces[from].Nonce.Sub(t.tx.Traces[from].Nonce, uint256.NewInt(1))
+	}
+}
+
+func (t *zeroTracer) CaptureEnter(op vm.OpCode, from libcommon.Address, to libcommon.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	t.addAccountToTrace(from)
+	t.addAccountToTrace(to)
+	t.addOpCodeToAccount(to, op)
+}
+
+func (t *zeroTracer) CaptureTxStart(gasLimit uint64) {
+	t.gasLimit = gasLimit
+}
+
+// CaptureState implements the EVMLogger interface to trace a single step of VM execution.
+func (t *zeroTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+	if err != nil {
+		return
+	}
+
+	// Skip if tracing was interrupted
+	if t.interrupt.Load() {
+		return
+	}
+
+	stack := scope.Stack
+	stackData := stack.Data
+	stackLen := len(stackData)
+	caller := scope.Contract.Address()
+
+	switch {
+	case stackLen >= 1 && op == vm.SLOAD:
+		slot := libcommon.Hash(stackData[stackLen-1].Bytes32())
+		t.addSLOADToAccount(caller, slot)
+	case stackLen >= 1 && op == vm.SSTORE:
+		slot := libcommon.Hash(stackData[stackLen-1].Bytes32())
+		t.addSSTOREToAccount(caller, slot, stackData[stackLen-2].Clone())
+	case stackLen >= 1 && (op == vm.EXTCODECOPY || op == vm.EXTCODEHASH || op == vm.EXTCODESIZE || op == vm.BALANCE || op == vm.SELFDESTRUCT):
+		addr := libcommon.Address(stackData[stackLen-1].Bytes20())
+		t.addAccountToTrace(addr)
+		t.addOpCodeToAccount(addr, op)
+	case stackLen >= 5 && (op == vm.DELEGATECALL || op == vm.CALL || op == vm.STATICCALL || op == vm.CALLCODE):
+		addr := libcommon.Address(stackData[stackLen-2].Bytes20())
+		t.addAccountToTrace(addr)
+		t.addOpCodeToAccount(addr, op)
+	case op == vm.CREATE:
+		nonce := t.env.IntraBlockState().GetNonce(caller)
+		addr := crypto.CreateAddress(caller, nonce)
+		t.addAccountToTrace(addr)
+		t.addOpCodeToAccount(addr, op)
+	case stackLen >= 4 && op == vm.CREATE2:
+		offset := stackData[stackLen-2]
+		size := stackData[stackLen-3]
+		init, err := GetMemoryCopyPadded(scope.Memory, int64(offset.Uint64()), int64(size.Uint64()))
+		if err != nil {
+			log.Warn("failed to copy CREATE2 input", "err", err, "tracer", "prestateTracer", "offset", offset, "size", size)
+			return
+		}
+		inithash := crypto.Keccak256(init)
+		salt := stackData[stackLen-4]
+		addr := crypto.CreateAddress2(caller, salt.Bytes32(), inithash)
+		t.addAccountToTrace(addr)
+		t.addOpCodeToAccount(addr, op)
+	}
+}
+
+const (
+	memoryPadLimit = 1024 * 1024
+)
+
+// GetMemoryCopyPadded returns offset + size as a new slice.
+// It zero-pads the slice if it extends beyond memory bounds.
+func GetMemoryCopyPadded(m *vm.Memory, offset, size int64) ([]byte, error) {
+	if offset < 0 || size < 0 {
+		return nil, errors.New("offset or size must not be negative")
+	}
+	if int(offset+size) < m.Len() { // slice fully inside memory
+		return m.GetCopy(offset, size), nil
+	}
+	paddingNeeded := int(offset+size) - m.Len()
+	if paddingNeeded > memoryPadLimit {
+		return nil, fmt.Errorf("reached limit for padding memory slice: %d", paddingNeeded)
+	}
+	cpy := make([]byte, size)
+	if overlap := int64(m.Len()) - offset; overlap > 0 {
+		copy(cpy, m.GetPtr(offset, overlap))
+	}
+	return cpy, nil
+}
+
+func (t *zeroTracer) CaptureTxEnd(restGas uint64) {
+	t.tx.Meta.GasUsed = t.gasLimit - restGas
+	*t.ctx.CumulativeGasUsed += t.tx.Meta.GasUsed
+
+	for addr := range t.tx.Traces {
+		trace := t.tx.Traces[addr]
+		newBalance := t.env.IntraBlockState().GetBalance(addr)
+		newNonce := uint256.NewInt(t.env.IntraBlockState().GetNonce(addr))
+		codeHash := t.env.IntraBlockState().GetCodeHash(addr)
+		code := t.env.IntraBlockState().GetCode(addr)
+		hasSelfDestructed := t.env.IntraBlockState().HasSelfdestructed(addr)
+
+		if newBalance.Cmp(trace.Balance) != 0 {
+			trace.Balance = newBalance.Clone()
+		} else {
+			trace.Balance = nil
+		}
+
+		if newNonce.Cmp(trace.Nonce) != 0 {
+			trace.Nonce = newNonce.Clone()
+		} else {
+			trace.Nonce = nil
+		}
+
+		if len(trace.StorageReadMap) > 0 {
+			trace.StorageRead = make([]libcommon.Hash, 0, len(trace.StorageReadMap))
+			for k := range trace.StorageReadMap {
+				trace.StorageRead = append(trace.StorageRead, k)
+			}
+		} else {
+			trace.StorageRead = nil
+		}
+
+		if len(trace.StorageWritten) == 0 {
+			trace.StorageWritten = nil
+		} else {
+			// A slot write could be reverted if the transaction is reverted. We will need to read the value from the statedb again to get the correct value.
+			for k := range trace.StorageWritten {
+				var value uint256.Int
+				t.env.IntraBlockState().GetState(addr, &k, &value)
+				trace.StorageWritten[k] = &value
+			}
+		}
+
+		if !bytes.Equal(codeHash[:], emptyCodeHash) && !bytes.Equal(codeHash[:], trace.CodeUsage.Read[:]) {
+			trace.CodeUsage.Read = nil
+			trace.CodeUsage.Write = make([]byte, len(code))
+			copy(trace.CodeUsage.Write, code)
+		} else if code != nil {
+			codeHashCopy := libcommon.BytesToHash(codeHash.Bytes())
+			trace.CodeUsage.Read = &codeHashCopy
+		}
+
+		// When the code is empty for this account, we don't need to store the code usage
+		if code == nil {
+			trace.CodeUsage = nil
+		}
+
+		// if addr == libcommon.HexToAddress("0xed12310d5a37326e6506209c4838146950166760") {
+		// 	fmt.Printf("Address: %s, opcodes: %v\n", addr.String(), t.addrOpCodes[addr])
+		// }
+
+		// We don't need to provide the actual bytecode UNLESS the opcode is the following:
+		// DELEGATECALL, CALL, STATICCALL, CALLCODE, EXTCODECOPY, EXTCODEHASH, EXTCODESIZE
+		if trace.CodeUsage != nil && trace.CodeUsage.Read != nil && t.addrOpCodes[addr] != nil {
+			opCodes := []vm.OpCode{vm.DELEGATECALL, vm.CALL, vm.STATICCALL, vm.CALLCODE, vm.EXTCODECOPY,
+				vm.EXTCODEHASH, vm.EXTCODESIZE}
+			keep := false
+			for _, opCode := range opCodes {
+				if _, ok := t.addrOpCodes[addr][opCode]; ok {
+					keep = true
+					break
+				}
+			}
+			if !keep {
+				trace.CodeUsage = nil
+			}
+		}
+
+		if hasSelfDestructed {
+			trace.SelfDestructed = new(bool)
+			*trace.SelfDestructed = true
+		}
+	}
+
+	receipt := &types.Receipt{Type: t.ctx.Txn.Type(), CumulativeGasUsed: *t.ctx.CumulativeGasUsed}
+	receipt.Status = t.txStatus
+	receipt.TxHash = t.ctx.Txn.Hash()
+	receipt.GasUsed = t.tx.Meta.GasUsed
+
+	// if the transaction created a contract, store the creation address in the receipt.
+	if t.to == nil {
+		receipt.ContractAddress = crypto.CreateAddress(t.env.TxContext().Origin, t.ctx.Txn.GetNonce())
+	}
+	// Set the receipt logs and create a bloom for filtering
+	receipt.Logs = t.env.IntraBlockState().GetLogs(t.ctx.Txn.Hash())
+	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	receipt.BlockNumber = big.NewInt(0).SetUint64(t.ctx.BlockNum)
+	receipt.TransactionIndex = uint(t.ctx.TxIndex)
+
+	receiptBuffer := &bytes.Buffer{}
+	encodeErr := receipt.EncodeRLP(receiptBuffer)
+
+	if encodeErr != nil {
+		log.Error("failed to encode receipt", "err", encodeErr)
+		return
+	}
+
+	t.tx.Meta.NewReceiptTrieNode = receiptBuffer.Bytes()
+
+	txBuffer := &bytes.Buffer{}
+	encodeErr = t.ctx.Txn.MarshalBinary(txBuffer)
+
+	if encodeErr != nil {
+		log.Error("failed to encode transaction", "err", encodeErr)
+		return
+	}
+
+	t.tx.Meta.NewTxnTrieNode = txBuffer.Bytes()
+	t.tx.Meta.ByteCode = txBuffer.Bytes()
+}
+
+func (t *zeroTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
+	if err != nil {
+		t.txStatus = types.ReceiptStatusFailed
+	} else {
+		t.txStatus = types.ReceiptStatusSuccessful
+	}
+}
+
+// GetResult returns the json-encoded nested list of call traces, and any
+// error arising from the encoding or forceful termination (via `Stop`).
+func (t *zeroTracer) GetResult() (json.RawMessage, error) {
+	var res []byte
+	var err error
+	res, err = json.Marshal(t.tx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return json.RawMessage(res), t.reason
+}
+
+func (t *zeroTracer) GetTxnInfo() types.TxnInfo {
+	return t.tx
+}
+
+// Stop terminates execution of the tracer at the first opportune moment.
+func (t *zeroTracer) Stop(err error) {
+	t.reason = err
+	t.interrupt.Store(true)
+}
+
+func (t *zeroTracer) addAccountToTrace(addr libcommon.Address) {
+	if _, ok := t.tx.Traces[addr]; ok {
+		return
+	}
+
+	nonce := uint256.NewInt(t.env.IntraBlockState().GetNonce(addr))
+	codeHash := t.env.IntraBlockState().GetCodeHash(addr)
+
+	t.tx.Traces[addr] = &types.TxnTrace{
+		Balance:        t.env.IntraBlockState().GetBalance(addr).Clone(),
+		Nonce:          nonce,
+		CodeUsage:      &types.ContractCodeUsage{Read: &codeHash},
+		StorageWritten: make(map[libcommon.Hash]*uint256.Int),
+		StorageRead:    make([]libcommon.Hash, 0),
+		StorageReadMap: make(map[libcommon.Hash]struct{}),
+	}
+}
+
+func (t *zeroTracer) addSLOADToAccount(addr libcommon.Address, key libcommon.Hash) {
+	var value uint256.Int
+	t.env.IntraBlockState().GetState(addr, &key, &value)
+	t.tx.Traces[addr].StorageReadMap[key] = struct{}{}
+
+	t.addOpCodeToAccount(addr, vm.SLOAD)
+}
+
+func (t *zeroTracer) addSSTOREToAccount(addr libcommon.Address, key libcommon.Hash, value *uint256.Int) {
+	t.tx.Traces[addr].StorageWritten[key] = value
+	t.addOpCodeToAccount(addr, vm.SSTORE)
+}
+
+func (t *zeroTracer) addOpCodeToAccount(addr libcommon.Address, op vm.OpCode) {
+	if t.addrOpCodes[addr] == nil {
+		t.addrOpCodes[addr] = make(map[vm.OpCode]struct{})
+	}
+	t.addrOpCodes[addr][op] = struct{}{}
+}

--- a/eth/tracers/tracers.go
+++ b/eth/tracers/tracers.go
@@ -23,15 +23,19 @@ import (
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 
+	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/core/vm"
 )
 
 // Context contains some contextual infos for a transaction execution that is not
 // available from within the EVM object.
 type Context struct {
-	BlockHash libcommon.Hash // Hash of the block the tx is contained within (zero if dangling tx or call)
-	TxIndex   int            // Index of the transaction within a block (zero if dangling tx or call)
-	TxHash    libcommon.Hash // Hash of the transaction being traced (zero if dangling call)
+	BlockHash         libcommon.Hash // Hash of the block the tx is contained within (zero if dangling tx or call)
+	TxIndex           int            // Index of the transaction within a block (zero if dangling tx or call)
+	TxHash            libcommon.Hash // Hash of the transaction being traced (zero if dangling call)
+	Txn               types.Transaction
+	CumulativeGasUsed *uint64
+	BlockNum          uint64
 }
 
 // Tracer interface extends vm.EVMLogger and additionally

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -172,7 +172,10 @@ func TraceTx(
 			cfg = *config.TracerConfig
 		}
 		if tracer, err = tracers.New(*config.Tracer, &tracers.Context{
-			TxHash: txCtx.TxHash,
+			TxHash:            txCtx.TxHash,
+			Txn:               txCtx.Txn,
+			CumulativeGasUsed: txCtx.CumulativeGasUsed,
+			BlockNum:          blockCtx.BlockNumber,
 		}, cfg); err != nil {
 			stream.WriteNil()
 			return err


### PR DESCRIPTION
Zero tracer is a specific type of transaction tracer that records states read and written by a transaction.
The output of this tracer could be used together with block witness to generate intermediate block states in-between transactions.

## Additional resources

### Trace model class diagram

```mermaid
classDiagram
    class ContractCodeUsage {
        *Hash Read
        HexBytes Write
    }
    
    class TxnTrace {
        *uint256 Balance
        *uint256 Nonce
        Hash[] StorageRead
        map[Hash]*uint256 StorageWritten
        *ContractCodeUsage CodeUsage
        *bool SelfDestructed
        map[Hash]struct StorageReadMap
    }
    
    class TxnMeta {
        HexBytes ByteCode
        HexBytes NewTxnTrieNode
        HexBytes NewReceiptTrieNode
        uint64 GasUsed
    }
    
    class TxnInfo {
        map[Address]*TxnTrace Traces
        TxnMeta Meta
    }
    
    class CombinedPreImages {
        HexBytes Compact
    }
    
    class TriePreImage {
        CombinedPreImages Combined
    }
    
    class BlockTrace {
        TriePreImage TriePreImage
        TxnInfo[] TxnInfo
    }

    TxnTrace --> ContractCodeUsage
    TxnInfo o-- TxnTrace
    TxnInfo --> TxnMeta
    BlockTrace --> TriePreImage
    BlockTrace o-- TxnInfo
    TriePreImage --> CombinedPreImages
```