### PR TITLE
Block info tree on injected batches fix

### DIFF
--- a/core/blockchain_zkevm.go
+++ b/core/blockchain_zkevm.go
@@ -110,10 +110,15 @@ func ExecuteBlockEphemerallyZk(
 		return nil, err
 	}
 
-	blockGer, l1BlockHash, err := roHermezDb.GetBlockGlobalExitRoot(blockNum)
+	blockGer, err := roHermezDb.GetBlockGlobalExitRoot(blockNum)
 	if err != nil {
 		return nil, err
 	}
+	l1BlockHash, err := roHermezDb.GetBlockL1BlockHash(blockNum)
+	if err != nil {
+		return nil, err
+	}
+
 	blockTime := block.Time()
 	ibs.SyncerPreExecuteStateSet(chainConfig, blockNum, blockTime, prevBlockHash, &blockGer, &l1BlockHash, &gersInBetween)
 	blockInfoTree := blockinfo.NewBlockInfoTree()

--- a/core/blockchain_zkevm.go
+++ b/core/blockchain_zkevm.go
@@ -125,6 +125,17 @@ func ExecuteBlockEphemerallyZk(
 	if chainConfig.IsForkID7Etrog(blockNum) {
 		coinbase := block.Coinbase()
 
+		// this is a case when we have injected batches
+		// we have to save the l1block hash and in this case we have to add
+		// the ger in that l1 bloc k into the block info tree
+		// even though it is previously added to the state
+		if l1BlockHash != (libcommon.Hash{}) && blockGer == (libcommon.Hash{}) {
+			blockGer, err = roHermezDb.GetGerForL1BlockHash(l1BlockHash)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		if err := blockInfoTree.InitBlockHeader(
 			prevBlockHash,
 			&coinbase,

--- a/core/state/intra_block_state_zkevm.go
+++ b/core/state/intra_block_state_zkevm.go
@@ -28,6 +28,7 @@ type ReadOnlyHermezDb interface {
 	GetBatchGlobalExitRoots(fromBatchNum, toBatchNum uint64) ([]*dstypes.GerUpdate, error)
 	GetBlockGlobalExitRoot(l2BlockNo uint64) (libcommon.Hash, error)
 	GetBlockL1BlockHash(l2BlockNo uint64) (libcommon.Hash, error)
+	GetGerForL1BlockHash(l1BlockHash libcommon.Hash) (libcommon.Hash, error)
 }
 
 func (sdb *IntraBlockState) GetTxCount() (uint64, error) {

--- a/core/state/intra_block_state_zkevm.go
+++ b/core/state/intra_block_state_zkevm.go
@@ -26,7 +26,8 @@ type ReadOnlyHermezDb interface {
 	GetStateRoot(l2BlockNo uint64) (libcommon.Hash, error)
 	GetBatchNoByL2Block(l2BlockNo uint64) (uint64, error)
 	GetBatchGlobalExitRoots(fromBatchNum, toBatchNum uint64) ([]*dstypes.GerUpdate, error)
-	GetBlockGlobalExitRoot(l2BlockNo uint64) (libcommon.Hash, libcommon.Hash, error)
+	GetBlockGlobalExitRoot(l2BlockNo uint64) (libcommon.Hash, error)
+	GetBlockL1BlockHash(l2BlockNo uint64) (libcommon.Hash, error)
 }
 
 func (sdb *IntraBlockState) GetTxCount() (uint64, error) {

--- a/turbo/transactions/tracing_zkevm.go
+++ b/turbo/transactions/tracing_zkevm.go
@@ -98,7 +98,12 @@ func ComputeTxEnv_ZkEvm(ctx context.Context, engine consensus.EngineReader, bloc
 		return nil, evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, nil, err
 	}
 
-	blockGer, l1BlockHash, err := hermezReader.GetBlockGlobalExitRoot(BlockContext.BlockNumber)
+	blockGer, err := hermezReader.GetBlockGlobalExitRoot(BlockContext.BlockNumber)
+	if err != nil {
+		return nil, evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, nil, err
+	}
+
+	l1BlockHash, err := hermezReader.GetBlockL1BlockHash(BlockContext.BlockNumber)
 	if err != nil {
 		return nil, evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, nil, err
 	}

--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -25,6 +25,8 @@ const L1_INFO_TREE_UPDATES = "l1_info_tree_updates"                // index -> L
 const BLOCK_L1_INFO_TREE_INDEX = "block_l1_info_tree_index"        // block number -> l1 info tree index
 const L1_INJECTED_BATCHES = "l1_injected_batches"                  // index increasing by 1 -> injected batch for the start of the chain
 const BLOCK_INFO_ROOTS = "block_info_roots"                        // block number -> block info root hash
+const L1_BLOCK_HASHES = "l1_block_hashes"                          // l1 block hash -> true
+const BLOCK_L1_BLOCK_HASHES = "block_l1_block_hashes"              // block number -> l1 block hash
 
 type HermezDb struct {
 	tx kv.RwTx
@@ -64,6 +66,8 @@ func CreateHermezBuckets(tx kv.RwTx) error {
 		BLOCK_L1_INFO_TREE_INDEX,
 		L1_INJECTED_BATCHES,
 		BLOCK_INFO_ROOTS,
+		L1_BLOCK_HASHES,
+		BLOCK_L1_BLOCK_HASHES,
 	}
 	for _, t := range tables {
 		if err := tx.CreateBucket(t); err != nil {
@@ -336,7 +340,7 @@ func (db *HermezDb) WriteGlobalExitRoot(ger common.Hash) error {
 	return db.tx.Put(GLOBAL_EXIT_ROOTS, ger.Bytes(), []byte{1})
 }
 
-func (db *HermezDbReader) GetGlobalExitRoot(ger common.Hash) (bool, error) {
+func (db *HermezDbReader) CheckGlobalExitRootWritten(ger common.Hash) (bool, error) {
 	bytes, err := db.tx.GetOne(GLOBAL_EXIT_ROOTS, ger.Bytes())
 	if err != nil {
 		return false, err
@@ -355,58 +359,105 @@ func (db *HermezDb) DeleteGlobalExitRoots(gers *[]common.Hash) error {
 	return nil
 }
 
-func (db *HermezDb) WriteBlockGlobalExitRoot(l2BlockNo uint64, ger, l1BlockHash common.Hash) error {
-	key := ConcatGerKey(l2BlockNo, l1BlockHash)
-	return db.tx.Put(BLOCK_GLOBAL_EXIT_ROOTS, key, ger.Bytes())
+func (db *HermezDb) WriteL1BlockHash(l1BlockHash common.Hash) error {
+	return db.tx.Put(L1_BLOCK_HASHES, l1BlockHash.Bytes(), []byte{1})
 }
 
-func (db *HermezDbReader) GetBlockGlobalExitRoot(l2BlockNo uint64) (common.Hash, common.Hash, error) {
-	var h common.Hash
-	var l1BlockHash common.Hash
-
-	blockNoBytes := Uint64ToBytes(l2BlockNo)
-	err := db.tx.ForPrefix(BLOCK_GLOBAL_EXIT_ROOTS, blockNoBytes, func(k, v []byte) error {
-		h = common.BytesToHash(v)
-		if len(k) == 40 {
-			l1BlockHash = common.BytesToHash(k[8:])
-		}
-		return nil
-	})
+func (db *HermezDbReader) CheckL1BlockHashWritten(l1BlockHash common.Hash) (bool, error) {
+	bytes, err := db.tx.GetOne(L1_BLOCK_HASHES, l1BlockHash.Bytes())
 	if err != nil {
-		return common.Hash{}, common.Hash{}, err
+		return false, err
+	}
+	return len(bytes) > 0, nil
+}
+
+func (db *HermezDb) DeleteL1BlockHashes(l1BlockHashes *[]common.Hash) error {
+	for _, l1BlockHash := range *l1BlockHashes {
+		err := db.tx.Delete(L1_BLOCK_HASHES, l1BlockHash.Bytes())
+		if err != nil {
+			return err
+		}
 	}
 
-	return h, l1BlockHash, nil
+	return nil
+}
+
+func (db *HermezDb) WriteBlockGlobalExitRoot(l2BlockNo uint64, ger common.Hash) error {
+	return db.tx.Put(BLOCK_GLOBAL_EXIT_ROOTS, Uint64ToBytes(l2BlockNo), ger.Bytes())
+}
+
+func (db *HermezDbReader) GetBlockGlobalExitRoot(l2BlockNo uint64) (common.Hash, error) {
+	bytes, err := db.tx.GetOne(BLOCK_GLOBAL_EXIT_ROOTS, Uint64ToBytes(l2BlockNo))
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return common.BytesToHash(bytes), nil
 }
 
 // from and to are inclusive
-func (db *HermezDbReader) GetBlockGlobalExitRoots(fromBlockNo, toBlockNo uint64) ([]common.Hash, []common.Hash, error) {
+func (db *HermezDbReader) GetBlockGlobalExitRoots(fromBlockNo, toBlockNo uint64) ([]common.Hash, error) {
 	c, err := db.tx.Cursor(BLOCK_GLOBAL_EXIT_ROOTS)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	defer c.Close()
 
-	var gers, l1BlockHashes []common.Hash
+	var gers []common.Hash
 
 	var k, v []byte
 
 	for k, v, err = c.First(); k != nil; k, v, err = c.Next() {
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		CurrentBlockNumber := BytesToUint64(k)
 		if CurrentBlockNumber >= fromBlockNo && CurrentBlockNumber <= toBlockNo {
 			h := common.BytesToHash(v)
 			gers = append(gers, h)
-			if len(k) == 40 {
-				l1BlockHash := common.BytesToHash(k[8:])
-				l1BlockHashes = append(l1BlockHashes, l1BlockHash)
-			}
 		}
 	}
 
-	return gers, l1BlockHashes, nil
+	return gers, nil
+}
+
+func (db *HermezDb) WriteBlockL1BlockHash(l2BlockNo uint64, l1BlockHash common.Hash) error {
+	return db.tx.Put(BLOCK_L1_BLOCK_HASHES, Uint64ToBytes(l2BlockNo), l1BlockHash.Bytes())
+}
+
+func (db *HermezDbReader) GetBlockL1BlockHash(l2BlockNo uint64) (common.Hash, error) {
+	bytes, err := db.tx.GetOne(BLOCK_L1_BLOCK_HASHES, Uint64ToBytes(l2BlockNo))
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return common.BytesToHash(bytes), nil
+}
+
+// from and to are inclusive
+func (db *HermezDbReader) GetBlockL1BlockHashes(fromBlockNo, toBlockNo uint64) ([]common.Hash, error) {
+	c, err := db.tx.Cursor(BLOCK_L1_BLOCK_HASHES)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+
+	var l1BlockHashes []common.Hash
+
+	var k, v []byte
+
+	for k, v, err = c.First(); k != nil; k, v, err = c.Next() {
+		if err != nil {
+			return nil, err
+		}
+		CurrentBlockNumber := BytesToUint64(k)
+		if CurrentBlockNumber >= fromBlockNo && CurrentBlockNumber <= toBlockNo {
+			h := common.BytesToHash(v)
+			l1BlockHashes = append(l1BlockHashes, h)
+		}
+	}
+
+	return l1BlockHashes, nil
 }
 
 func (db *HermezDb) WriteBatchGlobalExitRoot(batchNumber uint64, ger dstypes.GerUpdate) error {
@@ -456,60 +507,26 @@ func (db *HermezDbReader) GetBatchGlobalExitRoot(batchNum uint64) (*dstypes.GerU
 	return gerUpdate, nil
 }
 
-func (db *HermezDb) DeleteBatchGlobalExitRoots(fromBatchNum uint64) error {
-	c, err := db.tx.Cursor(GLOBAL_EXIT_ROOTS_BATCHES)
-	if err != nil {
-		return err
-	}
-	defer c.Close()
-
-	k, _, err := c.Last()
-	if err != nil {
-		return err
-	}
-
-	for i := fromBatchNum; i <= BytesToUint64(k); i++ {
-		err := db.tx.Delete(GLOBAL_EXIT_ROOTS_BATCHES, Uint64ToBytes(i))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+func (db *HermezDb) DeleteBatchGlobalExitRoots(fromBatchNum, toBatchNum uint64) error {
+	return db.deleteFromBucketWithUintKeysRange(GLOBAL_EXIT_ROOTS_BATCHES, fromBatchNum, toBatchNum)
 }
 
 func (db *HermezDb) DeleteBlockGlobalExitRoots(fromBlockNum, toBlockNum uint64) error {
-	c, err := db.tx.Cursor(BLOCK_GLOBAL_EXIT_ROOTS)
-	if err != nil {
-		return err
-	}
-	defer c.Close()
+	return db.deleteFromBucketWithUintKeysRange(BLOCK_GLOBAL_EXIT_ROOTS, fromBlockNum, toBlockNum)
+}
 
-	var k []byte
-	var keys [][]byte
-	for k, _, err = c.First(); k != nil; k, _, err = c.Next() {
-		if err != nil {
-			break
-		}
-		blockNum := BytesToUint64(k[:8])
-		if blockNum >= fromBlockNum && blockNum <= toBlockNum {
-			keys = append(keys, k)
-		}
-	}
-	for _, key := range keys {
-		err := db.tx.Delete(BLOCK_GLOBAL_EXIT_ROOTS, key)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+func (db *HermezDb) DeleteBlockL1BlockHashes(fromBlockNum, toBlockNum uint64) error {
+	return db.deleteFromBucketWithUintKeysRange(BLOCK_L1_BLOCK_HASHES, fromBlockNum, toBlockNum)
 }
 
 // from and to are inclusive
 func (db *HermezDb) DeleteBlockBatches(fromBlockNum, toBlockNum uint64) error {
+	return db.deleteFromBucketWithUintKeysRange(BLOCKBATCHES, fromBlockNum, toBlockNum)
+}
+
+func (db *HermezDb) deleteFromBucketWithUintKeysRange(bucket string, fromBlockNum, toBlockNum uint64) error {
 	for i := fromBlockNum; i <= toBlockNum; i++ {
-		err := db.tx.Delete(BLOCKBATCHES, Uint64ToBytes(i))
+		err := db.tx.Delete(bucket, Uint64ToBytes(i))
 		if err != nil {
 			return err
 		}
@@ -575,38 +592,7 @@ func (db *HermezDbReader) GetForkIdBlock(forkId uint64) (uint64, error) {
 }
 
 func (db *HermezDb) DeleteForkIdBlock(fromBlockNo, toBlockNo uint64) error {
-	c, err := db.tx.Cursor(FORKID_BLOCK)
-	if err != nil {
-		return err
-	}
-	defer c.Close()
-
-	var forkIds []uint64
-	var k, v []byte
-	for k, v, err = c.First(); k != nil; k, v, err = c.Next() {
-		if err != nil {
-			break
-		}
-
-		blockNum := BytesToUint64(v)
-		if blockNum >= fromBlockNo && blockNum <= toBlockNo {
-			currentForkId := BytesToUint64(k)
-			forkIds = append(forkIds, currentForkId)
-		}
-	}
-
-	if err != nil {
-		return err
-	}
-
-	for _, forkId := range forkIds {
-		err := db.tx.Delete(FORKID_BLOCK, Uint64ToBytes(forkId))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return db.deleteFromBucketWithUintKeysRange(FORKID_BLOCK, fromBlockNo, toBlockNo)
 }
 
 func (db *HermezDb) WriteForkIdBlockOnce(forkId, blockNum uint64) error {
@@ -623,14 +609,7 @@ func (db *HermezDb) WriteForkIdBlockOnce(forkId, blockNum uint64) error {
 }
 
 func (db *HermezDb) DeleteForkIds(fromBatchNum, toBatchNum uint64) error {
-	for i := fromBatchNum; i <= toBatchNum; i++ {
-		err := db.tx.Delete(FORKIDS, Uint64ToBytes(i))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return db.deleteFromBucketWithUintKeysRange(FORKIDS, fromBatchNum, toBatchNum)
 }
 
 func (db *HermezDb) WriteEffectiveGasPricePercentage(txHash common.Hash, txPricePercentage uint8) error {
@@ -671,12 +650,7 @@ func (db *HermezDbReader) GetStateRoot(l2BlockNo uint64) (common.Hash, error) {
 }
 
 func (db *HermezDb) DeleteStateRoots(fromBlockNo, toBlockNo uint64) error {
-	for i := fromBlockNo; i <= toBlockNo; i++ {
-		if err := db.tx.Delete(STATE_ROOTS, Uint64ToBytes(i)); err != nil {
-			return err
-		}
-	}
-	return nil
+	return db.deleteFromBucketWithUintKeysRange(STATE_ROOTS, fromBlockNo, toBlockNo)
 }
 
 func (db *HermezDb) WriteL1InfoTreeUpdate(update *types.L1InfoTreeUpdate) error {

--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -533,8 +533,22 @@ func (db *HermezDbReader) GetBatchGlobalExitRoot(batchNum uint64) (*dstypes.GerU
 	return gerUpdate, nil
 }
 
-func (db *HermezDb) DeleteBatchGlobalExitRoots(fromBatchNum, toBatchNum uint64) error {
-	return db.deleteFromBucketWithUintKeysRange(GLOBAL_EXIT_ROOTS_BATCHES, fromBatchNum, toBatchNum)
+func (db *HermezDb) DeleteBatchGlobalExitRoots(fromBatchNum uint64) error {
+	c, err := db.tx.Cursor(GLOBAL_EXIT_ROOTS_BATCHES)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	k, _, err := c.Last()
+	if err != nil {
+		return err
+	}
+	if k == nil {
+		return nil
+	}
+	lastBatchNum := BytesToUint64(k)
+	return db.deleteFromBucketWithUintKeysRange(GLOBAL_EXIT_ROOTS_BATCHES, fromBatchNum, lastBatchNum)
 }
 
 func (db *HermezDb) DeleteBlockGlobalExitRoots(fromBlockNum, toBlockNum uint64) error {

--- a/zk/stages/stage_batches.go
+++ b/zk/stages/stage_batches.go
@@ -357,11 +357,11 @@ func UnwindBatchesStage(u *stagedsync.UnwindState, tx kv.RwTx, cfg BatchesCfg, c
 	}
 	fromBatch, err := hermezDb.GetBatchNoByL2Block(fromBlock)
 	if err != nil {
-		return fmt.Errorf("get batch no by l2 block error: %v", err)
+		return fmt.Errorf("get fromBatch no by l2 block error: %v", err)
 	}
 	toBatch, err := hermezDb.GetBatchNoByL2Block(toBlock)
 	if err != nil {
-		return fmt.Errorf("get batch no by l2 block error: %v", err)
+		return fmt.Errorf("get toBatch no by l2 block error: %v", err)
 	}
 
 	// if previous block has different batch, delete the "fromBlock" one
@@ -375,7 +375,7 @@ func UnwindBatchesStage(u *stagedsync.UnwindState, tx kv.RwTx, cfg BatchesCfg, c
 		if err := hermezDb.DeleteForkIds(fromBatch, toBatch); err != nil {
 			return fmt.Errorf("delete fork ids error: %v", err)
 		}
-		if err := hermezDb.DeleteBatchGlobalExitRoots(fromBatch, toBatch); err != nil {
+		if err := hermezDb.DeleteBatchGlobalExitRoots(fromBatch); err != nil {
 			return fmt.Errorf("delete batch global exit roots error: %v", err)
 		}
 	}

--- a/zk/stages/stage_dataStreamCatchup.go
+++ b/zk/stages/stage_dataStreamCatchup.go
@@ -200,7 +200,7 @@ func writeGenesisToStream(
 		return err
 	}
 
-	ger, _, err := reader.GetBlockGlobalExitRoot(genesis.NumberU64())
+	ger, err := reader.GetBlockGlobalExitRoot(genesis.NumberU64())
 	if err != nil {
 		return err
 	}

--- a/zk/stages/stage_interhashes.go
+++ b/zk/stages/stage_interhashes.go
@@ -796,13 +796,12 @@ func verifyStateRoot(dbSmt *smt.SMT, expectedRootHash *libcommon.Hash, cfg *ZkIn
 	//psr := state2.NewPlainStateReader(tx)
 
 	if cfg.checkRoot && hash != *expectedRootHash {
+		log.Error("wrong root", "blockNumber", blockNo, "expected root", expectedRootHash.Hex(), "actual root", hash.Hex())
+		log.Info("Checking root with RPC...")
+
 		// convert txno to big int
 		bigTxNo := big.NewInt(0)
 		bigTxNo.SetUint64(blockNo)
-
-		log.Error("[zkevm] - txno: ", bigTxNo)
-		log.Error("[zkevm] - expected root: ", expectedRootHash.Hex())
-		log.Error("[zkevm] - actual root: ", hash.Hex())
 
 		sr, err := stateRootByTxNo(bigTxNo, cfg.zk.L2RpcUrl)
 		if err != nil {
@@ -810,7 +809,6 @@ func verifyStateRoot(dbSmt *smt.SMT, expectedRootHash *libcommon.Hash, cfg *ZkIn
 		}
 
 		if hash != *sr {
-			log.Warn(fmt.Sprintf("[%s] Wrong trie root: %x, expected (from header): %x, from rpc: %x", logPrefix, hash, expectedRootHash, *sr))
 			return fmt.Errorf("wrong trie root at %d: %x, expected (from header): %x, from rpc: %x", blockNo, hash, expectedRootHash, *sr)
 		}
 

--- a/zk/witness/witness.go
+++ b/zk/witness/witness.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/datadir"
 	"github.com/ledgerwatch/erigon-lib/kv"
@@ -176,7 +177,7 @@ func (g *Generator) GenerateWitness(tx kv.Tx, ctx context.Context, startBlock, e
 			globalExitRoots = append(globalExitRoots, gersInBetween...)
 		}
 
-		blockGer, _, err := hermezDb.GetBlockGlobalExitRoot(blockNum)
+		blockGer, err := hermezDb.GetBlockGlobalExitRoot(blockNum)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
On injected batches we should insert l1blockhash and ger into  the block info tree even if the GER is not a new one.