### PR TITLE
Mainnet blockhashes fix

### DIFF
--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -39,7 +39,7 @@ import (
 )
 
 func (api *BaseAPI) getReceipts(ctx context.Context, tx kv.Tx, chainConfig *chain.Config, block *types.Block, senders []common.Address) (types.Receipts, error) {
-	if cached := rawdb.ReadReceipts(tx, block, senders); cached != nil {
+	if cached := rawdb.ReadReceipts_zkEvm(tx, block, senders); cached != nil {
 		return cached, nil
 	}
 	engine := api.engine()

--- a/cmd/rpcdaemon/commands/otterscan_search_trace.go
+++ b/cmd/rpcdaemon/commands/otterscan_search_trace.go
@@ -78,7 +78,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 	}
 	engine := api.engine()
 
-	blockReceipts := rawdb.ReadReceipts(dbtx, block, senders)
+	blockReceipts := rawdb.ReadReceipts_zkEvm(dbtx, block, senders)
 	header := block.Header()
 	excessDataGas := header.ParentExcessDataGas(getHeader)
 	rules := chainConfig.Rules(block.NumberU64(), header.Time)

--- a/core/blockchain_zkevm.go
+++ b/core/blockchain_zkevm.go
@@ -239,7 +239,9 @@ func ExecuteBlockEphemerallyZk(
 			}
 		}
 		if !chainConfig.IsForkID7Etrog(block.NumberU64()) {
-			ibs.ScalableSetSmtRootHash(roHermezDb)
+			if err := ibs.ScalableSetSmtRootHash(roHermezDb); err != nil {
+				return nil, err
+			}
 		}
 
 		txSender, _ := tx.GetSender()

--- a/core/rawdb/accessors_indexes_zkevm.go
+++ b/core/rawdb/accessors_indexes_zkevm.go
@@ -1,0 +1,38 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"fmt"
+
+	"github.com/ledgerwatch/erigon-lib/kv"
+
+	"github.com/ledgerwatch/erigon/core/types"
+)
+
+// WriteTxLookupEntries stores a positional metadata for every transaction from
+// a block, enabling hash based transaction and receipt lookups.
+func WriteTxLookupEntries_zkEvm(db kv.Putter, block *types.Block) error {
+	for _, tx := range block.Transactions() {
+		data := block.Number().Bytes()
+		if err := db.Put(kv.TxLookup, tx.Hash().Bytes(), data); err != nil {
+			return fmt.Errorf("failed to store transaction lookup entry: %W", err)
+		}
+	}
+
+	return nil
+}

--- a/core/state/intra_block_state_zkevm.go
+++ b/core/state/intra_block_state_zkevm.go
@@ -8,6 +8,7 @@ import (
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/chain"
 	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/core/types"
 	dstypes "github.com/ledgerwatch/erigon/zk/datastream/types"
 )
 
@@ -209,4 +210,16 @@ func (sdb *IntraBlockState) ScalableGetTimestamp() uint64 {
 
 	sdb.GetState(ADDRESS_SCALABLE_L2, &TIMESTAMP_STORAGE_POS, timestamp)
 	return timestamp.Uint64()
+}
+
+// log index was derived from the count of ALL logs for all transactions
+// here it is made to be derived for the count of logs for the current transaction only
+func (sdb *IntraBlockState) AddLog_zkEvm(log2 *types.Log) {
+	sdb.journal.append(addLogChange{txhash: sdb.thash})
+	log2.TxHash = sdb.thash
+	log2.BlockHash = sdb.bhash
+	log2.TxIndex = uint(sdb.txIndex)
+	log2.Index = uint(len(sdb.logs[sdb.thash]))
+	sdb.logs[sdb.thash] = append(sdb.logs[sdb.thash], log2)
+	sdb.logSize++
 }

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -201,7 +201,7 @@ func TestDeriveFields(t *testing.T) {
 	hash := libcommon.BytesToHash([]byte{0x03, 0x14})
 
 	clearComputedFieldsOnReceipts(t, receipts)
-	if err := receipts.DeriveFields_zkEvm(hash, number.Uint64(), txs, []libcommon.Address{libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0})}); err != nil {
+	if err := receipts.DeriveFields(hash, number.Uint64(), txs, []libcommon.Address{libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0})}); err != nil {
 		t.Fatalf("DeriveFields_zkEvm(...) = %v, want <nil>", err)
 	}
 	// Iterate over all the computed fields and check that they're correct

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -201,8 +201,8 @@ func TestDeriveFields(t *testing.T) {
 	hash := libcommon.BytesToHash([]byte{0x03, 0x14})
 
 	clearComputedFieldsOnReceipts(t, receipts)
-	if err := receipts.DeriveFields(hash, number.Uint64(), txs, []libcommon.Address{libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0})}); err != nil {
-		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
+	if err := receipts.DeriveFields_zkEvm(hash, number.Uint64(), txs, []libcommon.Address{libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0})}); err != nil {
+		t.Fatalf("DeriveFields_zkEvm(...) = %v, want <nil>", err)
 	}
 	// Iterate over all the computed fields and check that they're correct
 	signer := MakeSigner(params.TestChainConfig, number.Uint64())

--- a/core/types/receipt_zkevm.go
+++ b/core/types/receipt_zkevm.go
@@ -1,0 +1,78 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"fmt"
+	"math/big"
+
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+
+	"github.com/ledgerwatch/erigon/crypto"
+)
+
+// DeriveFields fills the receipts with their computed fields based on consensus
+// data and contextual infos like containing block and transactions.
+func (r Receipts) DeriveFields_zkEvm(forkId8BlockNum uint64, hash libcommon.Hash, number uint64, txs Transactions, senders []libcommon.Address) error {
+	if len(txs) != len(r) {
+		return fmt.Errorf("transaction and receipt count mismatch, tx count = %d, receipts count = %d", len(txs), len(r))
+	}
+	if len(senders) != len(txs) {
+		return fmt.Errorf("transaction and senders count mismatch, tx count = %d, senders count = %d", len(txs), len(senders))
+	}
+	for i := 0; i < len(r); i++ {
+		// The transaction type and hash can be retrieved from the transaction itself
+		r[i].Type = txs[i].Type()
+		r[i].TxHash = txs[i].Hash()
+
+		// block location fields
+		r[i].BlockHash = hash
+		r[i].BlockNumber = new(big.Int).SetUint64(number)
+		r[i].TransactionIndex = uint(i)
+
+		// The contract address can be derived from the transaction itself
+		if txs[i].GetTo() == nil {
+			// If one wants to deploy a contract, one needs to send a transaction that does not have `To` field
+			// and then the address of the contract one is creating this way will depend on the `tx.From`
+			// and the nonce of the creating account (which is `tx.From`).
+			r[i].ContractAddress = crypto.CreateAddress(senders[i], txs[i].GetNonce())
+		}
+		// The used gas can be calculated based on previous r
+		// [hack] there was a cumulativeGasUsed bug priod to forkid8, so we need to check for it
+		// if the block is before forkId8 or forkid8 is not even on yet
+		// comuluative is equal to gas used
+		if i == 0 || number < forkId8BlockNum || forkId8BlockNum == 0 {
+			r[i].GasUsed = r[i].CumulativeGasUsed
+		} else {
+			r[i].GasUsed = r[i].CumulativeGasUsed - r[i-1].CumulativeGasUsed
+		}
+
+		//zkevm this was originally counting for all logs in the block
+		//in zkevm indexes are counting for within the receipt
+		logIndex := uint(0)
+		// The derived log fields can simply be set from the block and transaction
+		for j := 0; j < len(r[i].Logs); j++ {
+			r[i].Logs[j].BlockNumber = number
+			r[i].Logs[j].BlockHash = hash
+			r[i].Logs[j].TxHash = r[i].TxHash
+			r[i].Logs[j].TxIndex = uint(i)
+			r[i].Logs[j].Index = logIndex
+			logIndex++
+		}
+	}
+	return nil
+}

--- a/core/types/receipt_zkevm_test.go
+++ b/core/types/receipt_zkevm_test.go
@@ -1,0 +1,301 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+
+	"github.com/ledgerwatch/erigon/common/u256"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/params"
+)
+
+// Tests that receipt data can be correctly derived from the contextual infos
+func TestDeriveFields_zkEvm_preForkId8(t *testing.T) {
+	// Create a few transactions to have receipts for
+	to2 := libcommon.HexToAddress("0x2")
+	to3 := libcommon.HexToAddress("0x3")
+	txs := Transactions{
+		&LegacyTx{
+			CommonTx: CommonTx{
+				Nonce: 1,
+				Value: u256.Num1,
+				Gas:   1,
+			},
+			GasPrice: u256.Num1,
+		},
+		&LegacyTx{
+			CommonTx: CommonTx{
+				To:    &to2,
+				Nonce: 2,
+				Value: u256.Num2,
+				Gas:   2,
+			},
+			GasPrice: u256.Num2,
+		},
+		&AccessListTx{
+			LegacyTx: LegacyTx{
+				CommonTx: CommonTx{
+					To:    &to3,
+					Nonce: 3,
+					Value: uint256.NewInt(3),
+					Gas:   3,
+				},
+				GasPrice: uint256.NewInt(3),
+			},
+		},
+	}
+	// Create the corresponding receipts
+	receipts := Receipts{
+		&Receipt{
+			Status:            ReceiptStatusFailed,
+			CumulativeGasUsed: 1,
+			Logs: []*Log{
+				{Address: libcommon.BytesToAddress([]byte{0x11})},
+				{Address: libcommon.BytesToAddress([]byte{0x01, 0x11})},
+			},
+			TxHash:          txs[0].Hash(),
+			ContractAddress: libcommon.BytesToAddress([]byte{0x01, 0x11, 0x11}),
+			GasUsed:         1,
+		},
+		&Receipt{
+			PostState:         libcommon.Hash{2}.Bytes(),
+			CumulativeGasUsed: 2,
+			Logs: []*Log{
+				{Address: libcommon.BytesToAddress([]byte{0x22})},
+				{Address: libcommon.BytesToAddress([]byte{0x02, 0x22})},
+			},
+			TxHash:          txs[1].Hash(),
+			ContractAddress: libcommon.BytesToAddress([]byte{0x02, 0x22, 0x22}),
+			GasUsed:         2,
+		},
+		&Receipt{
+			Type:              AccessListTxType,
+			PostState:         libcommon.Hash{3}.Bytes(),
+			CumulativeGasUsed: 3,
+			Logs: []*Log{
+				{Address: libcommon.BytesToAddress([]byte{0x33})},
+				{Address: libcommon.BytesToAddress([]byte{0x03, 0x33})},
+			},
+			TxHash:          txs[2].Hash(),
+			ContractAddress: libcommon.BytesToAddress([]byte{0x03, 0x33, 0x33}),
+			GasUsed:         3,
+		},
+	}
+	// Clear all the computed fields and re-derive them
+	number := big.NewInt(1)
+	hash := libcommon.BytesToHash([]byte{0x03, 0x14})
+
+	clearComputedFieldsOnReceipts(t, receipts)
+	if err := receipts.DeriveFields_zkEvm(0, hash, number.Uint64(), txs, []libcommon.Address{libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0})}); err != nil {
+		t.Fatalf("DeriveFields_zkEvm(...) = %v, want <nil>", err)
+	}
+	// Iterate over all the computed fields and check that they're correct
+	signer := MakeSigner(params.TestChainConfig, number.Uint64())
+
+	for i := range receipts {
+		if receipts[i].Type != txs[i].Type() {
+			t.Errorf("receipts[%d].Type = %d, want %d", i, receipts[i].Type, txs[i].Type())
+		}
+		if receipts[i].TxHash != txs[i].Hash() {
+			t.Errorf("receipts[%d].TxHash = %s, want %s", i, receipts[i].TxHash.String(), txs[i].Hash().String())
+		}
+		if receipts[i].BlockHash != hash {
+			t.Errorf("receipts[%d].BlockHash = %s, want %s", i, receipts[i].BlockHash.String(), hash.String())
+		}
+		if receipts[i].BlockNumber.Cmp(number) != 0 {
+			t.Errorf("receipts[%c].BlockNumber = %s, want %s", i, receipts[i].BlockNumber.String(), number.String())
+		}
+		if receipts[i].TransactionIndex != uint(i) {
+			t.Errorf("receipts[%d].TransactionIndex = %d, want %d", i, receipts[i].TransactionIndex, i)
+		}
+		if receipts[i].GasUsed != txs[i].GetGas() {
+			t.Errorf("receipts[%d].GasUsed = %d, want %d", i, receipts[i].GasUsed, txs[i].GetGas())
+		}
+		if txs[i].GetTo() != nil && receipts[i].ContractAddress != (libcommon.Address{}) {
+			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), (libcommon.Address{}).String())
+		}
+		from, _ := txs[i].Sender(*signer)
+		contractAddress := crypto.CreateAddress(from, txs[i].GetNonce())
+		if txs[i].GetTo() == nil && receipts[i].ContractAddress != contractAddress {
+			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), contractAddress.String())
+		}
+
+		logIndex := uint(0)
+		for j := range receipts[i].Logs {
+			if receipts[i].Logs[j].BlockNumber != number.Uint64() {
+				t.Errorf("receipts[%d].Logs[%d].BlockNumber = %d, want %d", i, j, receipts[i].Logs[j].BlockNumber, number.Uint64())
+			}
+			if receipts[i].Logs[j].BlockHash != hash {
+				t.Errorf("receipts[%d].Logs[%d].BlockHash = %s, want %s", i, j, receipts[i].Logs[j].BlockHash.String(), hash.String())
+			}
+			if receipts[i].Logs[j].TxHash != txs[i].Hash() {
+				t.Errorf("receipts[%d].Logs[%d].TxHash = %s, want %s", i, j, receipts[i].Logs[j].TxHash.String(), txs[i].Hash().String())
+			}
+			if receipts[i].Logs[j].TxHash != txs[i].Hash() {
+				t.Errorf("receipts[%d].Logs[%d].TxHash = %s, want %s", i, j, receipts[i].Logs[j].TxHash.String(), txs[i].Hash().String())
+			}
+			if receipts[i].Logs[j].TxIndex != uint(i) {
+				t.Errorf("receipts[%d].Logs[%d].TransactionIndex = %d, want %d", i, j, receipts[i].Logs[j].TxIndex, i)
+			}
+			if receipts[i].Logs[j].Index != logIndex {
+				t.Errorf("receipts[%d].Logs[%d].Index = %d, want %d", i, j, receipts[i].Logs[j].Index, logIndex)
+			}
+			logIndex++
+		}
+	}
+}
+
+// Tests that receipt data can be correctly derived from the contextual infos
+func TestDeriveFields_zkEvmForkid8(t *testing.T) {
+	// Create a few transactions to have receipts for
+	to2 := libcommon.HexToAddress("0x2")
+	to3 := libcommon.HexToAddress("0x3")
+	txs := Transactions{
+		&LegacyTx{
+			CommonTx: CommonTx{
+				Nonce: 1,
+				Value: u256.Num1,
+				Gas:   1,
+			},
+			GasPrice: u256.Num1,
+		},
+		&LegacyTx{
+			CommonTx: CommonTx{
+				To:    &to2,
+				Nonce: 2,
+				Value: u256.Num2,
+				Gas:   2,
+			},
+			GasPrice: u256.Num2,
+		},
+		&AccessListTx{
+			LegacyTx: LegacyTx{
+				CommonTx: CommonTx{
+					To:    &to3,
+					Nonce: 3,
+					Value: uint256.NewInt(3),
+					Gas:   3,
+				},
+				GasPrice: uint256.NewInt(3),
+			},
+		},
+	}
+	// Create the corresponding receipts
+	receipts := Receipts{
+		&Receipt{
+			Status:            ReceiptStatusFailed,
+			CumulativeGasUsed: 1,
+			Logs: []*Log{
+				{Address: libcommon.BytesToAddress([]byte{0x11})},
+				{Address: libcommon.BytesToAddress([]byte{0x01, 0x11})},
+			},
+			TxHash:          txs[0].Hash(),
+			ContractAddress: libcommon.BytesToAddress([]byte{0x01, 0x11, 0x11}),
+			GasUsed:         1,
+		},
+		&Receipt{
+			PostState:         libcommon.Hash{2}.Bytes(),
+			CumulativeGasUsed: 3,
+			Logs: []*Log{
+				{Address: libcommon.BytesToAddress([]byte{0x22})},
+				{Address: libcommon.BytesToAddress([]byte{0x02, 0x22})},
+			},
+			TxHash:          txs[1].Hash(),
+			ContractAddress: libcommon.BytesToAddress([]byte{0x02, 0x22, 0x22}),
+			GasUsed:         2,
+		},
+		&Receipt{
+			Type:              AccessListTxType,
+			PostState:         libcommon.Hash{3}.Bytes(),
+			CumulativeGasUsed: 6,
+			Logs: []*Log{
+				{Address: libcommon.BytesToAddress([]byte{0x33})},
+				{Address: libcommon.BytesToAddress([]byte{0x03, 0x33})},
+			},
+			TxHash:          txs[2].Hash(),
+			ContractAddress: libcommon.BytesToAddress([]byte{0x03, 0x33, 0x33}),
+			GasUsed:         3,
+		},
+	}
+	// Clear all the computed fields and re-derive them
+	number := big.NewInt(100)
+	hash := libcommon.BytesToHash([]byte{0x03, 0x14})
+
+	clearComputedFieldsOnReceipts(t, receipts)
+	if err := receipts.DeriveFields_zkEvm(1, hash, number.Uint64(), txs, []libcommon.Address{libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0})}); err != nil {
+		t.Fatalf("DeriveFields_zkEvm(...) = %v, want <nil>", err)
+	}
+	// Iterate over all the computed fields and check that they're correct
+	signer := MakeSigner(params.TestChainConfig, number.Uint64())
+
+	for i := range receipts {
+		if receipts[i].Type != txs[i].Type() {
+			t.Errorf("receipts[%d].Type = %d, want %d", i, receipts[i].Type, txs[i].Type())
+		}
+		if receipts[i].TxHash != txs[i].Hash() {
+			t.Errorf("receipts[%d].TxHash = %s, want %s", i, receipts[i].TxHash.String(), txs[i].Hash().String())
+		}
+		if receipts[i].BlockHash != hash {
+			t.Errorf("receipts[%d].BlockHash = %s, want %s", i, receipts[i].BlockHash.String(), hash.String())
+		}
+		if receipts[i].BlockNumber.Cmp(number) != 0 {
+			t.Errorf("receipts[%c].BlockNumber = %s, want %s", i, receipts[i].BlockNumber.String(), number.String())
+		}
+		if receipts[i].TransactionIndex != uint(i) {
+			t.Errorf("receipts[%d].TransactionIndex = %d, want %d", i, receipts[i].TransactionIndex, i)
+		}
+		if receipts[i].GasUsed != txs[i].GetGas() {
+			t.Errorf("receipts[%d].GasUsed = %d, want %d", i, receipts[i].GasUsed, txs[i].GetGas())
+		}
+		if txs[i].GetTo() != nil && receipts[i].ContractAddress != (libcommon.Address{}) {
+			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), (libcommon.Address{}).String())
+		}
+		from, _ := txs[i].Sender(*signer)
+		contractAddress := crypto.CreateAddress(from, txs[i].GetNonce())
+		if txs[i].GetTo() == nil && receipts[i].ContractAddress != contractAddress {
+			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), contractAddress.String())
+		}
+
+		logIndex := uint(0)
+		for j := range receipts[i].Logs {
+			if receipts[i].Logs[j].BlockNumber != number.Uint64() {
+				t.Errorf("receipts[%d].Logs[%d].BlockNumber = %d, want %d", i, j, receipts[i].Logs[j].BlockNumber, number.Uint64())
+			}
+			if receipts[i].Logs[j].BlockHash != hash {
+				t.Errorf("receipts[%d].Logs[%d].BlockHash = %s, want %s", i, j, receipts[i].Logs[j].BlockHash.String(), hash.String())
+			}
+			if receipts[i].Logs[j].TxHash != txs[i].Hash() {
+				t.Errorf("receipts[%d].Logs[%d].TxHash = %s, want %s", i, j, receipts[i].Logs[j].TxHash.String(), txs[i].Hash().String())
+			}
+			if receipts[i].Logs[j].TxHash != txs[i].Hash() {
+				t.Errorf("receipts[%d].Logs[%d].TxHash = %s, want %s", i, j, receipts[i].Logs[j].TxHash.String(), txs[i].Hash().String())
+			}
+			if receipts[i].Logs[j].TxIndex != uint(i) {
+				t.Errorf("receipts[%d].Logs[%d].TransactionIndex = %d, want %d", i, j, receipts[i].Logs[j].TxIndex, i)
+			}
+			if receipts[i].Logs[j].Index != logIndex {
+				t.Errorf("receipts[%d].Logs[%d].Index = %d, want %d", i, j, receipts[i].Logs[j].Index, logIndex)
+			}
+			logIndex++
+		}
+	}
+}

--- a/core/vm/evmtypes/evmtypes.go
+++ b/core/vm/evmtypes/evmtypes.go
@@ -104,5 +104,6 @@ type IntraBlockState interface {
 	Snapshot() int
 
 	AddLog(*types.Log)
+	AddLog_zkEvm(*types.Log)
 	GetLogs(hash libcommon.Hash) []*types.Log
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -902,7 +902,7 @@ func makeLog(size int) executionFunc {
 		}
 
 		d := scope.Memory.GetCopy(int64(mStart.Uint64()), int64(mSize.Uint64()))
-		interpreter.evm.IntraBlockState().AddLog(&types.Log{
+		interpreter.evm.IntraBlockState().AddLog_zkEvm(&types.Log{
 			Address: scope.Contract.Address(),
 			Topics:  topics,
 			Data:    d,

--- a/core/vm/instructions_zkevm.go
+++ b/core/vm/instructions_zkevm.go
@@ -184,7 +184,7 @@ func makeLog_zkevm(size int) executionFunc {
 			d = append(d, make([]byte, 32-lenMod32)...)
 		}
 
-		interpreter.evm.IntraBlockState().AddLog(&types.Log{
+		interpreter.evm.IntraBlockState().AddLog_zkEvm(&types.Log{
 			Address: scope.Contract.Address(),
 			Topics:  topics,
 			Data:    d,

--- a/core/vm/instructions_zkevm_test.go
+++ b/core/vm/instructions_zkevm_test.go
@@ -5,6 +5,9 @@ package vm
 
 import (
 	"fmt"
+	"math/big"
+	"testing"
+
 	"github.com/holiman/uint256"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	types2 "github.com/ledgerwatch/erigon-lib/types"
@@ -13,8 +16,6 @@ import (
 	"github.com/ledgerwatch/erigon/core/vm/evmtypes"
 	"github.com/ledgerwatch/erigon/core/vm/stack"
 	"github.com/ledgerwatch/erigon/params"
-	"math/big"
-	"testing"
 )
 
 func TestBlockhashV2(t *testing.T) {
@@ -160,4 +161,4 @@ func (ibs TestIntraBlockState) AddAddressToAccessList(addr libcommon.Address)   
 func (ibs TestIntraBlockState) AddSlotToAccessList(addr libcommon.Address, slot libcommon.Hash) {}
 func (ibs TestIntraBlockState) RevertToSnapshot(int)                                            {}
 func (ibs TestIntraBlockState) Snapshot() int                                                   { return 0 }
-func (ibs TestIntraBlockState) AddLog(*types.Log)                                               {}
+func (ibs TestIntraBlockState) AddLog_zkEvm(*types.Log)                                         {}

--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -310,7 +310,9 @@ func postExecuteCommitValues(
 	*/
 	headerHash := header.Hash()
 	blockNum := block.NumberU64()
-	rawdb.WriteHeader(tx, header)
+	if err := rawdb.WriteHeader_zkEvm(tx, header); err != nil {
+		return fmt.Errorf("failed to write header: %v", err)
+	}
 
 	if err := rawdb.WriteCanonicalHash(tx, headerHash, blockNum); err != nil {
 		return fmt.Errorf("failed to write header: %v", err)
@@ -336,7 +338,9 @@ func postExecuteCommitValues(
 	}
 
 	// write the new block lookup entries
-	rawdb.WriteTxLookupEntries(tx, block)
+	if err := rawdb.WriteTxLookupEntries_zkEvm(tx, block); err != nil {
+		return fmt.Errorf("failed to write tx lookup entries: %v", err)
+	}
 
 	return nil
 }

--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -147,15 +147,12 @@ Loop:
 			return err
 		}
 
-		//TODO: SHOULD RETURN ERR?
 		if block == nil {
-			log.Error(fmt.Sprintf("[%s] Empty block", logPrefix), "blocknum", blockNum)
-			continue
+			return fmt.Errorf("[%s] Empty block blocknum: %d", logPrefix, blockNum)
 		}
 
 		if header == nil {
-			log.Error(fmt.Sprintf("[%s] Empty header", logPrefix), "blocknum", blockNum)
-			continue
+			return fmt.Errorf("[%s] Empty header blocknum: %d", logPrefix, blockNum)
 		}
 
 		lastLogTx += uint64(block.Transactions().Len())
@@ -164,11 +161,11 @@ Loop:
 		writeChangeSets := nextStagesExpectData || blockNum > cfg.prune.History.PruneTo(to)
 		writeReceipts := nextStagesExpectData || blockNum > cfg.prune.Receipts.PruneTo(to)
 		writeCallTraces := nextStagesExpectData || blockNum > cfg.prune.CallTraces.PruneTo(to)
-		if err = updateZkEVMBlockCfg(&cfg, hermezDb, logPrefix); err != nil {
+		if err := updateZkEVMBlockCfg(&cfg, hermezDb, logPrefix); err != nil {
 			return err
 		}
 		header.ParentHash = prevBlockHash
-		if err = executeBlockZk(block, &prevBlockRoot, header, tx, batch, cfg, *cfg.vmConfig, writeChangeSets, writeReceipts, writeCallTraces, initialCycle, stateStream, hermezDb); err != nil {
+		if err := executeBlockZk(block, &prevBlockRoot, header, tx, batch, cfg, *cfg.vmConfig, writeChangeSets, writeReceipts, writeCallTraces, initialCycle, stateStream, hermezDb); err != nil {
 			if !errors.Is(err, context.Canceled) {
 				log.Warn(fmt.Sprintf("[%s] Execution failed", logPrefix), "block", blockNum, "hash", block.Hash().String(), "err", err)
 				if cfg.hd != nil {
@@ -381,28 +378,23 @@ func executeBlockZk(
 	vmConfig.Debug = true
 	vmConfig.Tracer = callTracer
 
-	var receipts types.Receipts
-	var stateSyncReceipt *types.Receipt
-	var execRs *core.EphemeralExecResult
 	getHashFn := core.GetHashFn(block.Header(), getHeader)
-
-	execRs, err = core.ExecuteBlockEphemerallyZk(cfg.chainConfig, &vmConfig, getHashFn, cfg.engine, prevBlockRoot, block, stateReader, stateWriter, ChainReaderImpl{config: cfg.chainConfig, tx: tx, blockReader: cfg.blockReader}, getTracer, tx, roHermezDb)
-
+	execRs, err := core.ExecuteBlockEphemerallyZk(cfg.chainConfig, &vmConfig, getHashFn, cfg.engine, prevBlockRoot, block, stateReader, stateWriter, ChainReaderImpl{config: cfg.chainConfig, tx: tx, blockReader: cfg.blockReader}, getTracer, tx, roHermezDb)
 	if err != nil {
 		return err
 	}
-	receipts = execRs.Receipts
-	stateSyncReceipt = execRs.StateSyncReceipt
+	receipts := execRs.Receipts
 
 	header.GasUsed = uint64(execRs.GasUsed)
 	header.ReceiptHash = types.DeriveSha(receipts)
 	header.Bloom = execRs.Bloom
 
 	if writeReceipts {
-		if err = rawdb.AppendReceipts(tx, blockNum, receipts); err != nil {
+		if err := rawdb.AppendReceipts(tx, blockNum, receipts); err != nil {
 			return err
 		}
 
+		stateSyncReceipt := execRs.StateSyncReceipt
 		if stateSyncReceipt != nil && stateSyncReceipt.Status == types.ReceiptStatusSuccessful {
 			if err := rawdb.WriteBorReceipt(tx, block.Hash(), block.NumberU64(), stateSyncReceipt); err != nil {
 				return err

--- a/zk/datastream/test/test.go
+++ b/zk/datastream/test/test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ledgerwatch/erigon/zkevm/log"
 )
 
-const dataStreamUrl = "stream.zkevm-rpc.com:6900"
+const dataStreamUrl = "datastream.cardona.zkevm-rpc.com:6900"
 
 // This code downloads headers and blocks from a datastream server.
 func main() {
@@ -25,40 +25,18 @@ func main() {
 	}
 
 	// create bookmark
-	bookmark := types.NewL2BlockBookmark(0)
+	bookmark := types.NewL2BlockBookmark(1378348)
 
 	// Read all entries from server
-	blocksRead, _, _, entriesReadAmount, err := c.ReadEntries(bookmark, 1000000)
+	blocksRead, _, _, entriesReadAmount, err := c.ReadEntries(bookmark, 1)
 	if err != nil {
 		panic(err)
 	}
 	fmt.Println("Entries read amount: ", entriesReadAmount)
 	fmt.Println("Blocks read amount: ", len(*blocksRead))
 
-	lastGer := common.Hash{}
-	expectedDsBlock := uint64(1)
-
-	var missingBlocks []uint64
-
-	for i, dsBlock := range *blocksRead {
-		if i == 0 {
-			continue
-		}
-
-		if dsBlock.L2BlockNumber != expectedDsBlock {
-			missingBlocks = append(missingBlocks, dsBlock.L2BlockNumber)
-			log.Error("Missing blocks: %v", missingBlocks)
-		}
-		expectedDsBlock++
-
-		rpcBlock, _ := utils.GetBlockByHash(dsBlock.L2Blockhash.String())
-		match := matchBlocks(dsBlock, rpcBlock, lastGer)
-		if !match {
-			log.Error("Blocks don't match")
-		}
-		if lastGer.Hex() != dsBlock.GlobalExitRoot.Hex() {
-			lastGer = dsBlock.GlobalExitRoot
-		}
+	for _, dsBlock := range *blocksRead {
+		fmt.Println(dsBlock)
 	}
 }
 

--- a/zk/debug_tools/rpc-test-blockendpoints/main.go
+++ b/zk/debug_tools/rpc-test-blockendpoints/main.go
@@ -40,7 +40,7 @@ func main() {
 			panic(err)
 		}
 
-		if !debug_tools.CompareBlocks(ctx, blockByNumber, blockByHash, client, client) {
+		if !debug_tools.CompareBlocks(ctx, false, blockByNumber, blockByHash, client, client) {
 			log.Warn("Blocks mismatch", "blockNumber", i)
 		}
 


### PR DESCRIPTION
 - log indexes were derived from the total IBS log count. This was wrong. Now it is derived from the current tx log count
 - some better error handling
 - made the  logIndex returned by the RPC to be the position of the log within the transaction, no within the block, as it is on L1
 - deriveFields for receipt keeps implements preforkid8 gasUsed = cumulativeGasUsed