### PR TITLE
fix datastream reconnection and errCahn bug

### DIFF
--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"reflect"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -39,6 +38,7 @@ type StreamClient struct {
 	// Channels
 	l2BlockChan    chan types.FullL2Block
 	gerUpdatesChan chan types.GerUpdate // NB: unused from etrog onwards (forkid 7)
+	errChan        chan error
 }
 
 const (
@@ -89,11 +89,15 @@ func NewClient(server string, version int) *StreamClient {
 		},
 		l2BlockChan:    make(chan types.FullL2Block, 100000),
 		gerUpdatesChan: make(chan types.GerUpdate, 1000),
+		errChan:        make(chan error),
 	}
 
 	return c
 }
 
+func (c *StreamClient) GetErrChan() chan error {
+	return c.errChan
+}
 func (c *StreamClient) GetL2BlockChan() chan types.FullL2Block {
 	return c.l2BlockChan
 }
@@ -139,7 +143,7 @@ func (c *StreamClient) GetHeader() error {
 	// Read packet
 	packet, err := readBuffer(c.conn, 1)
 	if err != nil {
-		return fmt.Errorf("%s read buffer error: %v", c.id, err)
+		return fmt.Errorf("%s read buffer: %v", c.id, err)
 	}
 
 	// Check packet type
@@ -182,7 +186,7 @@ func (c *StreamClient) ReadEntries(bookmark *types.Bookmark, l2BlocksAmount int)
 		encodedBookmark = bookmark.EncodeBigEndian()
 	}
 	if err := c.initiateDownloadBookmark(encodedBookmark); err != nil {
-		return nil, nil, nil, 0, ErrBadBookmark
+		return nil, nil, nil, 0, err
 	}
 
 	fullL2Blocks, gerUpates, bookmarks, entriesRead, err := c.readFullL2Blocks(l2BlocksAmount)
@@ -196,6 +200,15 @@ func (c *StreamClient) ReadEntries(bookmark *types.Bookmark, l2BlocksAmount int)
 // reads entries to the end of the stream
 // at end will wait for new entries to arrive
 func (c *StreamClient) ReadAllEntriesToChannel(bookmark *types.Bookmark) error {
+	// if connection is lost, try to reconnect
+	// this occurs when all 5 attempts failed on previous run
+	if c.conn == nil {
+		if err := c.tryReConnect(); err != nil {
+			c.errChan <- err
+			return fmt.Errorf("failed to reconnect the datastream client: %W", err)
+		}
+	}
+
 	var encodedBookmark []byte
 	if c.version == PreBigEndianVersion {
 		encodedBookmark = bookmark.Encode()
@@ -204,11 +217,14 @@ func (c *StreamClient) ReadAllEntriesToChannel(bookmark *types.Bookmark) error {
 	}
 	// send start command
 	if err := c.initiateDownloadBookmark(encodedBookmark); err != nil {
-		return ErrBadBookmark
+		c.errChan <- err
+		return err
 	}
 
 	if err := c.readAllFullL2BlocksToChannel(); err != nil {
-		return fmt.Errorf("%s read full L2 blocks error: %v", c.id, err)
+		err2 := fmt.Errorf("%s read full L2 blocks error: %v", c.id, err)
+		c.errChan <- err2
+		return err2
 	}
 
 	return nil
@@ -218,7 +234,7 @@ func (c *StreamClient) ReadAllEntriesToChannel(bookmark *types.Bookmark) error {
 func (c *StreamClient) initiateDownloadBookmark(bookmark []byte) error {
 	// send start command
 	if err := c.sendStartBookmarkCmd(bookmark); err != nil {
-		return fmt.Errorf("send start command error: %v", err)
+		return err
 	}
 
 	if err := c.afterStartCommand(); err != nil {
@@ -270,9 +286,6 @@ func (c *StreamClient) readAllFullL2BlocksToChannel() error {
 		c.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
 		fullBlock, gerUpdates, _, _, _, localErr := c.readFullBlock()
 		if localErr != nil {
-			if errors.Is(localErr, net.ErrClosed) || strings.Contains(localErr.Error(), "i/o timeout") {
-				c.tryReConnect()
-			}
 			err = localErr
 			break
 		}
@@ -288,19 +301,34 @@ func (c *StreamClient) readAllFullL2BlocksToChannel() error {
 	}
 
 	c.streaming.Store(false)
+	if c.conn != nil {
+		if err2 := c.conn.Close(); err2 != nil {
+			return fmt.Errorf("failed to close connection after error: %W, close error: %W", err, err2)
+		}
+		c.conn = nil
+	}
 	return err
 }
 
-func (c *StreamClient) tryReConnect() {
+func (c *StreamClient) tryReConnect() error {
+	var err error
 	for i := 0; i < 5; i++ {
-		c.conn.Close()
-		c.conn = nil
-		if err := c.Start(); err != nil {
-			time.Sleep(1 * time.Second)
+		if c.conn != nil {
+			if err := c.conn.Close(); err != nil {
+				return err
+			}
+			c.conn = nil
+		}
+		if err = c.Start(); err != nil {
+			time.Sleep(5 * time.Second)
 			continue
 		}
-		break
+		c.streaming.Store(true)
+		return nil
 	}
+
+	c.streaming.Store(false)
+	return err
 }
 
 // reads a set amount of l2blocks from the server and returns them

--- a/zk/datastream/client/stream_client_test.go
+++ b/zk/datastream/client/stream_client_test.go
@@ -37,7 +37,7 @@ func Test_readHeaderEntry(t *testing.T) {
 			name:           "Invalid byte array length",
 			input:          []byte{20, 21, 22, 23, 24, 20},
 			expectedResult: types.HeaderEntry{},
-			expectedError:  fmt.Errorf("failed to read header bytes error reading from server: unexpected EOF"),
+			expectedError:  fmt.Errorf("failed to read header bytes reading from server: unexpected EOF"),
 		},
 	}
 
@@ -95,13 +95,13 @@ func Test_readResultEntry(t *testing.T) {
 			name:           "Invalid byte array length",
 			input:          []byte{20, 21, 22, 23, 24, 20},
 			expectedResult: types.ResultEntry{},
-			expectedError:  fmt.Errorf("failed to read main result bytes error reading from server: unexpected EOF"),
+			expectedError:  fmt.Errorf("failed to read main result bytes reading from server: unexpected EOF"),
 		},
 		{
 			name:           "Invalid error length",
 			input:          []byte{0, 0, 0, 12, 0, 0, 0, 0, 20, 21},
 			expectedResult: types.ResultEntry{},
-			expectedError:  fmt.Errorf("failed to read result errStr bytes error reading from server: unexpected EOF"),
+			expectedError:  fmt.Errorf("failed to read result errStr bytes reading from server: unexpected EOF"),
 		},
 	}
 
@@ -166,12 +166,12 @@ func Test_readFileEntry(t *testing.T) {
 			name:           "Invalid byte array length",
 			input:          []byte{2, 21, 22, 23, 24, 20},
 			expectedResult: types.FileEntry{},
-			expectedError:  fmt.Errorf("error reading file bytes: error reading from server: unexpected EOF"),
+			expectedError:  fmt.Errorf("error reading file bytes: reading from server: unexpected EOF"),
 		}, {
 			name:           "Invalid data length",
 			input:          []byte{2, 0, 0, 0, 31, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 45, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 64},
 			expectedResult: types.FileEntry{},
-			expectedError:  fmt.Errorf("error reading file data bytes: error reading from server: unexpected EOF"),
+			expectedError:  fmt.Errorf("error reading file data bytes: reading from server: unexpected EOF"),
 		},
 	}
 	for _, testCase := range testCases {

--- a/zk/datastream/client/utils.go
+++ b/zk/datastream/client/utils.go
@@ -8,10 +8,6 @@ import (
 	"net"
 )
 
-var (
-	ErrBadBookmark = errors.New("bad bookmark")
-)
-
 // writeFullUint64ToConn writes a uint64 to a connection
 func writeFullUint64ToConn(conn net.Conn, value uint64) error {
 	buffer := make([]byte, 8)
@@ -80,6 +76,6 @@ func parseIoReadError(err error) error {
 	if err == io.EOF {
 		return errors.New("server close connection")
 	} else {
-		return fmt.Errorf("error reading from server: %v", err)
+		return fmt.Errorf("reading from server: %v", err)
 	}
 }

--- a/zk/datastream/client/utils_test.go
+++ b/zk/datastream/client/utils_test.go
@@ -122,7 +122,7 @@ func Test_ReadBuffer(t *testing.T) {
 			name:           "test error",
 			input:          6,
 			expectedResult: []byte{},
-			expectedError:  fmt.Errorf("error reading from server: %v", io.ErrUnexpectedEOF),
+			expectedError:  fmt.Errorf("reading from server: %v", io.ErrUnexpectedEOF),
 		},
 	}
 
@@ -158,7 +158,7 @@ func Test_ParseIoReadError(t *testing.T) {
 		{
 			name:          "test error",
 			input:         errors.New("test error"),
-			expectedError: errors.New("error reading from server: test error"),
+			expectedError: errors.New("reading from server: test error"),
 		},
 	}
 

--- a/zk/stages/test_utils.go
+++ b/zk/stages/test_utils.go
@@ -13,6 +13,7 @@ type TestDatastreamClient struct {
 	streamingAtomic       atomic.Bool
 	l2BlockChan           chan types.FullL2Block
 	gerUpdatesChan        chan types.GerUpdate
+	errChan               chan error
 }
 
 func NewTestDatastreamClient(fullL2Blocks []types.FullL2Block, gerUpdates []types.GerUpdate) *TestDatastreamClient {
@@ -21,6 +22,7 @@ func NewTestDatastreamClient(fullL2Blocks []types.FullL2Block, gerUpdates []type
 		gerUpdates:     gerUpdates,
 		l2BlockChan:    make(chan types.FullL2Block, 100),
 		gerUpdatesChan: make(chan types.GerUpdate, 100),
+		errChan:        make(chan error, 100),
 	}
 
 	return client
@@ -46,6 +48,11 @@ func (c *TestDatastreamClient) GetL2BlockChan() chan types.FullL2Block {
 func (c *TestDatastreamClient) GetGerUpdatesChan() chan types.GerUpdate {
 	return c.gerUpdatesChan
 }
+
+func (c *TestDatastreamClient) GetErrChan() chan error {
+	return c.errChan
+}
+
 func (c *TestDatastreamClient) GetLastWrittenTimeAtomic() *atomic.Int64 {
 	return &c.lastWrittenTimeAtomic
 }


### PR DESCRIPTION
 - Put errChan in datastream client struct. It was being redeclared in stage_batched before and the errors were pushed in the old one, soe they weren't detected in the select
 - Refactor client reconnection