### PR TITLE
feat(debug): allow flag based bisection

### DIFF
--- a/cmd/bisect/main.go
+++ b/cmd/bisect/main.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"time"
+	"bytes"
+	"flag"
+	"bufio"
+	"strings"
+	"errors"
+)
+
+type Flags struct {
+	Limit     uint
+	Step      uint
+	StepAfter uint
+	Config    string
+}
+
+/// EXAMPLE ///
+// go run cmd/bisect/main.go --startingBlock=10 --maxBlock=100 --step=10 --stepAfter=50 --config=./hermezconfig-mainnet.yaml
+///////////////
+
+func main() {
+	var startingBlock, maxBlock uint
+	var step, stepAfter uint
+	var config string
+
+	flag.UintVar(&startingBlock, "startingBlock", 1, "Starting block number")
+	flag.UintVar(&maxBlock, "maxBlock", 100, "Maximum block number to check")
+	flag.UintVar(&step, "step", 1, "Number of blocks to process each run of the stage loop")
+	flag.UintVar(&stepAfter, "stepAfter", 0, "Start incrementing by debug.step after this block")
+	flag.StringVar(&config, "config", "./hermezconfig-mainnet.yaml", "Path to the config file")
+	flag.Parse()
+
+	flags := Flags{
+		Limit:     maxBlock,
+		Step:      step,
+		StepAfter: stepAfter,
+		Config:    config,
+	}
+
+	fmt.Println("Starting bisect with the following configuration:")
+	fmt.Printf("Starting Block: %d, Max Block: %d, Step: %d, Step After: %d, Config: %s\n",
+		startingBlock, maxBlock, step, stepAfter, config)
+
+	fmt.Println("Starting bisect...")
+	highestFailing, err := bisect(startingBlock, maxBlock, flags)
+	if err != nil {
+		fmt.Printf("An error occurred during bisect: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Highest failing block: %d\n", highestFailing)
+}
+
+func bisect(low, high uint, flags Flags) (uint, error) {
+	initialRange := high - low
+	initialStepSize := flags.Step
+	minStepSize := uint(1)
+
+	for low <= high {
+		mid := low + (high-low)/2
+		flags.Limit = mid
+
+		currentRange := high - low
+		stepSizeReductionFactor := float64(currentRange) / float64(initialRange)
+		dynamicStepSize := uint(float64(initialStepSize) * stepSizeReductionFactor)
+
+		if dynamicStepSize < minStepSize {
+			flags.Step = minStepSize
+		} else {
+			flags.Step = dynamicStepSize
+		}
+
+		fmt.Println("Bisect range:", low, "to", high, "Checking block", mid, "with dynamic step size", flags.Step)
+		success, execNo, err := runProgram(flags)
+		if err != nil {
+			fmt.Println("Error running program:", err)
+			return 0, err
+		}
+
+		if success {
+			fmt.Println("Success at block", mid)
+			low = mid + 1
+		} else {
+			fmt.Println("Failure at block", mid, "with execution failure at block", execNo)
+			if execNo > 0 && uint(execNo) < high {
+				fmt.Println("Adjusting high to", execNo, "based on execution failure")
+				high = uint(execNo)
+			} else {
+				high = mid - 1
+			}
+		}
+		fmt.Println("Updated bisect range:", low, "to", high)
+	}
+
+	return high, nil
+}
+
+func runProgram(flags Flags) (bool, uint64, error) {
+	ts := time.Now().UnixMilli()
+	dirName := "/tmp/datadirs/hermez-bisect-" + strconv.Itoa(int(ts)) + "-" + strconv.Itoa(int(flags.Limit))
+	cmd := exec.Command("./build/bin/cdk-erigon",
+		"--config="+flags.Config,
+		"--datadir="+dirName,
+		"--debug.limit="+strconv.Itoa(int(flags.Limit)),
+		"--debug.step="+strconv.Itoa(int(flags.Step)),
+		"--debug.step-after="+strconv.Itoa(int(flags.StepAfter)),
+	)
+
+	fmt.Println(cmd.String())
+
+	defer func() {
+		cmd := exec.Command("rm", "-rf", dirName)
+		err := cmd.Run()
+		if err != nil {
+			fmt.Printf("Error deleting directory %s: %v\n", dirName, err)
+		}
+	}()
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		var exiterr *exec.ExitError
+		if errors.As(err, &exiterr) {
+			fmt.Printf("Command failed with exit code %d for limit %d\n", exiterr.ExitCode(), flags.Limit)
+			fmt.Printf("Stderr: %s\n", stderr.String())
+			exitCode := exiterr.ExitCode()
+			if exitCode == 2 {
+				scanner := bufio.NewScanner(&stderr)
+				var lastLine string
+				for scanner.Scan() {
+					lastLine = scanner.Text()
+				}
+
+				blockNumber := parseBlockNumberFromStderr(lastLine)
+				if blockNumber > 0 {
+					return false, uint64(blockNumber - 1), nil
+				}
+			}
+
+			return false, 0, nil
+		}
+	}
+	return true, 0, nil
+}
+
+func parseBlockNumberFromStderr(stderrLine string) uint {
+	const prefix = "block="
+	start := strings.Index(stderrLine, prefix)
+	if start == -1 {
+		return 0
+	}
+	start += len(prefix)
+
+	end := start
+	for end < len(stderrLine) && (stderrLine[end] >= '0' && stderrLine[end] <= '9') {
+		end++
+	}
+
+	blockNumberStr := stderrLine[start:end]
+	if num, err := strconv.Atoi(blockNumberStr); err == nil {
+		return uint(num)
+	}
+	return 0
+}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -485,6 +485,19 @@ var (
 		Usage: "Enable/Diable witness full",
 		Value: true,
 	}
+	DebugLimit = cli.UintFlag{
+		Name:  "debug.limit",
+		Usage: "Limit the number of blocks to sync",
+		Value: 0,
+	}
+	DebugStep = cli.UintFlag{
+		Name:  "debug.step",
+		Usage: "Number of blocks to process each run of the stage loop",
+	}
+	DebugStepAfter = cli.UintFlag{
+		Name:  "debug.step-after",
+		Usage: "Start incrementing by debug.step after this block",
+	}
 	RpcBatchConcurrencyFlag = cli.UintFlag{
 		Name:  "rpc.batch.concurrency",
 		Usage: "Does limit amount of goroutines to process 1 batch request. Means 1 bach request can't overload server. 1 batch still can have unlimited amount of request",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -33,6 +33,10 @@ type Zk struct {
 
 	RebuildTreeAfter uint64
 	WitnessFull      bool
+
+	DebugLimit     uint64
+	DebugStep      uint64
+	DebugStepAfter uint64
 }
 
 var DefaultZkConfig = &Zk{}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -191,4 +191,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.DataStreamHost,
 	&utils.DataStreamPort,
 	&utils.WitnessFullFlag,
+	&utils.DebugLimit,
+	&utils.DebugStep,
+	&utils.DebugStepAfter,
 }

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -60,6 +60,9 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		AllowFreeTransactions:      ctx.Bool(utils.AllowFreeTransactions.Name),
 		AllowPreEIP155Transactions: ctx.Bool(utils.AllowPreEIP155Transactions.Name),
 		WitnessFull:                ctx.Bool(utils.WitnessFullFlag.Name),
+		DebugLimit:                 ctx.Uint64(utils.DebugLimit.Name),
+		DebugStep:                  ctx.Uint64(utils.DebugStep.Name),
+		DebugStepAfter:             ctx.Uint64(utils.DebugStepAfter.Name),
 	}
 
 	checkFlag(utils.L2ChainIdFlag.Name, cfg.Zk.L2ChainId)

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -47,7 +47,7 @@ func NewDefaultZkStages(ctx context.Context,
 
 	return zkStages.DefaultZkStages(ctx,
 		zkStages.StageL1SyncerCfg(db, l1Syncer, cfg.Zk),
-		zkStages.StageBatchesCfg(db, datastreamClient),
+		zkStages.StageBatchesCfg(db, datastreamClient, cfg.Zk),
 		zkStages.StageDataStreamCatchupCfg(datastreamServer, db, cfg.Genesis.Config.ChainID.Uint64(), zkStages.NodeTypeSynchronizer),
 		stagedsync.StageCumulativeIndexCfg(db),
 		stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig),

--- a/zk/stages/stage_batches_test.go
+++ b/zk/stages/stage_batches_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 
 	"github.com/stretchr/testify/require"
+	"github.com/ledgerwatch/erigon/eth/ethconfig"
 )
 
 func TestUnwindBatches(t *testing.T) {
@@ -72,7 +73,7 @@ func TestUnwindBatches(t *testing.T) {
 	require.NoError(t, err)
 
 	dsClient := NewTestDatastreamClient(fullL2Blocks, gerUpdates)
-	cfg := StageBatchesCfg(db1, dsClient)
+	cfg := StageBatchesCfg(db1, dsClient, &ethconfig.Zk{})
 
 	s := &stagedsync.StageState{ID: stages.Batches, BlockNumber: 0}
 	u := &stagedsync.Sync{}

--- a/zk/stages/stage_l1syncer.go
+++ b/zk/stages/stage_l1syncer.go
@@ -64,6 +64,12 @@ func SpawnStageL1Syncer(
 	quiet bool,
 ) error {
 
+	///// DEBUG BISECT /////
+	if cfg.zkCfg.DebugLimit > 0 {
+		return nil
+	}
+	///// DEBUG BISECT /////
+
 	logPrefix := s.LogPrefix()
 	log.Info(fmt.Sprintf("[%s] Starting L1 sync stage", logPrefix))
 	if sequencer.IsSequencer() {


### PR DESCRIPTION
Adds `cmd/bisect` which can be run and will bisect the node. Flags passed cause the node to exit with error/success code in execution or interhashes. Should be able to leave the script and return to a highest failing block number.

Turns off l1syncer stage for super speedup.