### PR TITLE
feat(rpc): proxy eth_gasPrice

### DIFF
--- a/cmd/gaspricechecker/main.go
+++ b/cmd/gaspricechecker/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"io"
+)
+
+type RequestBody struct {
+	JSONRPC string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+	ID      int           `json:"id"`
+}
+
+type ResponseBody struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Result  string `json:"result"`
+}
+
+func main() {
+	nodes := map[string]string{
+		"local":  "http://0.0.0.0:8545",
+		"legacy": "https://rpc-legacy.internal.zkevm-rpc.com/",
+	}
+
+	gasPrices := make(map[string]*big.Int)
+
+	requestBody := RequestBody{
+		JSONRPC: "2.0",
+		Method:  "eth_gasPrice",
+		Params:  make([]interface{}, 0),
+		ID:      1,
+	}
+
+	requestBodyJson, err := json.Marshal(requestBody)
+	if err != nil {
+		panic(err)
+	}
+
+	for name, url := range nodes {
+		resp, err := http.Post(url, "application/json", bytes.NewBuffer(requestBodyJson))
+		if err != nil {
+			panic(err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		resp.Body.Close()
+
+		var responseBody ResponseBody
+		err = json.Unmarshal(body, &responseBody)
+		if err != nil {
+			panic(err)
+		}
+
+		gasPrice := new(big.Int)
+		gasPrice, ok := gasPrice.SetString(responseBody.Result[2:], 16)
+		if !ok {
+			panic("Failed to parse gas price")
+		}
+		gasPrices[name] = gasPrice
+	}
+
+	var names [2]string
+	var prices [2]*big.Int
+	i := 0
+	for name, price := range gasPrices {
+		names[i] = name
+		prices[i] = price
+		i++
+	}
+
+	lowerIndex := 0
+	if prices[1].Cmp(prices[0]) < 0 {
+		lowerIndex = 1
+	}
+	higherIndex := 1 - lowerIndex
+
+	diff := new(big.Int).Sub(prices[higherIndex], prices[lowerIndex])
+
+	percentDiffLower := new(big.Float).Quo(new(big.Float).SetInt(diff), new(big.Float).SetInt(prices[lowerIndex]))
+	percentDiffLower.Mul(percentDiffLower, big.NewFloat(100))
+
+	percentDiffHigher := new(big.Float).Quo(new(big.Float).SetInt(diff), new(big.Float).SetInt(prices[higherIndex]))
+	percentDiffHigher.Mul(percentDiffHigher, big.NewFloat(100))
+
+	if diff.Sign() != 0 {
+		fmt.Printf("%s has a higher gas price than %s.\n", names[higherIndex], names[lowerIndex])
+		fmt.Printf("[%s: %s wei, %s: %s wei, Difference: %s wei]\n",
+			names[higherIndex], prices[higherIndex], names[lowerIndex], prices[lowerIndex], diff)
+		fmt.Printf("Difference as a percentage of %s's price: %.2f%%\n", names[lowerIndex], percentDiffLower)
+		fmt.Printf("Difference as a percentage of %s's price: %.2f%%\n", names[higherIndex], percentDiffHigher)
+	} else {
+		fmt.Printf("Both nodes have the same gas price. [%s: %s wei, %s: %s wei]\n",
+			names[0], prices[0], names[1], prices[1])
+	}
+}

--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -118,6 +118,11 @@ func (api *APIImpl) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 		return nil, err
 	}
 
+	// [zkevm] - proxy the request if the chainID is ZK and not a sequencer
+	if api.isZkNonSequencer(cc.ChainID) {
+		return api.gasPriceZk(api.l2RpcUrl)
+	}
+
 	oracle := gasprice.NewOracle(NewGasPriceOracleBackend(tx, cc, api.BaseAPI), ethconfig.Defaults.GPO, api.gasCache)
 	tipcap, err := oracle.SuggestTipCap(ctx)
 	gasResult := big.NewInt(0)

--- a/cmd/rpcdaemon/commands/eth_system_zk.go
+++ b/cmd/rpcdaemon/commands/eth_system_zk.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/ledgerwatch/erigon/zkevm/jsonrpc/client"
+	"github.com/ledgerwatch/erigon/common/hexutil"
+	"math/big"
+	"encoding/json"
+)
+
+func (api *APIImpl) gasPriceZk(rpcUrl string) (*hexutil.Big, error) {
+	res, err := client.JSONRPCCall(rpcUrl, "eth_gasPrice")
+	if err != nil {
+		return &hexutil.Big{}, err
+	}
+
+	if res.Error != nil {
+		return &hexutil.Big{}, fmt.Errorf("RPC error response: %s", res.Error.Message)
+	}
+	if res.Error != nil {
+		return &hexutil.Big{}, fmt.Errorf("RPC error response: %s", res.Error.Message)
+	}
+
+	var resultString string
+	if err := json.Unmarshal(res.Result, &resultString); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal result: %v", err)
+	}
+
+	price, ok := big.NewInt(0).SetString(resultString[2:], 16)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert result to big.Int")
+	}
+
+	return (*hexutil.Big)(price), nil
+}

--- a/hermezconfig-bali.yaml.example
+++ b/hermezconfig-bali.yaml.example
@@ -3,7 +3,7 @@ chain: hermez-bali
 http: true
 private.api.addr: localhost:9092
 zkevm.l2-chain-id: 2440
-zkevm.l2-sequencer-rpc-url: https://rpc.internal.zkevm-rpc.com/
+zkevm.l2-sequencer-rpc-url: https://rpc-legacy.internal.zkevm-rpc.com/
 zkevm.l2-datastreamer-url: datastream.internal.zkevm-rpc.com:6900
 zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: https://rpc.sepolia.org


### PR DESCRIPTION
1. change the l2 rpc url in example config for the legacy one - prevent infinite request forwarding between erigon nodes
2. add gaschecker in cmd to allow quick gas price comparison between rpcs
3. add and hook up gas rpc call proxy function