### PR TITLE
keep track of the last written GER and provide RPC endpoint

### DIFF
--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -35,6 +35,7 @@ const BATCH_COUNTERS = "hermez_batch_counters"                         // batch 
 const L1_BATCH_DATA = "l1_batch_data"                                  // batch number -> l1 batch data from transaction call data
 const L1_INFO_TREE_HIGHEST_BLOCK = "l1_info_tree_highest_block"        // highest l1 block number found with L1 info tree updates
 const REUSED_L1_INFO_TREE_INDEX = "reused_l1_info_tree_index"          // block number => const 1
+const LATEST_USED_GER = "latest_used_ger"                              // batch number -> GER latest used GER
 
 type HermezDb struct {
 	tx kv.RwTx
@@ -83,6 +84,7 @@ func CreateHermezBuckets(tx kv.RwTx) error {
 		L1_BATCH_DATA,
 		L1_INFO_TREE_HIGHEST_BLOCK,
 		REUSED_L1_INFO_TREE_INDEX,
+		LATEST_USED_GER,
 	}
 	for _, t := range tables {
 		if err := tx.CreateBucket(t); err != nil {
@@ -1065,4 +1067,43 @@ func (db *HermezDbReader) GetL1InfoTreeHighestBlock() (uint64, error) {
 		return 0, err
 	}
 	return BytesToUint64(data), nil
+}
+
+func (db *HermezDb) WriteLatestUsedGer(batchNo uint64, ger common.Hash) error {
+	batchBytes := Uint64ToBytes(batchNo)
+	return db.tx.Put(LATEST_USED_GER, batchBytes, ger.Bytes())
+}
+
+func (db *HermezDbReader) GetLatestUsedGer() (uint64, common.Hash, error) {
+	c, err := db.tx.Cursor(LATEST_USED_GER)
+	if err != nil {
+		return 0, common.Hash{}, err
+	}
+
+	k, v, err := c.Last()
+	if err != nil {
+		return 0, common.Hash{}, err
+	}
+
+	batchNo := BytesToUint64(k)
+	ger := common.BytesToHash(v)
+
+	return batchNo, ger, nil
+}
+
+func (db *HermezDb) TruncateLatestUsedGers(fromBatch uint64) error {
+	latestBatch, _, err := db.GetLatestUsedGer()
+	if err != nil {
+		return err
+	}
+
+	for i := fromBatch; i <= latestBatch; i++ {
+		err := db.tx.Delete(LATEST_USED_GER, Uint64ToBytes(i))
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
 }

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -190,7 +190,17 @@ func SpawnSequencingStage(
 		ibs := state.New(sdb.stateReader)
 
 		parentRoot := parentBlock.Root()
-		if err = handleStateForNewBlockStarting(cfg.chainConfig, sdb.hermezDb, ibs, thisBlockNumber, header.Time, &parentRoot, l1TreeUpdate, shouldWriteGerToContract); err != nil {
+		if err = handleStateForNewBlockStarting(
+			cfg.chainConfig,
+			sdb.hermezDb,
+			ibs,
+			thisBlockNumber,
+			thisBatch,
+			header.Time,
+			&parentRoot,
+			l1TreeUpdate,
+			shouldWriteGerToContract,
+		); err != nil {
 			return err
 		}
 

--- a/zk/stages/stage_sequence_execute_blocks.go
+++ b/zk/stages/stage_sequence_execute_blocks.go
@@ -28,6 +28,7 @@ func handleStateForNewBlockStarting(
 	hermezDb *hermez_db.HermezDb,
 	ibs *state.IntraBlockState,
 	blockNumber uint64,
+	batchNumber uint64,
 	timestamp uint64,
 	stateRoot *common.Hash,
 	l1info *zktypes.L1InfoTreeUpdate,
@@ -54,7 +55,9 @@ func handleStateForNewBlockStarting(
 			if l1BlockHash == (common.Hash{}) {
 				// not in the contract so let's write it!
 				ibs.WriteGerManagerL1BlockHash(l1info.GER, l1info.ParentHash)
-
+				if err := hermezDb.WriteLatestUsedGer(batchNumber, l1info.GER); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/zk/stages/stage_sequence_execute_injected_batch.go
+++ b/zk/stages/stage_sequence_execute_injected_batch.go
@@ -16,6 +16,7 @@ import (
 const (
 	injectedBatchNumber      = 1
 	injectedBatchBlockNumber = 1
+	injectedBatchBatchNumber = 1
 )
 
 func processInjectedInitialBatch(
@@ -44,7 +45,17 @@ func processInjectedInitialBatch(
 	header.Time = injected.Timestamp
 
 	parentRoot := parentBlock.Root()
-	if err = handleStateForNewBlockStarting(cfg.chainConfig, sdb.hermezDb, ibs, injectedBatchBlockNumber, injected.Timestamp, &parentRoot, fakeL1TreeUpdate, true); err != nil {
+	if err = handleStateForNewBlockStarting(
+		cfg.chainConfig,
+		sdb.hermezDb,
+		ibs,
+		injectedBatchBlockNumber,
+		injectedBatchBatchNumber,
+		injected.Timestamp,
+		&parentRoot,
+		fakeL1TreeUpdate,
+		true,
+	); err != nil {
 		return err
 	}
 

--- a/zk/witness/witness.go
+++ b/zk/witness/witness.go
@@ -264,6 +264,7 @@ func populateDbTables(batch *memdb.MemoryMutation) error {
 		hermez_db.BLOCK_L1_BLOCK_HASHES,
 		hermez_db.INTERMEDIATE_TX_STATEROOTS,
 		hermez_db.REUSED_L1_INFO_TREE_INDEX,
+		hermez_db.LATEST_USED_GER,
 	}
 
 	for _, t := range tables {


### PR DESCRIPTION
more complex than initially thought as we need to consider unwinds so can't just write a single value all the time and we also need to consider re-used l1 info tree indexes after all of the recent issues we've had with these as well