### PR TITLE
Add default config for zkevm rpc url

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -102,7 +102,9 @@ var Defaults = Config{
 		Produce:    true,
 	},
 	DropUselessPeers: false,
-	Zk:               &Zk{},
+	Zk: &Zk{
+		L2RpcUrl: "https://zkevm-rpc.com",
+	},
 }
 
 func init() {


### PR DESCRIPTION
When making rpcdaemon the endpoint for zkevm won't work because l2rpcUrl is missing. By adding the zkevm url on the default it solves the issue.