### PR TITLE
Concurrent executor verifications

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -60,6 +60,7 @@ import (
 	"github.com/ledgerwatch/erigon/p2p/netutil"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/params/networkname"
+	"time"
 )
 
 // These are all the command line flags we support.
@@ -470,6 +471,16 @@ var (
 		Name:  "zkevm.executor-strict",
 		Usage: "Defaulted to true to ensure you must set some executor URLs, bypass this restriction by setting to false",
 		Value: true,
+	}
+	ExecutorRequestTimeout = cli.DurationFlag{
+		Name:  "zkevm.executor-request-timeout",
+		Usage: "The timeout for the executor request",
+		Value: 60 * time.Second,
+	}
+	ExecutorMaxConcurrentRequests = cli.IntFlag{
+		Name:  "zkevm.executor-max-concurrent-requests",
+		Usage: "The maximum number of concurrent requests to the executor",
+		Value: 1,
 	}
 	RpcRateLimitsFlag = cli.IntFlag{
 		Name:  "zkevm.rpc-ratelimit",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -799,8 +799,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			var legacyExecutors []legacy_executor_verifier.ILegacyExecutor
 			if len(cfg.ExecutorUrls) > 0 && cfg.ExecutorUrls[0] != "" {
 				levCfg := legacy_executor_verifier.Config{
-					GrpcUrls: cfg.ExecutorUrls,
-					Timeout:  time.Second * 5,
+					GrpcUrls:              cfg.ExecutorUrls,
+					Timeout:               time.Second * 60,
+					MaxConcurrentRequests: 1,
 				}
 				executors := legacy_executor_verifier.NewExecutors(levCfg)
 				for _, e := range executors {
@@ -817,8 +818,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 				backend.l1Syncer,
 				backend.dataStream,
 			)
-
-			verifier.StartWork()
 
 			// we need to make sure the pool is always aware of the latest block for when
 			// we switch context from being an RPC node to a sequencer

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -800,8 +800,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			if len(cfg.ExecutorUrls) > 0 && cfg.ExecutorUrls[0] != "" {
 				levCfg := legacy_executor_verifier.Config{
 					GrpcUrls:              cfg.ExecutorUrls,
-					Timeout:               time.Second * 60,
-					MaxConcurrentRequests: 1,
+					Timeout:               cfg.ExecutorRequestTimeout,
+					MaxConcurrentRequests: cfg.ExecutorMaxConcurrentRequests,
 				}
 				executors := legacy_executor_verifier.NewExecutors(levCfg)
 				for _, e := range executors {

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -32,6 +32,8 @@ type Zk struct {
 	SequencerNonEmptyBatchSealTime         time.Duration
 	ExecutorUrls                           []string
 	ExecutorStrictMode                     bool
+	ExecutorRequestTimeout                 time.Duration
+	ExecutorMaxConcurrentRequests          int
 	L1QueryBlocksThreads                   uint64
 	AllowFreeTransactions                  bool
 	AllowPreEIP155Transactions             bool

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -190,6 +190,8 @@ var DefaultFlags = []cli.Flag{
 	&utils.SequencerNonEmptyBatchSealTime,
 	&utils.ExecutorUrls,
 	&utils.ExecutorStrictMode,
+	&utils.ExecutorRequestTimeout,
+	&utils.ExecutorMaxConcurrentRequests,
 	&utils.L1QueryBlocksThreads,
 	&utils.AllowFreeTransactions,
 	&utils.AllowPreEIP155Transactions,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -97,6 +97,8 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		SequencerNonEmptyBatchSealTime:         sequencerNonEmptyBatchSealTime,
 		ExecutorUrls:                           strings.Split(ctx.String(utils.ExecutorUrls.Name), ","),
 		ExecutorStrictMode:                     ctx.Bool(utils.ExecutorStrictMode.Name),
+		ExecutorRequestTimeout:                 ctx.Duration(utils.ExecutorRequestTimeout.Name),
+		ExecutorMaxConcurrentRequests:          ctx.Int(utils.ExecutorMaxConcurrentRequests.Name),
 		L1QueryBlocksThreads:                   ctx.Uint64(utils.L1QueryBlocksThreads.Name),
 		AllowFreeTransactions:                  ctx.Bool(utils.AllowFreeTransactions.Name),
 		AllowPreEIP155Transactions:             ctx.Bool(utils.AllowPreEIP155Transactions.Name),

--- a/zk/legacy_executor_verifier/executor.go
+++ b/zk/legacy_executor_verifier/executor.go
@@ -15,8 +15,9 @@ import (
 )
 
 type Config struct {
-	GrpcUrls []string
-	Timeout  time.Duration
+	GrpcUrls              []string
+	Timeout               time.Duration
+	MaxConcurrentRequests int
 }
 
 type Payload struct {
@@ -46,21 +47,18 @@ type Executor struct {
 	conn       *grpc.ClientConn
 	connCancel context.CancelFunc
 	client     executor.ExecutorServiceClient
+	semaphore  chan struct{}
 }
 
 func NewExecutors(cfg Config) []*Executor {
 	executors := make([]*Executor, len(cfg.GrpcUrls))
-	var err error
 	for i, grpcUrl := range cfg.GrpcUrls {
-		executors[i], err = NewExecutor(grpcUrl, cfg.Timeout)
-		if err != nil {
-			log.Warn("Failed to create executor", "error", err)
-		}
+		executors[i] = NewExecutor(grpcUrl, cfg.Timeout, cfg.MaxConcurrentRequests)
 	}
 	return executors
 }
 
-func NewExecutor(grpcUrl string, timeout time.Duration) (*Executor, error) {
+func NewExecutor(grpcUrl string, timeout time.Duration, maxConcurrentRequests int) *Executor {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -78,9 +76,10 @@ func NewExecutor(grpcUrl string, timeout time.Duration) (*Executor, error) {
 		conn:       conn,
 		connCancel: cancel,
 		client:     client,
+		semaphore:  make(chan struct{}, maxConcurrentRequests),
 	}
 
-	return e, nil
+	return e
 }
 
 func (e *Executor) Close() {
@@ -92,6 +91,11 @@ func (e *Executor) Close() {
 	if err != nil {
 		log.Warn("Failed to close grpc connection", err)
 	}
+}
+
+// QueueLength check 'how busy' the executor is
+func (e *Executor) QueueLength() int {
+	return len(e.semaphore)
 }
 
 func (e *Executor) CheckOnline() bool {
@@ -129,6 +133,9 @@ func (e *Executor) CheckOnline() bool {
 }
 
 func (e *Executor) Verify(p *Payload, request *VerifierRequest, oldStateRoot common.Hash) (bool, error) {
+	e.semaphore <- struct{}{}
+	defer func() { <-e.semaphore }()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/zk/legacy_executor_verifier/legacy_executor_verifier.go
+++ b/zk/legacy_executor_verifier/legacy_executor_verifier.go
@@ -2,8 +2,6 @@ package legacy_executor_verifier
 
 import (
 	"context"
-	"encoding/hex"
-	"strconv"
 	"sync"
 
 	"github.com/gateway-fm/cdk-erigon-lib/common"
@@ -16,11 +14,11 @@ import (
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 	"github.com/ledgerwatch/erigon/zk/legacy_executor_verifier/proto/github.com/0xPolygonHermez/zkevm-node/state/runtime/executor"
 	"github.com/ledgerwatch/erigon/zk/syncer"
-	"github.com/ledgerwatch/log/v3"
 	"fmt"
-	"sort"
-	"time"
 	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
+	"strconv"
+	"github.com/ledgerwatch/log/v3"
+	"encoding/hex"
 )
 
 const (
@@ -58,18 +56,17 @@ type LegacyExecutorVerifier struct {
 	executors      []ILegacyExecutor
 	executorNumber int
 
-	working       *sync.Mutex
-	openRequests  []*VerifierRequest
-	requestsMap   map[uint64]uint64
-	responses     []*VerifierResponse
-	responseMutex *sync.Mutex
-	quit          chan struct{}
+	quit chan struct{}
 
 	streamServer     *server.DataStreamServer
 	stream           *datastreamer.StreamServer
 	witnessGenerator WitnessGenerator
 	l1Syncer         *syncer.L1Syncer
 	executorGrpc     executor.ExecutorServiceClient
+
+	promises     []*Promise[*VerifierResponse]
+	promisesLock sync.Mutex
+	addedBatches map[uint64]struct{}
 }
 
 func NewLegacyExecutorVerifier(
@@ -89,150 +86,65 @@ func NewLegacyExecutorVerifier(
 	streamServer := server.NewDataStreamServer(stream, chainCfg.ChainID.Uint64(), server.ExecutorOperationMode)
 
 	verifier := &LegacyExecutorVerifier{
+		db:               db,
 		cfg:              cfg,
 		executors:        executors,
-		db:               db,
 		executorNumber:   0,
-		working:          &sync.Mutex{},
-		openRequests:     make([]*VerifierRequest, 0),
-		requestsMap:      make(map[uint64]uint64),
-		responses:        make([]*VerifierResponse, 0),
-		responseMutex:    &sync.Mutex{},
 		quit:             make(chan struct{}),
 		streamServer:     streamServer,
 		stream:           stream,
 		witnessGenerator: witnessGenerator,
 		l1Syncer:         l1Syncer,
+		promises:         make([]*Promise[*VerifierResponse], 0),
+		promisesLock:     sync.Mutex{},
+		addedBatches:     make(map[uint64]struct{}),
 	}
 
 	return verifier
 }
 
-func (v *LegacyExecutorVerifier) StopWork() {
-	close(v.quit)
-}
-
-func (v *LegacyExecutorVerifier) StartWork() {
-	go func() {
-		tick := time.NewTicker(1 * time.Second)
-	LOOP:
-		for {
-			select {
-			case <-v.quit:
-				break LOOP
-			case <-tick.C:
-				go v.processOpenRequests()
-			}
-		}
-	}()
-}
-
-func (v *LegacyExecutorVerifier) processOpenRequests() {
-	v.working.Lock()
-	defer v.working.Unlock()
-
-	if len(v.openRequests) == 0 {
-		return
-	}
-
-	// sort the requests by batch number ascending
-	sort.Slice(v.openRequests, func(i, j int) bool {
-		return v.openRequests[i].BatchNumber < v.openRequests[j].BatchNumber
-	})
-
-	// we want to trim down the requests once we have worked through them so keep track of
-	// where we got to
-	successCount := 0
-
-	// process the requests
-	for _, request := range v.openRequests {
-		processed, err := v.handleRequest(context.Background(), request)
-		if err != nil {
-			log.Error("[Verifier] error handling request", "batch", request.BatchNumber, "err", err)
-			break
-		}
-		if !processed {
-			// likely the underlying stage loop is still running so the batch had no transactions
-			// in this case subsequent batches will also be in the same state so exit now and wait
-			// for the next iteration
-			break
-		}
-		successCount++
-	}
-
-	v.openRequests = v.openRequests[successCount:]
-}
-
-func (v *LegacyExecutorVerifier) getNextOnlineExecutor() ILegacyExecutor {
-	var exec ILegacyExecutor
-
-	// attempt to find an executor that is online amongst them all
-	for i := 0; i < len(v.executors); i++ {
-		v.executorNumber++
-		if v.executorNumber >= len(v.executors) {
-			v.executorNumber = 0
-		}
-		temp := v.executors[v.executorNumber]
-		if temp.CheckOnline() {
-			exec = temp
-			break
-		}
-	}
-
-	return exec
-}
-
-func (v *LegacyExecutorVerifier) handleRequest(ctx context.Context, request *VerifierRequest) (bool, error) {
+func (v *LegacyExecutorVerifier) AddRequestUnsafe(ctx context.Context, tx kv.RwTx, request *VerifierRequest) (*Promise[*VerifierResponse], error) {
 	// if we have no executor config then just skip this step and treat everything as OK
 	if len(v.executors) == 0 {
 		response := &VerifierResponse{
 			BatchNumber: request.BatchNumber,
 			Valid:       true,
 		}
-		v.handleResponse(response)
-		return true, nil
+		return &Promise[*VerifierResponse]{
+			result: response,
+			err:    nil,
+		}, nil
 	}
 
-	execer := v.getNextOnlineExecutor()
+	execer := v.getNextOnlineAvailableExecutor()
 	if execer == nil {
-		return false, ErrNoExecutorAvailable
+		return nil, ErrNoExecutorAvailable
 	}
-
-	// mapmutation has some issue with us not having a quit channel on the context call to `Done` so
-	// here we're creating a cancelable context and just deferring the cancel
-	innerCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	tx, err := v.db.BeginRo(innerCtx)
-	if err != nil {
-		return false, err
-	}
-	defer tx.Rollback()
 
 	hermezDb := hermez_db.NewHermezDbReader(tx)
 
 	// get the data stream bytes
 	blocks, err := hermezDb.GetL2BlockNosByBatch(request.BatchNumber)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	// we might not have blocks yet as the underlying stage loop might still be running and the tx hasn't been
 	// committed yet so just requeue the request
 	if len(blocks) == 0 {
 		request.CheckCount++
-		return false, nil
+		return nil, nil
 	}
 
 	l1InfoTreeMinTimestamps := make(map[uint64]uint64)
 	streamBytes, err := v.GetStreamBytes(request, tx, blocks, hermezDb, l1InfoTreeMinTimestamps)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	witness, err := v.witnessGenerator.GenerateWitness(tx, innerCtx, blocks[0], blocks[len(blocks)-1], false, v.cfg.WitnessFull)
+	witness, err := v.witnessGenerator.GenerateWitness(tx, ctx, blocks[0], blocks[len(blocks)-1], false, v.cfg.WitnessFull)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	log.Debug("witness generated", "data", hex.EncodeToString(witness))
@@ -246,7 +158,7 @@ func (v *LegacyExecutorVerifier) handleRequest(ctx context.Context, request *Ver
 	// and just add 5 minutes
 	lastBlock, err := rawdb.ReadBlockByNumber(tx, blocks[len(blocks)-1])
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	timestampLimit := lastBlock.Time()
 
@@ -264,26 +176,95 @@ func (v *LegacyExecutorVerifier) handleRequest(ctx context.Context, request *Ver
 
 	previousBlock, _ := rawdb.ReadBlockByNumber(tx, blocks[0]-1)
 
-	ok, err := execer.Verify(payload, request, previousBlock.Root())
+	// eager promise will do the work as soon as called in a goroutine, then we can retrieve the result later
+	promise := NewPromise[*VerifierResponse](func() (*VerifierResponse, error) {
+		p := payload
+		r := request
+		root := previousBlock.Root()
+		failureResponse := &VerifierResponse{
+			BatchNumber: request.BatchNumber,
+			Valid:       false,
+			Witness:     witness,
+		}
+
+		ok, err2 := execer.Verify(p, r, root)
+		if err2 != nil {
+			return failureResponse, err2
+		}
+
+		response := &VerifierResponse{
+			BatchNumber: request.BatchNumber,
+			Valid:       ok,
+			Witness:     witness,
+		}
+
+		return response, nil
+	})
+
+	// add batch to the list of batches we've added
+	v.addedBatches[request.BatchNumber] = struct{}{}
+
+	// add the promise to the list of promises
+	v.promises = append(v.promises, promise)
+	return promise, nil
+}
+
+func writeBatchToStream(result *VerifierResponse, hdb *hermez_db.HermezDbReader, roTx kv.Tx, v *LegacyExecutorVerifier) error {
+	blks, err := hdb.GetL2BlockNosByBatch(result.BatchNumber)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	if ok {
-		// update the datastream now that we know the batch is OK
-		if err = server.WriteBlocksToStream(tx, hermezDb, v.streamServer, v.stream, blocks[0], blocks[len(blocks)-1], "verifier"); err != nil {
-			return true, err
+	if err := server.WriteBlocksToStream(roTx, hdb, v.streamServer, v.stream, blks[0], blks[len(blks)-1], "verifier"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *LegacyExecutorVerifier) ConsumeResultsUnsafe(tx kv.RwTx) ([]*VerifierResponse, error) {
+	v.promisesLock.Lock()
+	defer v.promisesLock.Unlock()
+
+	hdb := hermez_db.NewHermezDbReader(tx)
+
+	results := make([]*VerifierResponse, len(v.promises))
+	for i, promise := range v.promises {
+		result, err := promise.Get(func(r *VerifierResponse) error {
+			return writeBatchToStream(v.promises[i].result, hdb, tx, v)
+		})
+		if err != nil {
+			log.Error("error getting verifier result", "err", err)
+		}
+		results[i] = result
+		// remove from addedBatches
+		delete(v.addedBatches, result.BatchNumber)
+	}
+
+	// clear the promises
+	v.promises = nil
+
+	return results, nil
+}
+
+func (v *LegacyExecutorVerifier) getNextOnlineAvailableExecutor() ILegacyExecutor {
+	var exec ILegacyExecutor
+
+	// TODO: find executors with spare capacity
+
+	// attempt to find an executor that is online amongst them all
+	for i := 0; i < len(v.executors); i++ {
+		v.executorNumber++
+		if v.executorNumber >= len(v.executors) {
+			v.executorNumber = 0
+		}
+		temp := v.executors[v.executorNumber]
+		if temp.CheckOnline() {
+			exec = temp
+			break
 		}
 	}
 
-	response := &VerifierResponse{
-		BatchNumber: request.BatchNumber,
-		Valid:       ok,
-		Witness:     witness,
-	}
-	v.handleResponse(response)
-
-	return true, nil
+	return exec
 }
 
 func (v *LegacyExecutorVerifier) GetStreamBytes(request *VerifierRequest, tx kv.Tx, blocks []uint64, hermezDb *hermez_db.HermezDbReader, l1InfoTreeMinTimestamps map[uint64]uint64) ([]byte, error) {
@@ -320,63 +301,11 @@ func (v *LegacyExecutorVerifier) GetStreamBytes(request *VerifierRequest, tx kv.
 	return streamBytes, nil
 }
 
-func (v *LegacyExecutorVerifier) handleResponse(response *VerifierResponse) {
-	v.responseMutex.Lock()
-	defer v.responseMutex.Unlock()
-	v.responses = append(v.responses, response)
-}
-
-// not thread safe
-func (v *LegacyExecutorVerifier) IsRequestAdded(batchNumber uint64) bool {
-	_, exists := v.requestsMap[batchNumber]
-	return exists
-}
-
-// not thread safe
-func (v *LegacyExecutorVerifier) AddRequest(request *VerifierRequest) {
-	_, exists := v.requestsMap[request.BatchNumber]
-	if exists {
-		return
-	}
-
-	v.requestsMap[request.BatchNumber] = request.BatchNumber
-	go v.addRequestWhenFree(request)
-}
-
-func (v *LegacyExecutorVerifier) addRequestWhenFree(request *VerifierRequest) {
-	v.working.Lock()
-	v.openRequests = append(v.openRequests, request)
-	v.working.Unlock()
-
-	v.processOpenRequests()
-}
-
-// not thread safe
-func (v *LegacyExecutorVerifier) MarkRequestAsHandled(batchNumber uint64) {
-	delete(v.requestsMap, batchNumber)
-}
-
-func (v *LegacyExecutorVerifier) GetAllResponses() []*VerifierResponse {
-	v.responseMutex.Lock()
-	defer v.responseMutex.Unlock()
-	result := make([]*VerifierResponse, len(v.responses))
-	copy(result, v.responses)
-	return result
-}
-
-func (v *LegacyExecutorVerifier) RemoveResponse(batchNumber uint64) {
-	v.responseMutex.Lock()
-	defer v.responseMutex.Unlock()
-
-	result := make([]*VerifierResponse, 0, len(v.responses))
-	for _, response := range v.responses {
-		if response.BatchNumber != batchNumber {
-			result = append(result, response)
-		}
-	}
-	v.responses = result
-}
-
 func (v *LegacyExecutorVerifier) HasExecutors() bool {
 	return len(v.executors) > 0
+}
+
+func (v *LegacyExecutorVerifier) IsRequestAddedUnsafe(batch uint64) bool {
+	_, ok := v.addedBatches[batch]
+	return ok
 }

--- a/zk/legacy_executor_verifier/promise.go
+++ b/zk/legacy_executor_verifier/promise.go
@@ -23,9 +23,12 @@ func NewPromise[T any](f func() (T, error)) *Promise[T] {
 	return p
 }
 
-func (p *Promise[T]) Get() (T, error) {
+func (p *Promise[T]) Get(f func(r T) error) (T, error) {
 	p.wg.Wait()
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+	if p.err == nil && f != nil {
+		return p.result, f(p.result)
+	}
 	return p.result, p.err
 }

--- a/zk/legacy_executor_verifier/promise.go
+++ b/zk/legacy_executor_verifier/promise.go
@@ -32,3 +32,9 @@ func (p *Promise[T]) Get(f func(r T) error) (T, error) {
 	}
 	return p.result, p.err
 }
+
+func (p *Promise[T]) GetNonBlocking() (T, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return p.result, p.err
+}

--- a/zk/legacy_executor_verifier/promise.go
+++ b/zk/legacy_executor_verifier/promise.go
@@ -1,0 +1,31 @@
+package legacy_executor_verifier
+
+import "sync"
+
+type Promise[T any] struct {
+	result T
+	err    error
+	wg     sync.WaitGroup
+	mutex  sync.Mutex
+}
+
+func NewPromise[T any](f func() (T, error)) *Promise[T] {
+	p := &Promise[T]{}
+	p.wg.Add(1)
+	go func() {
+		result, err := f()
+		p.mutex.Lock()
+		p.result = result
+		p.err = err
+		p.mutex.Unlock()
+		p.wg.Done()
+	}()
+	return p
+}
+
+func (p *Promise[T]) Get() (T, error) {
+	p.wg.Wait()
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return p.result, p.err
+}

--- a/zk/legacy_executor_verifier/promise_test.go
+++ b/zk/legacy_executor_verifier/promise_test.go
@@ -1,0 +1,113 @@
+package legacy_executor_verifier
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type TestStruct struct {
+	id int
+}
+
+// specific failures for specificId
+func mightFail2(id int) (TestStruct, error) {
+	if id == 4 {
+		return TestStruct{}, fmt.Errorf("specificId failed")
+	}
+	return TestStruct{id: id}, nil
+}
+
+func TestPromiseConcurrentExecution(t *testing.T) {
+	type testCase struct {
+		id        int
+		expectErr bool
+	}
+
+	cases := []testCase{
+		{id: 1, expectErr: false},
+		{id: 2, expectErr: false},
+		{id: 3, expectErr: false},
+		{id: 4, expectErr: true},
+		{id: 5, expectErr: false},
+	}
+
+	promises := make(map[int]*Promise[TestStruct])
+
+	// promise per testcase
+	for _, c := range cases {
+		id := c.id
+		promise := NewPromise(func() (TestStruct, error) {
+			return mightFail2(id)
+		})
+		promises[id] = promise
+	}
+
+	// get the results (waiting on each 'promise')
+	for _, c := range cases {
+		result, err := promises[c.id].Get()
+		if (err != nil) != c.expectErr {
+			t.Errorf("Test failed for Id %d: expected error: %v, got: %v", c.id, c.expectErr, err)
+		} else if err == nil {
+			if result.id != c.id {
+				t.Errorf("Unexpected result for Id %d: expected %d, got %d", c.id, c.id, result.id)
+			}
+		}
+	}
+}
+
+func TestSpecificIdFail(t *testing.T) {
+	id := 4
+	promise := NewPromise(func() (TestStruct, error) {
+		return mightFail2(id)
+	})
+	result, err := promise.Get()
+
+	if err == nil {
+		t.Error("Expected an error for specificId but got nil")
+	}
+
+	if result.id != 0 {
+		t.Errorf("Expected empty result id, but got: %d", result.id)
+	}
+}
+
+var sleepDuration = 2000
+
+func mightFailRandomSleep(id int) (TestStruct, error) {
+	if sleepDuration > 0 {
+		sleepDuration -= 20
+	}
+
+	randomSleep := time.Duration(sleepDuration) * time.Millisecond
+	time.Sleep(randomSleep)
+	return TestStruct{id: id}, nil
+}
+
+func TestHighConcurrencyAndOrder(t *testing.T) {
+	numTests := 100
+	promises := make([]*Promise[TestStruct], numTests)
+
+	// create promises - doing work
+	for i := 0; i < numTests; i++ {
+		id := i // important to get the value of i - capture variables!!!!
+		promise := NewPromise(func() (TestStruct, error) {
+			return mightFailRandomSleep(id)
+		})
+		promises[i] = promise
+	}
+
+	// start resolving them
+	results := make([]TestStruct, numTests)
+	for i := 0; i < numTests; i++ {
+		res, _ := promises[i].Get()
+		results[i] = res
+	}
+
+	// check the ordering
+	for i := 0; i < numTests; i++ {
+		if results[i].id != i {
+			t.Errorf("Expected id %d, but got %d", i, results[i].id)
+		}
+	}
+}


### PR DESCRIPTION
- implements a generic 'eager executing' js-promise-like primitive
- verification stage adds promises, and then subsequently reads them
- limit executor in-flight requests (channel used as sempahore)