### PR TITLE
feat(debug): debug.no-sync flag to turn off sync

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -566,6 +566,11 @@ var (
 		Usage: "Support gasless transactions",
 		Value: false,
 	}
+	DebugNoSync = cli.BoolFlag{
+		Name:  "debug.no-sync",
+		Usage: "Disable syncing",
+		Value: false,
+	}
 	DebugLimit = cli.UintFlag{
 		Name:  "debug.limit",
 		Usage: "Limit the number of blocks to sync",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1333,6 +1333,11 @@ func (s *Ethereum) Start() error {
 	s.sentriesClient.StartStreamLoops(s.sentryCtx)
 	time.Sleep(10 * time.Millisecond) // just to reduce logs order confusion
 
+	// don't start the stageloop if debug.no-sync flag set
+	if s.config.DebugNoSync {
+		return nil
+	}
+
 	go stages2.StageLoop(s.sentryCtx, s.chainConfig, s.chainDB, s.stagedSync, s.sentriesClient.Hd, s.notifications, s.sentriesClient.UpdateHead, s.waitForStageLoopStop, s.config.Sync.LoopThrottle)
 
 	return nil

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -48,6 +48,7 @@ type Zk struct {
 	SyncLimit        uint64
 	Gasless          bool
 
+	DebugNoSync    bool
 	DebugLimit     uint64
 	DebugStep      uint64
 	DebugStepAfter uint64

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -205,6 +205,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.WitnessFullFlag,
 	&utils.SyncLimit,
 	&utils.SupportGasless,
+	&utils.DebugNoSync,
 	&utils.DebugLimit,
 	&utils.DebugStep,
 	&utils.DebugStepAfter,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -110,6 +110,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		WitnessFull:                            ctx.Bool(utils.WitnessFullFlag.Name),
 		SyncLimit:                              ctx.Uint64(utils.SyncLimit.Name),
 		Gasless:                                ctx.Bool(utils.SupportGasless.Name),
+		DebugNoSync:                            ctx.Bool(utils.DebugNoSync.Name),
 		DebugLimit:                             ctx.Uint64(utils.DebugLimit.Name),
 		DebugStep:                              ctx.Uint64(utils.DebugStep.Name),
 		DebugStepAfter:                         ctx.Uint64(utils.DebugStepAfter.Name),


### PR DESCRIPTION
Allows using the node purely for RPC without stageloop running.