### PR TITLE
register reads for non-initialized slots for newly created SC for the witness

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -184,6 +184,7 @@ func (so *stateObject) GetCommittedState(key *libcommon.Hash, out *uint256.Int) 
 		}
 	}
 	if so.created {
+		so.db.stateReader.ReadAccountStorage(so.address, so.data.GetIncarnation(), key)
 		out.Clear()
 		return
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -184,7 +184,13 @@ func (so *stateObject) GetCommittedState(key *libcommon.Hash, out *uint256.Int) 
 		}
 	}
 	if so.created {
-		so.db.stateReader.ReadAccountStorage(so.address, so.data.GetIncarnation(), key)
+		/*
+		* Due to specifics of an SMT, it needs to know all intermediate nodes to write stuff.
+		* If the smart contract is just created, and the slot is reset after use,
+		* it will never get registered in the witness, and SMT won't be able to insert data there,
+		* getting the HASH key.
+		 */
+		so.registerKeyReadForWitness(key)
 		out.Clear()
 		return
 	}

--- a/core/state/state_object_zkevm.go
+++ b/core/state/state_object_zkevm.go
@@ -1,0 +1,15 @@
+package state
+
+import (
+	libcommon "github.com/gateway-fm/cdk-erigon-lib/common"
+	"github.com/ledgerwatch/log/v3"
+)
+
+func (so *stateObject) registerKeyReadForWitness(key *libcommon.Hash) {
+	_, witnessGeneration := so.db.stateReader.(*TrieDbState)
+
+	if witnessGeneration {
+		log.Debug("[WITNESS] we are registering an extra touch for recently created contract", "addr", so.address, "key", key)
+		so.db.stateReader.ReadAccountStorage(so.address, so.data.GetIncarnation(), key)
+	}
+}


### PR DESCRIPTION
fixed an edge case when if the storage slot is written and reset back to 0 during a transaction execution for the smart contract that was deployed in the same transaction, the read is not registered for the witness.

fixes #381