### PR TITLE
fix rare overwrites in the preimageMap when generating witness

### DIFF
--- a/core/state/trie_db.go
+++ b/core/state/trie_db.go
@@ -541,11 +541,15 @@ func (tds *TrieDbState) GetAccount(addrHash common.Hash) (*accounts.Account, boo
 }
 
 func (tds *TrieDbState) HashSave(data []byte) (common.Hash, error) {
-	h, err := eriCommon.HashData(data)
+	cpy := make([]byte, len(data))
+	copy(cpy, data)
+	h, err := eriCommon.HashData(cpy)
 	if err != nil {
 		return common.Hash{}, err
 	} else {
-		tds.preimageMap[h] = data
+		h1 := common.Hash{}
+		copy(h1[:], h[:])
+		tds.preimageMap[h1] = cpy
 		return h, nil
 	}
 }


### PR DESCRIPTION
it is always pointers...

Sometimes get I wrong values for preimages, for example when fixing #381, the preimage value for key 0x0C unexpectedly has a value 0x05 that was from another write.