### PR TITLE
fix(witness): closed growing number of cursors

### DIFF
--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -81,6 +81,13 @@ func NewPlainState(tx kv.Tx, blockNr uint64, systemContractLookup map[libcommon.
 	return ps
 }
 
+func (s *PlainState) Close() {
+	s.accHistoryC.Close()
+	s.storageHistoryC.Close()
+	s.accChangesC.Close()
+	s.storageChangesC.Close()
+}
+
 func (s *PlainState) SetTrace(trace bool) {
 	s.trace = trace
 }

--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -971,6 +971,7 @@ func (db *HermezDb) WriteL1InjectedBatch(batch *types.L1InjectedBatch) error {
 	if err != nil {
 		return err
 	}
+	defer cursor.Close()
 
 	count, err := cursor.Count()
 	if err != nil {
@@ -1070,6 +1071,7 @@ func (db *HermezDbReader) GetLastL1BatchData() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
+	defer c.Close()
 
 	k, _, err := c.Last()
 	if err != nil {
@@ -1101,6 +1103,7 @@ func (db *HermezDbReader) GetLatestUsedGer() (uint64, common.Hash, error) {
 	if err != nil {
 		return 0, common.Hash{}, err
 	}
+	defer c.Close()
 
 	k, v, err := c.Last()
 	if err != nil {

--- a/zk/witness/witness.go
+++ b/zk/witness/witness.go
@@ -218,6 +218,7 @@ func (g *Generator) GenerateWitness(tx kv.Tx, ctx context.Context, startBlock, e
 		}
 
 		prevStateRoot = block.Root()
+		reader.Close() // close the cursors created by the plainstate
 	}
 
 	var rl trie.RetainDecider


### PR DESCRIPTION
- close opened cursors in defer in hermezdb
- added Close() func to plainstate for closing the 4x cursors created on instantiation