### PR TITLE
faster fork lookup

### DIFF
--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -723,28 +723,11 @@ func (db *HermezDb) deleteFromBucketWithUintKeysRange(bucket string, fromBlockNu
 }
 
 func (db *HermezDbReader) GetForkId(batchNo uint64) (uint64, error) {
-	c, err := db.tx.Cursor(FORKIDS)
+	v, err := db.tx.GetOne(FORKIDS, Uint64ToBytes(batchNo))
 	if err != nil {
 		return 0, err
 	}
-	defer c.Close()
-
-	var forkId uint64 = 0
-	var k, v []byte
-
-	for k, v, err = c.First(); k != nil; k, v, err = c.Next() {
-		if err != nil {
-			break
-		}
-		currentBatchNo := BytesToUint64(k)
-		if currentBatchNo <= batchNo {
-			forkId = BytesToUint64(v)
-		} else {
-			break
-		}
-	}
-
-	return forkId, err
+	return BytesToUint64(v), nil
 }
 
 func (db *HermezDb) WriteForkId(batchNo, forkId uint64) error {

--- a/zk/hermez_db/db_test.go
+++ b/zk/hermez_db/db_test.go
@@ -210,6 +210,8 @@ func TestGetAndSetForkId(t *testing.T) {
 
 			err := db.WriteForkId(10, 1)
 			require.NoError(t, err, "Failed to write ForkId")
+			err = db.WriteForkId(tc.batchNo, tc.forkId)
+			require.NoError(t, err, "Failed to write ForkId")
 			err = db.WriteForkId(100, 2)
 			require.NoError(t, err, "Failed to write ForkId")
 


### PR DESCRIPTION
speeds up the datastream repopulation process dramatically.  It is written on a per block basis during batches so seems a safe enough change to make