### PR TITLE
[bug fix] Add zkevm contract address to syncer's listening address

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -776,7 +776,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 				contracts.VerificationTopicPreEtrog,
 				contracts.VerificationTopicEtrog,
 			}}
-			l1Contracts = []libcommon.Address{cfg.AddressRollup, cfg.AddressAdmin}
+			l1Contracts = []libcommon.Address{cfg.AddressRollup, cfg.AddressAdmin, cfg.AddressZkevm}
 		}
 
 		ethermanClients := make([]syncer.IEtherman, len(backend.etherManClients))


### PR DESCRIPTION
`sequenceBatches` events are emitted from zkevm contract, see the [contract](https://sepolia.etherscan.io/address/0xA13Ddb14437A8F34897131367ad3ca78416d6bCa) on Sepolia for instance. Without listening to it, RPC nodes won't be able to sync sequence events, resulting errors on calling `zkevm_virtualBatchNumber` endpoint.