### PR TITLE
do not panic when executor is not available

### DIFF
--- a/zk/legacy_executor_verifier/promise.go
+++ b/zk/legacy_executor_verifier/promise.go
@@ -3,10 +3,11 @@ package legacy_executor_verifier
 import "sync"
 
 type Promise[T any] struct {
-	result T
-	err    error
-	wg     sync.WaitGroup
-	mutex  sync.Mutex
+	result    T
+	err       error
+	wg        sync.WaitGroup
+	mutex     sync.Mutex
+	ExtraInfo interface{}
 }
 
 func NewPromise[T any](f func() (T, error)) *Promise[T] {


### PR DESCRIPTION
also stops spamming the console with repeated errors the more the verifications get behind