### PR TITLE
Add a local kurtosis devnet to CI

### DIFF
--- a/.github/workflows/ci_zkevm.yml
+++ b/.github/workflows/ci_zkevm.yml
@@ -53,3 +53,40 @@ jobs:
 
       - name: Test
         run: make test
+
+  kurtosis-cdk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cdk-erigon
+        uses: actions/checkout@v4
+        with:
+          path: cdk-erigon
+
+      - name: Checkout kurtosis-cdk
+        uses: actions/checkout@v4
+        with:
+          repository: 0xPolygon/kurtosis-cdk
+          ref: feat/cdk-erigon-zkevm
+          path: kurtosis-cdk
+
+      - name: Install Kurtosis CDK tools
+        uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk
+
+      - name: Build docker image
+        working-directory: ./cdk-erigon
+        run: docker build -t cdk-erigon:local --file Dockerfile .
+
+      - name: Configure Kurtosis CDK
+        working-directory: ./kurtosis-cdk
+        run: |
+          yq -Y --in-place '.args.data_availability_mode = "rollup"' params.yml
+          yq -Y --in-place '.args.cdk_erigon_node_image = "cdk-erigon:local"' params.yml
+
+      - name: Deploy Kurtosis CDK package
+        working-directory: ./kurtosis-cdk
+        run: kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
+
+      - name: Monitor verified batches
+        working-directory: ./kurtosis-cdk
+        shell: bash
+        run: .github/actions/monitor-cdk-verified-batches/batch_verification_monitor.sh 20 600 cdk-erigon-node-001


### PR DESCRIPTION
This PR adds a new job that performs basic e2e/smoke tests. Other tests, e.g. bridge, RPC endpoint, could be added later on top of this job.

What this job does:
* Builds a new docker image based on the PR or new commits pushed to zkevm branch.
* Spins up a local devnet with a fresh state of L1 and L2 (using cdk-erigon built in previous step as a sequencer and a RPC node), with other relevant components, e.g. sequence sender, executor, prover, aggregator.
* Deploys smart contracts to L1 and L2.
* Periodically checks whether sequences are verified on L1. 
* Passes the test if verified sequences is found through cdk-erigon RPC endpoint within a specified time window. Otherwise, fails the test.

The job takes roughly 20 minutes to run, 10 minutes for deployment and 10 minutes for sequence batch verification. An example of job run output could be found [here](https://github.com/0xPolygonHermez/cdk-erigon/actions/runs/9424802135/job/25965622805?pr=580)