### PR TITLE
add missing table to witness memory batch

### DIFF
--- a/zk/witness/witness.go
+++ b/zk/witness/witness.go
@@ -272,6 +272,7 @@ func populateDbTables(batch *memdb.MemoryMutation) error {
 		hermez_db.REUSED_L1_INFO_TREE_INDEX,
 		hermez_db.LATEST_USED_GER,
 		hermez_db.L1_INFO_TREE_UPDATES_BY_GER,
+		hermez_db.SMT_DEPTHS,
 	}
 
 	for _, t := range tables {


### PR DESCRIPTION
without it the witness can't be generated