### PR TITLE
Keep empty fields in the response of zkevm_getBatchByNumber

### DIFF
--- a/cmd/rpcdaemon/commands/zkevm_api.go
+++ b/cmd/rpcdaemon/commands/zkevm_api.go
@@ -857,29 +857,18 @@ func populateBatchDetails(batch *types.Batch) (json.RawMessage, error) {
 	jBatch["timestamp"] = batch.Timestamp
 	jBatch["blocks"] = batch.Blocks
 	jBatch["transactions"] = batch.Transactions
-	if batch.GlobalExitRoot != (common.Hash{}) {
-		jBatch["globalExitRoot"] = batch.GlobalExitRoot
-	}
+	jBatch["globalExitRoot"] = batch.GlobalExitRoot
+	jBatch["mainnetExitRoot"] = batch.MainnetExitRoot
+	jBatch["rollupExitRoot"] = batch.RollupExitRoot
+	jBatch["localExitRoot"] = batch.LocalExitRoot
+	jBatch["sendSequencesTxHash"] = batch.SendSequencesTxHash
+	jBatch["verifyBatchTxHash"] = batch.VerifyBatchTxHash
+
 	if batch.ForcedBatchNumber != nil {
 		jBatch["forcedBatchNumber"] = batch.ForcedBatchNumber
 	}
-	if batch.MainnetExitRoot != (common.Hash{}) {
-		jBatch["mainnetExitRoot"] = batch.MainnetExitRoot
-	}
-	if batch.RollupExitRoot != (common.Hash{}) {
-		jBatch["rollupExitRoot"] = batch.RollupExitRoot
-	}
-	if batch.LocalExitRoot != (common.Hash{}) {
-		jBatch["localExitRoot"] = batch.LocalExitRoot
-	}
 	if batch.AccInputHash != (common.Hash{}) {
 		jBatch["accInputHash"] = batch.AccInputHash
-	}
-	if batch.SendSequencesTxHash != nil {
-		jBatch["sendSequencesTxHash"] = batch.SendSequencesTxHash
-	}
-	if batch.VerifyBatchTxHash != nil {
-		jBatch["verifyBatchTxHash"] = batch.VerifyBatchTxHash
 	}
 	jBatch["closed"] = batch.Closed
 	if len(batch.BatchL2Data) > 0 {


### PR DESCRIPTION
In a fresh state, exit roots could be empty, and we don't want to exclude them from the response of `zkevm_getBatchByNumber`. Otherwise, it might cause problems other components that consume this output.