### PR TITLE
Erigon DB data browser

### DIFF
--- a/core/state/intra_block_state_zkevm.go
+++ b/core/state/intra_block_state_zkevm.go
@@ -36,6 +36,7 @@ type ReadOnlyHermezDb interface {
 	GetReusedL1InfoTreeIndex(blockNum uint64) (bool, error)
 	GetSequenceByBatchNo(batchNo uint64) (*zktypes.L1BatchInfo, error)
 	GetHighestBlockInBatch(batchNo uint64) (uint64, error)
+	GetLowestBlockInBatch(batchNo uint64) (uint64, bool, error)
 	GetL2BlockNosByBatch(batchNo uint64) ([]uint64, error)
 	GetBatchGlobalExitRoot(batchNum uint64) (*dstypes.GerUpdate, error)
 	GetVerificationByBatchNo(batchNo uint64) (*zktypes.L1BatchInfo, error)

--- a/core/state/intra_block_state_zkevm.go
+++ b/core/state/intra_block_state_zkevm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	dstypes "github.com/ledgerwatch/erigon/zk/datastream/types"
+	zktypes "github.com/ledgerwatch/erigon/zk/types"
 )
 
 var (
@@ -33,6 +34,13 @@ type ReadOnlyHermezDb interface {
 	GetGerForL1BlockHash(l1BlockHash libcommon.Hash) (libcommon.Hash, error)
 	GetIntermediateTxStateRoot(blockNum uint64, txhash libcommon.Hash) (libcommon.Hash, error)
 	GetReusedL1InfoTreeIndex(blockNum uint64) (bool, error)
+	GetSequenceByBatchNo(batchNo uint64) (*zktypes.L1BatchInfo, error)
+	GetHighestBlockInBatch(batchNo uint64) (uint64, error)
+	GetL2BlockNosByBatch(batchNo uint64) ([]uint64, error)
+	GetBatchGlobalExitRoot(batchNum uint64) (*dstypes.GerUpdate, error)
+	GetVerificationByBatchNo(batchNo uint64) (*zktypes.L1BatchInfo, error)
+	GetL1BatchData(batchNumber uint64) ([]byte, error)
+	GetL1InfoTreeUpdateByGer(ger libcommon.Hash) (*zktypes.L1InfoTreeUpdate, error)
 }
 
 func (sdb *IntraBlockState) GetTxCount() (uint64, error) {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -495,3 +495,12 @@ func (r Receipts) DeriveFields(hash libcommon.Hash, number uint64, txs Transacti
 	}
 	return nil
 }
+
+// ToSlice converts Receipts into slice of value type Receipt
+func (r Receipts) ToSlice() []Receipt {
+	result := make([]Receipt, 0, r.Len())
+	for _, receipt := range r {
+		result = append(result, *receipt)
+	}
+	return result
+}

--- a/zk/debug_tools/mdbx-data-browser/README.md
+++ b/zk/debug_tools/mdbx-data-browser/README.md
@@ -65,11 +65,11 @@ In case `file-output` flag is provided, results are printed to a JSON file (othe
 #### `output-batches` Command
 
 ```sh
-./mdbx-data-browser output-batches --bn 1,2,3 [--verbose] [--file-output]
+./mdbx-data-browser output-batches --datadir mdbx.dat --bn 1,2,3 [--verbose] [--file-output]
 ```
 
 #### `output-blocks` Command
 
 ```sh
-./mdbx-data-browser output-blocks --bn 100,101,102 [--verbose] [--file-output]
+./mdbx-data-browser output-blocks --datadir mdbx.dat --bn 100,101,102 [--verbose] [--file-output]
 ```

--- a/zk/debug_tools/mdbx-data-browser/README.md
+++ b/zk/debug_tools/mdbx-data-browser/README.md
@@ -1,0 +1,75 @@
+# MDBX data browser
+
+MDBX data browser represents a CLI tool, that is able to query the MDBX database, used by the CDK Erigon.
+It offers two CLI commands:
+- `output-blocks` - it receives block numbers as the parameter and outputs the blocks information
+- `output-batches` - it receives batch number as the parameter and outputs the retrieved batches information
+
+## CLI Commands Documentation
+This paragraph documents the CLI commands that are incorporated into the MDBX DB browser.
+
+### Global Flags
+
+#### `verbose`
+- **Name**: `verbose`
+- **Usage**: If verbose output is enabled, it prints all the details about blocks and transactions in the batches, otherwise just its hashes.
+- **Destination**: `&verboseOutput`
+- **Default Value**: `false`
+
+#### `file-output`
+- **Name**: `file-output`
+- **Usage**: If file output is enabled, all the results are persisted within a file.
+- **Destination**: `&fileOutput`
+- **Default Value**: `false`
+
+### Commands
+
+#### `output-batches`
+It is used to output the batches by numbers from the Erigon database. 
+In case `verbose` flag is provided, it collects all the data for the blocks and transactions in the batch (otherwise only hashes).
+In case `file-output` flag is provided, results are printed to a JSON file (otherwise on a standard output).
+
+- **Name**: `output-batches`
+- **Usage**: Outputs batches by numbers.
+- **Action**: `dumpBatchesByNumbers`
+- **Flags**:
+  - `data-dir`: Specifies the data directory to use.
+  - `bn`: Batch numbers.
+    - **Name**: `bn`
+    - **Usage**: Batch numbers.
+    - **Destination**: `batchOrBlockNumbers`
+  - `verbose`: See [verbose](#verbose) flag.
+  - `file-output`: See [file-output](#file-output) flag.
+
+#### `output-blocks`
+It is used to output the blocks by numbers from the Erigon database. 
+In case `verbose` flag is provided, it collects all the data for the blocks and transactions in the batch (otherwise only hashes).
+In case `file-output` flag is provided, results are printed to a JSON file (otherwise on a standard output).
+
+- **Name**: `output-blocks`
+- **Usage**: Outputs blocks by numbers.
+- **Action**: `dumpBlocksByNumbers`
+- **Flags**:
+  - `data-dir`: Specifies the data directory to use.
+  - `bn`: Block numbers.
+    - **Name**: `bn`
+    - **Usage**: Block numbers.
+    - **Destination**: `batchOrBlockNumbers`
+  - `verbose`: See [verbose](#verbose) flag.
+  - `file-output`: See [file-output](#file-output) flag.
+
+### Example Usage
+
+**Pre-requisite:** Navigate to the `zk/debug_tools/mdbx-data-browser` folder and run `go build -o mdbx-data-browser`
+
+#### `output-batches` Command
+
+```sh
+./mdbx-data-browser output-batches --bn 1,2,3 [--verbose] [--file-output]
+```
+
+#### `output-blocks` Command
+
+```sh
+./mdbx-data-browser output-blocks --bn 100,101,102 [--verbose] [--file-output]
+```

--- a/zk/debug_tools/mdbx-data-browser/README.md
+++ b/zk/debug_tools/mdbx-data-browser/README.md
@@ -65,11 +65,11 @@ In case `file-output` flag is provided, results are printed to a JSON file (othe
 #### `output-batches` Command
 
 ```sh
-./mdbx-data-browser output-batches --datadir mdbx.dat --bn 1,2,3 [--verbose] [--file-output]
+./mdbx-data-browser output-batches --datadir chaindata/ --bn 1,2,3 [--verbose] [--file-output]
 ```
 
 #### `output-blocks` Command
 
 ```sh
-./mdbx-data-browser output-blocks --datadir mdbx.dat --bn 100,101,102 [--verbose] [--file-output]
+./mdbx-data-browser output-blocks --datadir chaindata/ --bn 100,101,102 [--verbose] [--file-output]
 ```

--- a/zk/debug_tools/mdbx-data-browser/README.md
+++ b/zk/debug_tools/mdbx-data-browser/README.md
@@ -58,6 +58,8 @@ In case `file-output` flag is provided, results are printed to a JSON file (othe
   - `verbose`: See [verbose](#verbose) flag.
   - `file-output`: See [file-output](#file-output) flag.
 
+**Note:** In case, `output-blocks` is ran with `verbose` flag provided, it is necessary to provide the proper chain id to the `params/chainspecs/mainnet.json`. This is the case, because CDK Erigon (for now) uses hardcoded data to recover transaction senders, and chain id information is read from the mentioned file.
+
 ### Example Usage
 
 **Pre-requisite:** Navigate to the `zk/debug_tools/mdbx-data-browser` folder and run `go build -o mdbx-data-browser`

--- a/zk/debug_tools/mdbx-data-browser/cli.go
+++ b/zk/debug_tools/mdbx-data-browser/cli.go
@@ -149,7 +149,7 @@ func dumpBlocksByNumbers(cliCtx *cli.Context) error {
 
 // createDbTx creates a read-only database transaction, that allows querying it.
 func createDbTx(chainDataDir string, ctx context.Context) (kv.Tx, func(), error) {
-	db := mdbx.MustOpenRo(chainDataDir)
+	db := mdbx.MustOpen(chainDataDir)
 	dbTx, err := db.BeginRo(ctx)
 	cleanupFn := func() {
 		dbTx.Rollback()

--- a/zk/debug_tools/mdbx-data-browser/cli.go
+++ b/zk/debug_tools/mdbx-data-browser/cli.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gateway-fm/cdk-erigon-lib/kv"
@@ -173,7 +174,17 @@ func outputResults(results string) error {
 		defer file.Close()
 
 		_, err = file.Write([]byte(results))
-		return err
+		if err != nil {
+			return err
+		}
+
+		path, err := filepath.Abs(file.Name())
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("results are written to the '%s'", path)
+		return nil
 	}
 
 	// output results to the standard output

--- a/zk/debug_tools/mdbx-data-browser/cli.go
+++ b/zk/debug_tools/mdbx-data-browser/cli.go
@@ -101,8 +101,8 @@ func dumpBatchesByNumbers(cliCtx *cli.Context) error {
 		return fmt.Errorf("failed to serialize batches into the JSON format: %w", err)
 	}
 
-	if err := printResults(string(jsonBatches)); err != nil {
-		return fmt.Errorf("failed to print results: %w", err)
+	if err := outputResults(string(jsonBatches)); err != nil {
+		return fmt.Errorf("failed to output results: %w", err)
 	}
 
 	return nil
@@ -138,8 +138,8 @@ func dumpBlocksByNumbers(cliCtx *cli.Context) error {
 		return fmt.Errorf("failed to serialize blocks into the JSON format: %w", err)
 	}
 
-	if err := printResults(string(jsonBlocks)); err != nil {
-		return fmt.Errorf("failed to print results: %w", err)
+	if err := outputResults(string(jsonBlocks)); err != nil {
+		return fmt.Errorf("failed to output results: %w", err)
 	}
 
 	return nil
@@ -153,8 +153,8 @@ func createDbTx(chainDataDir string, ctx context.Context) (kv.Tx, error) {
 	return db.BeginRo(ctx)
 }
 
-// printResults prints results either to the terminal or to the file
-func printResults(results string) error {
+// outputResults prints results either to the terminal or to the file
+func outputResults(results string) error {
 	// output results to the file
 	if fileOutput {
 		formattedTime := time.Now().Format("02-01-2006 15:04:05")

--- a/zk/debug_tools/mdbx-data-browser/cli.go
+++ b/zk/debug_tools/mdbx-data-browser/cli.go
@@ -1,4 +1,4 @@
-package mdbxdatabrowser
+package main
 
 import (
 	"context"

--- a/zk/debug_tools/mdbx-data-browser/cli.go
+++ b/zk/debug_tools/mdbx-data-browser/cli.go
@@ -1,0 +1,143 @@
+package mdbxdatabrowser
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gateway-fm/cdk-erigon-lib/kv"
+	"github.com/gateway-fm/cdk-erigon-lib/kv/mdbx"
+	"github.com/urfave/cli/v2"
+
+	"github.com/ledgerwatch/erigon/cmd/utils"
+	types "github.com/ledgerwatch/erigon/zk/rpcdaemon"
+)
+
+var (
+	// common flags
+	verboseFlag = &cli.BoolFlag{
+		Name: "verbose",
+		Usage: "If verbose output is enabled, it prints all the details about blocks and transactions in the batches, " +
+			"otherwise just its hashes",
+		Destination: &verboseOutput,
+	}
+
+	fileOutputFlag = &cli.BoolFlag{
+		Name:        "file-output",
+		Usage:       "If file output is enabled, all the results are persisted within a file",
+		Destination: &fileOutput,
+	}
+
+	// commands
+	getBatchByNumberCmd = &cli.Command{
+		Action: dumpBatchesByNumbers,
+		Name:   "get-batch",
+		Usage:  "Gets batch by number",
+		Flags: []cli.Flag{
+			&utils.DataDirFlag,
+			&cli.Uint64SliceFlag{
+				Name:        "bn",
+				Usage:       "Batch numbers",
+				Destination: batchOrBlockNumbers,
+			},
+			verboseFlag,
+			fileOutputFlag,
+		},
+	}
+
+	getBlockByNumberCmd = &cli.Command{
+		Action: dumpBlocksByNumbers,
+		Name:   "get-block",
+		Usage:  "Gets block by number",
+		Flags: []cli.Flag{
+			&utils.DataDirFlag,
+			&cli.Uint64SliceFlag{
+				Name:        "bn",
+				Usage:       "Block numbers",
+				Destination: batchOrBlockNumbers,
+			},
+			verboseFlag,
+			fileOutputFlag,
+		},
+	}
+
+	// parameters
+	chainDataDir        string
+	batchOrBlockNumbers *cli.Uint64Slice
+	verboseOutput       bool
+	fileOutput          bool
+)
+
+// dumpBatchesByNumbers retrieves batches by given numbers and dumps them either on standard output or to a file
+func dumpBatchesByNumbers(cliCtx *cli.Context) error {
+	if !cliCtx.IsSet(utils.DataDirFlag.Name) {
+		return errors.New("chain data directory is not provided")
+	}
+
+	chainDataDir = cliCtx.String(utils.DataDirFlag.Name)
+
+	tx, err := createDbTx(chainDataDir, cliCtx.Context)
+	if err != nil {
+		return fmt.Errorf("failed to create read-only db transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	r := newDbDataRetriever(tx)
+	batches := make([]*types.Batch, 0, len(batchOrBlockNumbers.Value()))
+	for _, batchNum := range batchOrBlockNumbers.Value() {
+		batch, err := r.GetBatchByNumber(batchNum, true)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve the batch %d: %w", batchOrBlockNumbers, err)
+		}
+
+		batches = append(batches, batch)
+	}
+
+	jsonBatches, err := json.MarshalIndent(batches, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize batches into the JSON format: %w", err)
+	}
+
+	if err := printResults(string(jsonBatches)); err != nil {
+		return fmt.Errorf("failed to print results: %w", err)
+	}
+
+	return nil
+}
+
+func dumpBlocksByNumbers(cliCtx *cli.Context) error {
+	// TODO: IMPLEMENT ME
+	return nil
+}
+
+// createDbTx creates a read-only database transaction, that allows querying it.
+func createDbTx(chainDataDir string, ctx context.Context) (kv.Tx, error) {
+	db := mdbx.MustOpenRo(chainDataDir)
+	defer db.Close()
+
+	return db.BeginRo(ctx)
+}
+
+// printResults prints results either to the terminal or to the file
+func printResults(results string) error {
+	if fileOutput {
+		formattedTime := time.Now().Format("02-01-2006 15:04:05")
+		fileName := fmt.Sprintf("output_%s.json", formattedTime)
+
+		file, err := os.Create(fileName)
+		if err != nil {
+			return fmt.Errorf("error creating file: %w", err)
+		}
+		defer file.Close()
+
+		_, err = file.Write([]byte(results))
+		return err
+	}
+
+	fmt.Println(results)
+
+	return nil
+}

--- a/zk/debug_tools/mdbx-data-browser/cli.go
+++ b/zk/debug_tools/mdbx-data-browser/cli.go
@@ -85,12 +85,12 @@ func dumpBatchesByNumbers(cliCtx *cli.Context) error {
 	}
 	defer tx.Rollback()
 
-	r := newDbDataRetriever(tx)
+	r := NewDbDataRetriever(tx)
 	batches := make([]*types.Batch, 0, len(batchOrBlockNumbers.Value()))
 	for _, batchNum := range batchOrBlockNumbers.Value() {
 		batch, err := r.GetBatchByNumber(batchNum, verboseOutput)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve the batch %d: %w", batchOrBlockNumbers, err)
+			return fmt.Errorf("failed to retrieve the batch %d: %w", batchNum, err)
 		}
 
 		batches = append(batches, batch)
@@ -122,12 +122,12 @@ func dumpBlocksByNumbers(cliCtx *cli.Context) error {
 	}
 	defer tx.Rollback()
 
-	r := newDbDataRetriever(tx)
+	r := NewDbDataRetriever(tx)
 	blocks := make([]*types.Block, 0, len(batchOrBlockNumbers.Value()))
-	for _, batchNum := range batchOrBlockNumbers.Value() {
-		block, err := r.GetBlockByNumber(batchNum, verboseOutput, verboseOutput)
+	for _, blockNum := range batchOrBlockNumbers.Value() {
+		block, err := r.GetBlockByNumber(blockNum, verboseOutput, verboseOutput)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve the block %d: %w", batchOrBlockNumbers, err)
+			return fmt.Errorf("failed to retrieve the block %d: %w", blockNum, err)
 		}
 
 		blocks = append(blocks, block)

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gateway-fm/cdk-erigon-lib/kv"
@@ -31,6 +32,10 @@ func (d *DbDataRetriever) GetBatchByNumber(batchNum uint64, verboseOutput bool) 
 	latestBlockInBatch, err := d.getHighestBlockInBatch(batchNum)
 	if err != nil {
 		return nil, err
+	}
+
+	if latestBlockInBatch == nil {
+		return nil, errors.New("failed to retrieve the latest block in batch")
 	}
 
 	// Initialize batch
@@ -98,6 +103,15 @@ func (d *DbDataRetriever) GetBatchByNumber(batchNum uint64, verboseOutput bool) 
 
 // getHighestBlockInBatch reads the block with the highest block number from the batch
 func (d *DbDataRetriever) getHighestBlockInBatch(batchNum uint64) (*coreTypes.Block, error) {
+	_, found, err := d.dbReader.GetLowestBlockInBatch(batchNum)
+	if err != nil {
+		return nil, err
+	}
+
+	if !found {
+		return nil, nil
+	}
+
 	blockNum, err := d.dbReader.GetHighestBlockInBatch(batchNum)
 	if err != nil {
 		return nil, err

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
@@ -1,6 +1,8 @@
 package mdbxdatabrowser
 
 import (
+	"fmt"
+
 	"github.com/gateway-fm/cdk-erigon-lib/kv"
 
 	"github.com/ledgerwatch/erigon/core/rawdb"
@@ -14,8 +16,8 @@ type DbDataRetriever struct {
 	dbReader state.ReadOnlyHermezDb
 }
 
-// newDbDataRetriever instantiates DbDataRetriever instance
-func newDbDataRetriever(tx kv.Tx) *DbDataRetriever {
+// NewDbDataRetriever instantiates DbDataRetriever instance
+func NewDbDataRetriever(tx kv.Tx) *DbDataRetriever {
 	return &DbDataRetriever{
 		tx:       tx,
 		dbReader: hermez_db.NewHermezDbReader(tx),
@@ -144,8 +146,11 @@ func (d *DbDataRetriever) GetBlockByNumber(blockNum uint64, includeTxs, includeR
 	}
 
 	block := rawdb.ReadBlock(d.tx, blockHash, blockNum)
-	receipts := rawdb.ReadReceipts(d.tx, block, block.Body().SendersFromTxs())
+	if block == nil {
+		return nil, fmt.Errorf("block %d not found", blockNum)
+	}
 
+	receipts := rawdb.ReadReceipts(d.tx, block, block.Body().SendersFromTxs())
 	rpcBlock, err := rpcTypes.NewBlock(block, receipts.ToSlice(), includeTxs, includeReceipts)
 	if err != nil {
 		return nil, err

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
@@ -124,15 +124,17 @@ func (d *DbDataRetriever) GetBatchByNumber(batchNum uint64, verboseOutput bool) 
 	}
 	batch.BatchL2Data = batchL2Data
 
-	// L1 info tree (exit roots)
-	l1InfoTree, err := d.dbReader.GetL1InfoTreeUpdateByGer(batch.GlobalExitRoot)
-	if err != nil {
-		return nil, err
-	}
+	if batch.GlobalExitRoot != rpcTypes.ZeroHash {
+		// L1 info tree (exit roots)
+		l1InfoTree, err := d.dbReader.GetL1InfoTreeUpdateByGer(batch.GlobalExitRoot)
+		if err != nil {
+			return nil, err
+		}
 
-	if l1InfoTree != nil {
-		batch.MainnetExitRoot = l1InfoTree.MainnetExitRoot
-		batch.RollupExitRoot = l1InfoTree.RollupExitRoot
+		if l1InfoTree != nil {
+			batch.MainnetExitRoot = l1InfoTree.MainnetExitRoot
+			batch.RollupExitRoot = l1InfoTree.RollupExitRoot
+		}
 	}
 
 	return batch, nil

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
@@ -1,4 +1,4 @@
-package mdbxdatabrowser
+package main
 
 import (
 	"fmt"

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
@@ -125,7 +125,7 @@ func (d *DbDataRetriever) collectBlocksInBatch(batch *rpcTypes.Batch, batchNum u
 
 	// Handle genesis block separately
 	if batchNum == 0 {
-		if err := d.addGenesisBlock(batch, verboseOutput); err != nil {
+		if err := d.addBlockToBatch(batch, 0, verboseOutput); err != nil {
 			return err
 		}
 	}
@@ -135,22 +135,6 @@ func (d *DbDataRetriever) collectBlocksInBatch(batch *rpcTypes.Batch, batchNum u
 		if err := d.addBlockToBatch(batch, blockNum, verboseOutput); err != nil {
 			return err
 		}
-	}
-
-	return nil
-}
-
-// addGenesisBlock adds the genesis block to the batch
-func (d *DbDataRetriever) addGenesisBlock(batch *rpcTypes.Batch, verboseOutput bool) error {
-	genesisBlock, err := rawdb.ReadBlockByNumber(d.tx, 0)
-	if err != nil {
-		return err
-	}
-
-	if verboseOutput {
-		batch.Blocks = append(batch.Blocks, genesisBlock)
-	} else {
-		batch.Blocks = append(batch.Blocks, genesisBlock.Hash())
 	}
 
 	return nil

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 )
 
-func Test_DbDataRetriever_GetBatchByNumber(t *testing.T) {
+func TestDbDataRetrieverGetBatchByNumber(t *testing.T) {
 	const (
 		batchNum      = uint64(5)
 		blocksInBatch = uint64(6)
@@ -49,7 +49,7 @@ func Test_DbDataRetriever_GetBatchByNumber(t *testing.T) {
 	}
 }
 
-func Test_DbDataRetriever_GetBlockByNumber(t *testing.T) {
+func TestDbDataRetrieverGetBlockByNumber(t *testing.T) {
 	t.Run("querying an existing block", func(t *testing.T) {
 		// arrange
 		_, dbTx := memdb.NewTestTx(t)

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
@@ -38,7 +38,7 @@ func TestDbDataRetriever_GetBatchByNumber(t *testing.T) {
 	batch, err := dbReader.GetBatchByNumber(batchNum, true)
 	require.NoError(t, err)
 
-	require.Equal(t, batchNum, batch.Number)
+	require.Equal(t, batchNum, uint64(batch.Number))
 	require.Len(t, expectedBlockHashes, int(blocksInBatch))
 	for _, blockGeneric := range batch.Blocks {
 		block, ok := blockGeneric.(*types.Block)

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
@@ -1,0 +1,54 @@
+package mdbxdatabrowser
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	libcommon "github.com/gateway-fm/cdk-erigon-lib/common"
+	"github.com/gateway-fm/cdk-erigon-lib/kv/memdb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ledgerwatch/erigon/common/u256"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/types"
+)
+func TestDbDataRetriever_GetBlockByNumber(t *testing.T) {
+	t.Run("querying an existing block", func(t *testing.T) {
+		// arrange
+		_, tx := memdb.NewTestTx(t)
+
+		tx1 := types.NewTransaction(1, libcommon.HexToAddress("0x1050"), u256.Num1, 1, u256.Num1, nil)
+		tx2 := types.NewTransaction(2, libcommon.HexToAddress("0x100"), u256.Num27, 2, u256.Num2, nil)
+
+		block := types.NewBlockWithHeader(
+			&types.Header{
+				Number:      big.NewInt(5),
+				Extra:       []byte("some random data"),
+				UncleHash:   types.EmptyUncleHash,
+				TxHash:      types.EmptyRootHash,
+				ReceiptHash: types.EmptyRootHash,
+			})
+		block = block.WithBody(types.Transactions{tx1, tx2}, nil)
+
+		require.NoError(t, rawdb.WriteCanonicalHash(tx, block.Hash(), block.NumberU64()))
+		require.NoError(t, rawdb.WriteBlock(tx, block))
+
+		// act and assert
+		dbReader := NewDbDataRetriever(tx)
+		result, err := dbReader.GetBlockByNumber(block.NumberU64(), true, true)
+		require.NoError(t, err)
+		require.Equal(t, block.Hash(), result.Hash)
+		require.Equal(t, block.Number().Uint64(), uint64(result.Number))
+	})
+
+	t.Run("querying non-existent block", func(t *testing.T) {
+		blockNum := uint64(10)
+
+		_, tx := memdb.NewTestTx(t)
+		dbReader := NewDbDataRetriever(tx)
+		result, err := dbReader.GetBlockByNumber(blockNum, true, true)
+		require.ErrorContains(t, err, fmt.Sprintf("block %d not found", blockNum))
+		require.Nil(t, result)
+	})
+}

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
@@ -12,30 +12,57 @@ import (
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/zk/hermez_db"
 )
+
+func TestDbDataRetriever_GetBatchByNumber(t *testing.T) {
+	const (
+		batchNum      = uint64(5)
+		blocksInBatch = uint64(6)
+	)
+
+	_, dbTx := memdb.NewTestTx(t)
+	require.NoError(t, hermez_db.CreateHermezBuckets(dbTx))
+	db := hermez_db.NewHermezDb(dbTx)
+	expectedBlockHashes := make(map[uint64]libcommon.Hash, blocksInBatch)
+	for blockNum := uint64(1); blockNum <= blocksInBatch; blockNum++ {
+		require.NoError(t, db.WriteBlockBatch(blockNum, batchNum))
+		tx := types.NewTransaction(1, libcommon.HexToAddress(fmt.Sprintf("0x100%d", blockNum)), u256.Num1, 1, u256.Num1, nil)
+		block := createBlock(t, blockNum, types.Transactions{tx})
+		require.NoError(t, rawdb.WriteCanonicalHash(dbTx, block.Hash(), block.NumberU64()))
+		require.NoError(t, rawdb.WriteBlock(dbTx, block))
+		expectedBlockHashes[blockNum] = block.Hash()
+	}
+
+	dbReader := NewDbDataRetriever(dbTx)
+	batch, err := dbReader.GetBatchByNumber(batchNum, true)
+	require.NoError(t, err)
+
+	require.Equal(t, batchNum, batch.Number)
+	require.Len(t, expectedBlockHashes, int(blocksInBatch))
+	for _, blockGeneric := range batch.Blocks {
+		block, ok := blockGeneric.(*types.Block)
+		require.True(t, ok)
+		expectedHash, exists := expectedBlockHashes[block.NumberU64()]
+		require.True(t, exists)
+		require.Equal(t, expectedHash, block.Hash())
+	}
+}
+
 func TestDbDataRetriever_GetBlockByNumber(t *testing.T) {
 	t.Run("querying an existing block", func(t *testing.T) {
 		// arrange
-		_, tx := memdb.NewTestTx(t)
-
+		_, dbTx := memdb.NewTestTx(t)
 		tx1 := types.NewTransaction(1, libcommon.HexToAddress("0x1050"), u256.Num1, 1, u256.Num1, nil)
 		tx2 := types.NewTransaction(2, libcommon.HexToAddress("0x100"), u256.Num27, 2, u256.Num2, nil)
 
-		block := types.NewBlockWithHeader(
-			&types.Header{
-				Number:      big.NewInt(5),
-				Extra:       []byte("some random data"),
-				UncleHash:   types.EmptyUncleHash,
-				TxHash:      types.EmptyRootHash,
-				ReceiptHash: types.EmptyRootHash,
-			})
-		block = block.WithBody(types.Transactions{tx1, tx2}, nil)
+		block := createBlock(t, 5, types.Transactions{tx1, tx2})
 
-		require.NoError(t, rawdb.WriteCanonicalHash(tx, block.Hash(), block.NumberU64()))
-		require.NoError(t, rawdb.WriteBlock(tx, block))
+		require.NoError(t, rawdb.WriteCanonicalHash(dbTx, block.Hash(), block.NumberU64()))
+		require.NoError(t, rawdb.WriteBlock(dbTx, block))
 
 		// act and assert
-		dbReader := NewDbDataRetriever(tx)
+		dbReader := NewDbDataRetriever(dbTx)
 		result, err := dbReader.GetBlockByNumber(block.NumberU64(), true, true)
 		require.NoError(t, err)
 		require.Equal(t, block.Hash(), result.Hash)
@@ -51,4 +78,24 @@ func TestDbDataRetriever_GetBlockByNumber(t *testing.T) {
 		require.ErrorContains(t, err, fmt.Sprintf("block %d not found", blockNum))
 		require.Nil(t, result)
 	})
+}
+
+// createBlock is a helper function, that allows creating block
+func createBlock(t *testing.T, number uint64, txs types.Transactions) *types.Block {
+	t.Helper()
+
+	block := types.NewBlockWithHeader(
+		&types.Header{
+			Number:      new(big.Int).SetUint64(number),
+			Extra:       []byte("some random data"),
+			UncleHash:   types.EmptyUncleHash,
+			TxHash:      types.EmptyRootHash,
+			ReceiptHash: types.EmptyRootHash,
+		})
+
+	if txs.Len() > 0 {
+		block = block.WithBody(txs, nil)
+	}
+
+	return block
 }

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
@@ -1,4 +1,4 @@
-package mdbxdatabrowser
+package main
 
 import (
 	"fmt"

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 )
 
-func TestDbDataRetriever_GetBatchByNumber(t *testing.T) {
+func Test_DbDataRetriever_GetBatchByNumber(t *testing.T) {
 	const (
 		batchNum      = uint64(5)
 		blocksInBatch = uint64(6)
@@ -49,7 +49,7 @@ func TestDbDataRetriever_GetBatchByNumber(t *testing.T) {
 	}
 }
 
-func TestDbDataRetriever_GetBlockByNumber(t *testing.T) {
+func Test_DbDataRetriever_GetBlockByNumber(t *testing.T) {
 	t.Run("querying an existing block", func(t *testing.T) {
 		// arrange
 		_, dbTx := memdb.NewTestTx(t)

--- a/zk/debug_tools/mdbx-data-browser/main.go
+++ b/zk/debug_tools/mdbx-data-browser/main.go
@@ -1,0 +1,27 @@
+package mdbxdatabrowser
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ledgerwatch/erigon/params"
+	cli2 "github.com/ledgerwatch/erigon/turbo/cli"
+	"github.com/ledgerwatch/erigon/turbo/logging"
+)
+
+func main() {
+	app := cli2.NewApp(params.GitCommit, "MDBX data browser")
+	app.Commands = []*cli.Command{
+		getBatchByNumberCmd,
+		getBlockByNumberCmd,
+	}
+
+	logging.SetupLogger("mdbx data browser")
+
+	if err := app.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/zk/debug_tools/mdbx-data-browser/main.go
+++ b/zk/debug_tools/mdbx-data-browser/main.go
@@ -1,4 +1,4 @@
-package mdbxdatabrowser
+package main
 
 import (
 	"fmt"

--- a/zk/debug_tools/mdbx-data-browser/zkdata_retriever.go
+++ b/zk/debug_tools/mdbx-data-browser/zkdata_retriever.go
@@ -1,0 +1,141 @@
+package mdbxdatabrowser
+
+import (
+	"github.com/gateway-fm/cdk-erigon-lib/kv"
+
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/zk/hermez_db"
+	types "github.com/ledgerwatch/erigon/zk/rpcdaemon"
+)
+
+type DbDataRetriever struct {
+	tx       kv.Tx
+	dbReader state.ReadOnlyHermezDb
+}
+
+// newDbDataRetriever instantiates DbDataRetriever instance
+func newDbDataRetriever(tx kv.Tx) *DbDataRetriever {
+	return &DbDataRetriever{
+		tx:       tx,
+		dbReader: hermez_db.NewHermezDbReader(tx),
+	}
+}
+
+// GetBatchByNumber reads batch by number from the database
+func (z *DbDataRetriever) GetBatchByNumber(batchNum uint64, verboseOutput bool) (*types.Batch, error) {
+	// highest block in batch
+	blockNo, err := z.dbReader.GetHighestBlockInBatch(batchNum)
+	if err != nil {
+		return nil, err
+	}
+
+	blockHash, err := rawdb.ReadCanonicalHash(z.tx, blockNo)
+	if err != nil {
+		return nil, err
+	}
+
+	block := rawdb.ReadBlock(z.tx, blockHash, blockNo)
+
+	// last block in batch data
+	batch := &types.Batch{
+		Number:    types.ArgUint64(batchNum),
+		Coinbase:  block.Coinbase(),
+		StateRoot: block.Root(),
+		Timestamp: types.ArgUint64(block.Time()),
+	}
+
+	// block numbers in batch
+	blocksInBatch, err := z.dbReader.GetL2BlockNosByBatch(batchNum)
+	if err != nil {
+		return nil, err
+	}
+
+	// collect blocks in batch
+	// TODO: REMOVE
+	// batch.Blocks = []interface{}{}
+	// batch.Transactions = []interface{}{}
+	// handle genesis - not in the hermez tables so requires special treament
+	if batchNum == 0 {
+		blk, err := rawdb.ReadBlockByNumber(z.tx, 0)
+		if err != nil {
+			return nil, err
+		}
+		batch.Blocks = append(batch.Blocks, blk.Hash())
+	}
+
+	for _, blkNo := range blocksInBatch {
+		blk, err := rawdb.ReadBlockByNumber(z.tx, blkNo)
+		if err != nil {
+			return nil, err
+		}
+
+		if !verboseOutput {
+			batch.Blocks = append(batch.Blocks, blk.Hash())
+		} else {
+			batch.Blocks = append(batch.Blocks, blk)
+		}
+
+		for _, tx := range blk.Transactions() {
+			if !verboseOutput {
+				batch.Transactions = append(batch.Transactions, tx)
+			} else {
+				batch.Transactions = append(batch.Transactions, tx.Hash())
+			}
+		}
+	}
+
+	// global exit root of batch
+	ger, err := z.dbReader.GetBatchGlobalExitRoot(batchNum)
+	if err != nil {
+		return nil, err
+	}
+	if ger != nil {
+		batch.GlobalExitRoot = ger.GlobalExitRoot
+	}
+
+	// sequence
+	seq, err := z.dbReader.GetSequenceByBatchNo(batchNum)
+	if err != nil {
+		return nil, err
+	}
+	if seq != nil {
+		batch.SendSequencesTxHash = &seq.L1TxHash
+	}
+
+	// sequenced, genesis or injected batch 1 - special batches 0,1 will always be closed
+	batch.Closed = (seq != nil || batchNum <= 1)
+
+	// verification
+	ver, err := z.dbReader.GetVerificationByBatchNo(batchNum)
+	if err != nil {
+		return nil, err
+	}
+	if ver != nil {
+		batch.VerifyBatchTxHash = &ver.L1TxHash
+	}
+
+	// batch l2 data
+	batchL2Data, err := z.dbReader.GetL1BatchData(batchNum)
+	if err != nil {
+		return nil, err
+	}
+	batch.BatchL2Data = batchL2Data
+
+	// exit roots
+	l1InfoTree, err := z.dbReader.GetL1InfoTreeUpdateByGer(batch.GlobalExitRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	if l1InfoTree != nil {
+		batch.MainnetExitRoot = l1InfoTree.MainnetExitRoot
+		batch.RollupExitRoot = l1InfoTree.RollupExitRoot
+	}
+
+	return batch, nil
+}
+
+func (z *DbDataRetriever) GetBlockByNumber(blockNum uint64, includeTxs bool) {
+	// TODO: zkevm_api.go, GetFullBlockByNumber implementation
+}

--- a/zk/hermez_db/db_test.go
+++ b/zk/hermez_db/db_test.go
@@ -141,10 +141,10 @@ func TestGetAndSetLatest(t *testing.T) {
 			} else {
 				err = tc.writeVerificationMethod(db, tc.l1BlockNo, tc.batchNo, tc.l1TxHashBytes, tc.stateRoot)
 			}
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			info, err := db.getLatest(tc.table)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.batchNo, info.BatchNo)
 			assert.Equal(t, tc.l1BlockNo, info.L1BlockNo)
 			assert.Equal(t, tc.l1TxHashBytes, info.L1TxHash)
@@ -176,7 +176,7 @@ func TestGetAndSetLatestUnordered(t *testing.T) {
 
 	for _, tc := range testCases {
 		err := tc.writeMethod(db, tc.l1BlockNo, tc.batchNo, tc.l1TxHashBytes, tc.stateRoot)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		if tc.batchNo > highestBatchNo {
 			highestBatchNo = tc.batchNo
@@ -184,7 +184,7 @@ func TestGetAndSetLatestUnordered(t *testing.T) {
 	}
 
 	info, err := db.getLatest(L1VERIFICATIONS)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, highestBatchNo, info.BatchNo)
 
 	cleanup()
@@ -352,7 +352,7 @@ func TestTruncateBlockBatches(t *testing.T) {
 
 	for i := l2BlockNo + 1; i <= 1000; i++ {
 		_, err := db.GetBatchNoByL2Block(i)
-		require.Equal(t, err, nil)
+		require.NoError(t, err)
 	}
 
 	for i := uint64(1); i <= l2BlockNo; i++ {


### PR DESCRIPTION
This PR introduces a CLI tool that allows us to query the MDBX state. 

So far it incorporates the two commands:
- output-batches - this command outputs batches by batch numbers (the logic for querying the batches from the db was borrowed from https://github.com/0xPolygonHermez/cdk-erigon/blob/af9f9ec41f51c37c8ed6e01d1b36ead59bc00503/cmd/rpcdaemon/commands/zkevm_api.go#L228
- output-blocks - this command outputs blocks by block numbers.

Both of these commands are able to output just transaction hashes or all transaction details. Also, results can be printed out to the std out or to the json file. Results are always displayed in the JSON format.

Note that in case `--verbose` flag is included, a proper chain id must be provided to the `chainspecs/mainnet.json`, because of this line, which resolves the chain id in the hardcoded manner: https://github.com/0xPolygonHermez/cdk-erigon/blob/af9f9ec41f51c37c8ed6e01d1b36ead59bc00503/zk/rpcdaemon/types.go#L415

TODOs:
- [x] include examples on how to run the tool
- [ ] figure out why the `output-batches` isn't working properly, with the help of Erigon folks