### PR TITLE
feat(smt): regen smt in ram flag (default false - slower)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ In order to enable the zkevm_ namespace, please add 'zkevm' to the http.api flag
 - `zkevm_getBroadcastURI` - it was removed by zkEvm
 ***
 
-## Limitations/Warnings
+## Limitations/Warnings/Performance
 
 - The golden poseidon hashing will be much faster on x86, so developers on Mac may experience slowness on Apple silicone
 - Falling behind the network significantly will cause a SMT rebuild - which will take some time for longer chains
+
+Initial SMT build performance can be increased if machine has enough RAM:
+- `zkevm.smt-regenerate-in-memory` - setting this to true will use RAM to build the SMT rather than disk which is faster, but requires enough RAM (OOM kill potential)
 
 ***
 
@@ -184,6 +187,9 @@ Sequencer specific config:
 - `zkevm.executor-strict`: Defaulted to true, but can be set to false when running the sequencer without verifications (use with extreme caution)
 - `zkevm.witness-full`: Defaulted to true.  Controls whether the full or partial witness is used with the executor.
 - `zkevm.sequencer-initial-fork-id`: The fork id to start the network with.
+
+Resource Utilisation config:
+- `zkevm.smt-regenerate-in-memory`: As documented above, allows SMT regeneration in memory if machine has enough RAM, for a speedup in initial sync.
 
 Useful config entries:
 - `zkevm.sync-limit`: This will ensure the network only syncs to a given block height.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -456,6 +456,11 @@ var (
 		Usage: "Increment the state tree, never rebuild",
 		Value: false,
 	}
+	SmtRegenerateInMemory = cli.BoolFlag{
+		Name:  "zkevm.smt-regenerate-in-memory",
+		Usage: "Regenerate the SMT in memory (requires a lot of RAM for most chains)",
+		Value: false,
+	}
 	SequencerInitialForkId = cli.Uint64Flag{
 		Name:  "zkevm.sequencer-initial-fork-id",
 		Usage: "The initial fork id to launch the sequencer with",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -51,11 +51,12 @@ type Zk struct {
 	DataStreamHost                         string
 	DataStreamPort                         uint
 
-	RebuildTreeAfter    uint64
-	IncrementTreeAlways bool
-	WitnessFull         bool
-	SyncLimit           uint64
-	Gasless             bool
+	RebuildTreeAfter      uint64
+	IncrementTreeAlways   bool
+	SmtRegenerateInMemory bool
+	WitnessFull           bool
+	SyncLimit             uint64
+	Gasless               bool
 
 	DebugNoSync    bool
 	DebugLimit     uint64

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -187,6 +187,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.DatastreamVersionFlag,
 	&utils.RebuildTreeAfterFlag,
 	&utils.IncrementTreeAlways,
+	&utils.SmtRegenerateInMemory,
 	&utils.SequencerInitialForkId,
 	&utils.SequencerBlockSealTime,
 	&utils.SequencerBatchSealTime,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -106,6 +106,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		DatastreamVersion:                      ctx.Int(utils.DatastreamVersionFlag.Name),
 		RebuildTreeAfter:                       ctx.Uint64(utils.RebuildTreeAfterFlag.Name),
 		IncrementTreeAlways:                    ctx.Bool(utils.IncrementTreeAlways.Name),
+		SmtRegenerateInMemory:                  ctx.Bool(utils.SmtRegenerateInMemory.Name),
 		SequencerInitialForkId:                 ctx.Uint64(utils.SequencerInitialForkId.Name),
 		SequencerBlockSealTime:                 sequencerBlockSealTime,
 		SequencerBatchSealTime:                 sequencerBatchSealTime,

--- a/zk/stages/stage_interhashes.go
+++ b/zk/stages/stage_interhashes.go
@@ -129,10 +129,9 @@ func SpawnZkIntermediateHashesStage(s *stagedsync.StageState, u stagedsync.Unwin
 	eridb := db2.NewEriDb(tx)
 	smt := smt.NewSMT(eridb)
 
-	eridb.OpenBatch(quit)
-
 	if cfg.zk.IncrementTreeAlways {
 		// increment only behaviour
+		eridb.OpenBatch(quit)
 		log.Debug(fmt.Sprintf("[%s] IncrementTreeAlways true - incrementing tree", logPrefix), "previousRootHeight", s.BlockNumber, "calculatingRootHeight", to)
 		if root, err = zkIncrementIntermediateHashes(ctx, logPrefix, s, tx, eridb, smt, s.BlockNumber, to); err != nil {
 			return trie.EmptyRoot, err
@@ -140,21 +139,17 @@ func SpawnZkIntermediateHashesStage(s *stagedsync.StageState, u stagedsync.Unwin
 	} else {
 		// default behaviour
 		if s.BlockNumber == 0 || shouldRegenerate {
-			if !cfg.zk.SmtRegenerateInMemory {
-				// commit the batch to prevent using mapmutation (i.e. don't use RAM)
-				err = eridb.CommitBatch()
-				if err != nil {
-					return trie.EmptyRoot, err
-				}
+			if cfg.zk.SmtRegenerateInMemory {
+				log.Info(fmt.Sprintf("[%s] SMT using mapmutation", logPrefix))
+				eridb.OpenBatch(quit)
+			} else {
+				log.Info(fmt.Sprintf("[%s] SMT not using mapmutation", logPrefix))
 			}
 			if root, err = regenerateIntermediateHashes(logPrefix, tx, eridb, smt, to); err != nil {
 				return trie.EmptyRoot, err
 			}
-			if !cfg.zk.SmtRegenerateInMemory {
-				// re-open the batch for subsequent operations
-				eridb.OpenBatch(quit)
-			}
 		} else {
+			eridb.OpenBatch(quit)
 			if root, err = zkIncrementIntermediateHashes(ctx, logPrefix, s, tx, eridb, smt, s.BlockNumber, to); err != nil {
 				return trie.EmptyRoot, err
 			}
@@ -178,7 +173,9 @@ func SpawnZkIntermediateHashesStage(s *stagedsync.StageState, u stagedsync.Unwin
 		headerHash = syncHeadHeader.Hash()
 
 		if root != expectedRootHash {
-			eridb.RollbackBatch()
+			if cfg.zk.SmtRegenerateInMemory {
+				eridb.RollbackBatch()
+			}
 			panic(fmt.Sprintf("[%s] Wrong trie root of block %d: %x, expected (from header): %x. Block hash: %x", logPrefix, to, root, expectedRootHash, headerHash))
 
 			if cfg.badBlockHalt {


### PR DESCRIPTION
Adds flag `zkevm.smt-regenerate-in-memory` to force SMT regeneration in RAM (using map mutation), and updates the default so that SMT regen takes longer, but does not use map mutation - i.e. works directly with disk.