### PR TITLE
fix(zkevm_api): getBatchByNumber, ler, other fixes

### DIFF
--- a/cmd/rpcdaemon/commands/zkevm_api.go
+++ b/cmd/rpcdaemon/commands/zkevm_api.go
@@ -286,6 +286,7 @@ func (api *ZkEvmAPIImpl) GetBatchDataByNumbers(ctx context.Context, batchNumbers
 			return nil, err
 		}
 
+		// todo: max - take out shared logic with getBatchByNumber
 		// collect blocks in batch
 		var batchBlocks []*eritypes.Block
 		var batchTxs []eritypes.Transaction

--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -453,6 +453,7 @@ func executeBlockZk(
 			return nil, err
 		}
 	}
+
 	return execRs, nil
 }
 

--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -453,7 +453,6 @@ func executeBlockZk(
 			return nil, err
 		}
 	}
-
 	return execRs, nil
 }
 

--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -113,6 +113,7 @@ func SpawnExecuteBlocksStageZk(s *StageState, u Unwinder, tx kv.RwTx, toBlock ui
 Loop:
 	for blockNum := s.BlockNumber + 1; blockNum <= to; blockNum++ {
 		if cfg.zk.SyncLimit > 0 && blockNum > cfg.zk.SyncLimit {
+			log.Info(fmt.Sprintf("[%s] Sync limit reached", s.LogPrefix()), "block", blockNum)
 			break
 		}
 

--- a/hermezconfig-bali.yaml.example
+++ b/hermezconfig-bali.yaml.example
@@ -8,10 +8,10 @@ zkevm.l2-datastreamer-url: datastream.internal.zkevm-rpc.com:6900
 zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: https://rpc.sepolia.org
 
-zkevm.address-sequencer: ""
-zkevm.address-zkevm: ""
-zkevm.address-admin: "0xE2EF6215aDc132Df6913C8DD16487aBF118d1764"
-zkevm.address-rollup: "0x89BA0Ed947a88fe43c22Ae305C0713eC8a7Eb361"
+zkevm.address-sequencer: "0x9aeCf44E36f20DC407d1A580630c9a2419912dcB"
+zkevm.address-zkevm: "0x89BA0Ed947a88fe43c22Ae305C0713eC8a7Eb361"
+zkevm.address-admin: "0x229A5bDBb09d8555f9214F7a6784804999BA4E0D"
+zkevm.address-rollup: "0xE2EF6215aDc132Df6913C8DD16487aBF118d1764"
 zkevm.address-ger-manager: "0x2968D6d736178f8FE7393CC33C87f29D9C287e78"
 
 zkevm.default-gas-price: 10000000

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -38,6 +38,22 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 			if v == 0 {
 				panic(fmt.Sprintf("Flag not set: %s", flagName))
 			}
+		case []string:
+			if len(v) == 0 {
+				panic(fmt.Sprintf("Flag not set: %s", flagName))
+			}
+		case libcommon.Address:
+			if v == (libcommon.Address{}) {
+				panic(fmt.Sprintf("Flag not set: %s", flagName))
+			}
+		case time.Duration:
+			if v == 0 {
+				panic(fmt.Sprintf("Flag not set: %s", flagName))
+			}
+		case bool:
+			// nothing to check
+		default:
+			panic(fmt.Sprintf("Unsupported type for flag check: %T", value))
 		}
 	}
 

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -161,7 +161,6 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	if !sequencer.IsSequencer() {
 		checkFlag(utils.L2RpcUrlFlag.Name, cfg.L2RpcUrl)
 		checkFlag(utils.L2DataStreamerUrlFlag.Name, cfg.L2DataStreamerUrl)
-		checkFlag(utils.L2DataStreamerTimeout.Name, cfg.L2DataStreamerTimeout)
 	} else {
 		checkFlag(utils.SequencerInitialForkId.Name, cfg.SequencerInitialForkId)
 		checkFlag(utils.ExecutorUrls.Name, cfg.ExecutorUrls)

--- a/zk/datastream/server/data_stream_server.go
+++ b/zk/datastream/server/data_stream_server.go
@@ -6,11 +6,11 @@ import (
 	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
 	libcommon "github.com/gateway-fm/cdk-erigon-lib/common"
 	"github.com/gateway-fm/cdk-erigon-lib/kv"
-	"github.com/ledgerwatch/erigon/core/state"
 	eritypes "github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/zk/datastream/proto/github.com/0xPolygonHermez/zkevm-node/state/datastream"
 	"github.com/ledgerwatch/erigon/zk/datastream/types"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
+	"github.com/ledgerwatch/erigon/zk/utils"
 )
 
 type BookmarkType byte
@@ -274,7 +274,7 @@ func (srv *DataStreamServer) CreateStreamEntriesProto(
 				}
 
 				// seal off the last batch
-				localExitRoot, err := srv.getLocalExitRoot(workingBatch, reader, tx)
+				localExitRoot, err := utils.GetBatchLocalExitRoot(workingBatch, reader, tx)
 				if err != nil {
 					return nil, err
 				}
@@ -372,7 +372,7 @@ func (srv *DataStreamServer) CreateStreamEntriesProto(
 			}
 		}
 
-		localExitRoot, err := srv.getLocalExitRoot(batchNumber, reader, tx)
+		localExitRoot, err := utils.GetBatchLocalExitRoot(batchNumber, reader, tx)
 		if err != nil {
 			return nil, err
 		}
@@ -412,31 +412,6 @@ func (srv *DataStreamServer) addBatchStartEntries(reader *hermez_db.HermezDbRead
 	batchStart := srv.CreateBatchStartProto(batchNum, srv.chainId, fork, batchType)
 	entries.Add(batchStart)
 	return nil
-}
-
-func (srv *DataStreamServer) getLocalExitRoot(batch uint64, reader *hermez_db.HermezDbReader, tx kv.Tx) (libcommon.Hash, error) {
-	// now to fetch the LER for the batch - based on the last block of the batch
-	var localExitRoot libcommon.Hash
-	if batch > 0 {
-		checkBatch := batch
-		for ; checkBatch > 0; checkBatch-- {
-			lastBlockNumber, err := reader.GetHighestBlockInBatch(checkBatch)
-			if err != nil {
-				return libcommon.Hash{}, err
-			}
-			stateReader := state.NewPlainState(tx, lastBlockNumber, nil)
-			rawLer, err := stateReader.ReadAccountStorage(state.GER_MANAGER_ADDRESS, 1, &state.GLOBAL_EXIT_ROOT_POS_1)
-			if err != nil {
-				return libcommon.Hash{}, err
-			}
-			stateReader.Close()
-			localExitRoot = libcommon.BytesToHash(rawLer)
-			if localExitRoot != (libcommon.Hash{}) {
-				break
-			}
-		}
-	}
-	return localExitRoot, nil
 }
 
 func (srv *DataStreamServer) CreateAndBuildStreamEntryBytesProto(

--- a/zk/datastream/server/data_stream_server.go
+++ b/zk/datastream/server/data_stream_server.go
@@ -500,7 +500,7 @@ func (srv *DataStreamServer) UnwindToBlock(blockNumber uint64) error {
 		if err != nil {
 			return err
 		}
-		if entry.Type == datastreamer.EntryType(3) {
+		if entry.Type == datastreamer.EntryType(datastream.EntryType_ENTRY_TYPE_L2_BLOCK) {
 			break
 		}
 		entryNum -= 1

--- a/zk/datastream/server/datastream_populate.go
+++ b/zk/datastream/server/datastream_populate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/datastream/types"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 	"github.com/ledgerwatch/log/v3"
+	"github.com/ledgerwatch/erigon/zk/utils"
 )
 
 const GenesisForkId = 0 // genesis fork is always 0 in the datastream
@@ -217,7 +218,7 @@ func WriteGenesisToStream(
 	l2Block := srv.CreateL2BlockProto(genesis, genesis.Hash().Bytes(), batchNo, ger, 0, 0, common.Hash{}, 0, common.Hash{})
 	batchStart := srv.CreateBatchStartProto(batchNo, chainId, GenesisForkId, datastream.BatchType_BATCH_TYPE_REGULAR)
 
-	ler, err := srv.getLocalExitRoot(0, reader, tx)
+	ler, err := utils.GetBatchLocalExitRoot(0, reader, tx)
 	if err != nil {
 		return err
 	}

--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -45,6 +45,7 @@ const SMT_DEPTHS = "smt_depths"                                        // block 
 const L1_INFO_LEAVES = "l1_info_leaves"                                // l1 info tree index -> l1 info tree leaf
 const L1_INFO_ROOTS = "l1_info_roots"                                  // root hash -> l1 info tree index
 const INVALID_BATCHES = "invalid_batches"                              // batch number -> true
+const LOCAL_EXIT_ROOTS = "local_exit_roots"                            // l2 block number -> local exit root
 
 type HermezDb struct {
 	tx kv.RwTx
@@ -100,6 +101,7 @@ func CreateHermezBuckets(tx kv.RwTx) error {
 		L1_INFO_LEAVES,
 		L1_INFO_ROOTS,
 		INVALID_BATCHES,
+		LOCAL_EXIT_ROOTS,
 	}
 	for _, t := range tables {
 		if err := tx.CreateBucket(t); err != nil {
@@ -1497,4 +1499,16 @@ func (db *HermezDbReader) GetInvalidBatch(batchNo uint64) (bool, error) {
 		return false, err
 	}
 	return len(v) > 0, nil
+}
+
+func (db *HermezDb) WriteLocalExitRootForBatchNo(batchNo uint64, root common.Hash) error {
+	return db.tx.Put(LOCAL_EXIT_ROOTS, Uint64ToBytes(batchNo), root.Bytes())
+}
+
+func (db *HermezDbReader) GetLocalExitRootForBatchNo(batchNo uint64) (common.Hash, error) {
+	v, err := db.tx.GetOne(LOCAL_EXIT_ROOTS, Uint64ToBytes(batchNo))
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return common.BytesToHash(v), nil
 }

--- a/zk/rpcdaemon/types_zkevm.go
+++ b/zk/rpcdaemon/types_zkevm.go
@@ -21,3 +21,9 @@ type Batch struct {
 	Transactions        []interface{}  `json:"transactions"`
 	BatchL2Data         ArgBytes       `json:"batchL2Data"`
 }
+
+type BatchDataSlim struct {
+	Number      uint64   `json:"number"`
+	BatchL2Data ArgBytes `json:"batchL2Data,omitempty"`
+	Empty       bool     `json:"empty"`
+}

--- a/zk/stages/stage_batches.go
+++ b/zk/stages/stage_batches.go
@@ -69,6 +69,7 @@ type HermezDb interface {
 	WriteIntermediateTxStateRoot(l2BlockNumber uint64, txHash common.Hash, rpcRoot common.Hash) error
 	WriteBlockL1InfoTreeIndex(blockNumber uint64, l1Index uint64) error
 	WriteLatestUsedGer(batchNo uint64, ger common.Hash) error
+	WriteLocalExitRootForBatchNo(batchNo uint64, localExitRoot common.Hash) error
 }
 
 type DatastreamClient interface {
@@ -829,6 +830,13 @@ func writeL2Block(eriDb ErigonDb, hermezDb HermezDb, l2Block *types.FullL2Block,
 			if l2Block.GlobalExitRoot != emptyHash {
 				if err := hermezDb.WriteGerForL1BlockHash(l2Block.L1BlockHash, l2Block.GlobalExitRoot); err != nil {
 					return fmt.Errorf("write ger for l1 block hash error: %v", err)
+				}
+			}
+
+			// LER per batch - write the ler of the last block in the batch
+			if l2Block.BatchEnd && l2Block.LocalExitRoot != emptyHash {
+				if err := hermezDb.WriteLocalExitRootForBatchNo(l2Block.BatchNumber, l2Block.LocalExitRoot); err != nil {
+					return fmt.Errorf("write local exit root for l1 block hash error: %v", err)
 				}
 			}
 		}

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -494,6 +494,16 @@ func SpawnSequencingStage(
 		return err
 	}
 
+	// Local Exit Root (ler): read s/c storage every batch to store the LER for the highest block in the batch
+	ler, err := utils.GetBatchLocalExitRootFromSCStorage(thisBatch, sdb.hermezDb.HermezDbReader, tx)
+	if err != nil {
+		return err
+	}
+	// write ler to hermezdb
+	if err = sdb.hermezDb.WriteLocalExitRootForBatchNo(thisBatch, ler); err != nil {
+		return err
+	}
+
 	log.Info(fmt.Sprintf("[%s] Finish batch %d...", logPrefix, thisBatch))
 
 	if freshTx {

--- a/zk/utils/utils.go
+++ b/zk/utils/utils.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ledgerwatch/erigon/zk/constants"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 	"github.com/ledgerwatch/log/v3"
+	libcommon "github.com/gateway-fm/cdk-erigon-lib/common"
+	"github.com/ledgerwatch/erigon/core/state"
 )
 
 // if current sync is before verified batch - short circuit to verified batch, otherwise to enx of next batch
@@ -122,4 +124,44 @@ func RecoverySetBlockConfigForks(blockNum uint64, forkId uint64, cfg ForkConfigW
 	}
 
 	return nil
+}
+
+func GetBatchLocalExitRoot(batchNo uint64, db *hermez_db.HermezDbReader, tx kv.Tx) (libcommon.Hash, error) {
+	// check db first
+	localExitRoot, err := db.GetLocalExitRootForBatchNo(batchNo)
+	if err != nil {
+		return libcommon.Hash{}, err
+	}
+
+	if localExitRoot != (libcommon.Hash{}) {
+		return localExitRoot, nil
+	}
+
+	return GetBatchLocalExitRootFromSCStorage(batchNo, db, tx)
+}
+
+func GetBatchLocalExitRootFromSCStorage(batchNo uint64, db *hermez_db.HermezDbReader, tx kv.Tx) (libcommon.Hash, error) {
+	var localExitRoot libcommon.Hash
+
+	if batchNo > 0 {
+		checkBatch := batchNo
+		for ; checkBatch > 0; checkBatch-- {
+			blockNo, err := db.GetHighestBlockInBatch(checkBatch)
+			if err != nil {
+				return libcommon.Hash{}, err
+			}
+			stateReader := state.NewPlainState(tx, blockNo, nil)
+			rawLer, err := stateReader.ReadAccountStorage(state.GER_MANAGER_ADDRESS, 1, &state.GLOBAL_EXIT_ROOT_POS_1)
+			if err != nil {
+				return libcommon.Hash{}, err
+			}
+			stateReader.Close()
+			localExitRoot = libcommon.BytesToHash(rawLer)
+			if localExitRoot != (libcommon.Hash{}) {
+				break
+			}
+		}
+	}
+
+	return localExitRoot, nil
 }

--- a/zk/utils/utils.go
+++ b/zk/utils/utils.go
@@ -153,6 +153,7 @@ func GetBatchLocalExitRootFromSCStorage(batchNo uint64, db *hermez_db.HermezDbRe
 			stateReader := state.NewPlainState(tx, blockNo, nil)
 			rawLer, err := stateReader.ReadAccountStorage(state.GER_MANAGER_ADDRESS, 1, &state.GLOBAL_EXIT_ROOT_POS_1)
 			if err != nil {
+				stateReader.Close()
 				return libcommon.Hash{}, err
 			}
 			stateReader.Close()


### PR DESCRIPTION
## Sequencer
- read s/c once per batch to get/store the LER into hermezdb table

## RPC
- stores LER from stream against batch number
- if not found in db on zkevm_api JSON RPC call, retrieves from S/C storage