### PR TITLE
Fix getBatchByNumber Exit Roots (#725)

### DIFF
--- a/cmd/rpcdaemon/commands/zkevm_api.go
+++ b/cmd/rpcdaemon/commands/zkevm_api.go
@@ -638,6 +638,29 @@ func (api *ZkEvmAPIImpl) GetBatchByNumber(ctx context.Context, batchNumber rpc.B
 	}
 	batch.AccInputHash = oldAccInputHash
 
+	// forkid exit roots logic
+	// if forkid < 12 then we should only set the exit roots if they have changed, otherwise 0x00..00
+	// if forkid >= 12 then we should always set the exit roots
+	if forkId < 12 {
+		// get the previous batches exit roots
+		prevBatchNo := batchNo - 1
+		prevBatchGer, _, err := hermezDb.GetLastBatchGlobalExitRoot(prevBatchNo)
+		if err != nil {
+			return nil, err
+		}
+
+		itu, err := hermezDb.GetL1InfoTreeUpdateByGer(prevBatchGer.GlobalExitRoot)
+		if err != nil {
+			return nil, err
+		}
+
+		if itu == nil || batch.MainnetExitRoot == itu.MainnetExitRoot {
+			batch.MainnetExitRoot = common.Hash{}
+			batch.RollupExitRoot = common.Hash{}
+			batch.GlobalExitRoot = common.Hash{}
+		}
+	}
+
 	return populateBatchDetails(batch)
 }
 


### PR DESCRIPTION
* fix(zkevm_api): pre fork 10 zkevm-node match on getBatchByNumber

* fix(zkevm_api): 0x00 ger, mer, rer on no change