### PR TITLE
Fix getBatchByNumber

### DIFF
--- a/cmd/rpcdaemon/commands/zkevm_api.go
+++ b/cmd/rpcdaemon/commands/zkevm_api.go
@@ -645,15 +645,17 @@ func (api *ZkEvmAPIImpl) GetBatchByNumber(ctx context.Context, batchNumber rpc.B
 			return nil, err
 		}
 
-		itu, err := hermezDb.GetL1InfoTreeUpdateByGer(prevBatchGer.GlobalExitRoot)
-		if err != nil {
-			return nil, err
-		}
+		if prevBatchGer != nil {
+			itu, err := hermezDb.GetL1InfoTreeUpdateByGer(prevBatchGer.GlobalExitRoot)
+			if err != nil {
+				return nil, err
+			}
 
-		if itu == nil || batch.MainnetExitRoot == itu.MainnetExitRoot {
-			batch.MainnetExitRoot = common.Hash{}
-			batch.RollupExitRoot = common.Hash{}
-			batch.GlobalExitRoot = common.Hash{}
+			if itu == nil || batch.MainnetExitRoot == itu.MainnetExitRoot {
+				batch.MainnetExitRoot = common.Hash{}
+				batch.RollupExitRoot = common.Hash{}
+				batch.GlobalExitRoot = common.Hash{}
+			}
 		}
 	}
 


### PR DESCRIPTION
RPC method `zkevm_getBatchByNumber` will panic when there isn't previous batch ger. This PR fixes this issue. 