### PR TITLE
Fix L1 info tree due to duplicated logs

### DIFF
--- a/zk/l1infotree/tree.go
+++ b/zk/l1infotree/tree.go
@@ -186,7 +186,6 @@ func (mt *L1InfoTree) AddLeaf(index uint32, leaf [32]byte) (common.Hash, error) 
 
 func (mt *L1InfoTree) LeafExists(leaf [32]byte) bool {
 	_, ok := mt.allLeaves[leaf]
-	log.Info("All leaves: ", mt.allLeaves)
 	return ok
 }
 

--- a/zk/l1infotree/tree.go
+++ b/zk/l1infotree/tree.go
@@ -3,8 +3,8 @@ package l1infotree
 import (
 	"fmt"
 
-	"github.com/ledgerwatch/log/v3"
 	"github.com/gateway-fm/cdk-erigon-lib/common"
+	"github.com/ledgerwatch/log/v3"
 )
 
 // L1InfoTree provides methods to compute L1InfoTree
@@ -14,6 +14,7 @@ type L1InfoTree struct {
 	count       uint32
 	siblings    [][32]byte
 	currentRoot common.Hash
+	allLeaves   map[[32]byte]struct{}
 }
 
 // NewL1InfoTree creates new L1InfoTree.
@@ -29,6 +30,12 @@ func NewL1InfoTree(height uint8, initialLeaves [][32]byte) (*L1InfoTree, error) 
 		log.Error("error initializing siblings. Error: ", err)
 		return nil, err
 	}
+
+	mt.allLeaves = make(map[[32]byte]struct{})
+	for _, leaf := range initialLeaves {
+		mt.allLeaves[leaf] = struct{}{}
+	}
+
 	log.Debug("Initial count: ", mt.count)
 	log.Debug("Initial root: ", mt.currentRoot)
 	return mt, nil
@@ -48,6 +55,12 @@ func (mt *L1InfoTree) ResetL1InfoTree(initialLeaves [][32]byte) (*L1InfoTree, er
 		log.Error("error initializing siblings. Error: ", err)
 		return nil, err
 	}
+
+	newMT.allLeaves = make(map[[32]byte]struct{})
+	for _, leaf := range initialLeaves {
+		newMT.allLeaves[leaf] = struct{}{}
+	}
+
 	log.Debug("Reset initial count: ", newMT.count)
 	log.Debug("Reset initial root: ", newMT.currentRoot)
 	return newMT, nil
@@ -163,9 +176,18 @@ func (mt *L1InfoTree) AddLeaf(index uint32, leaf [32]byte) (common.Hash, error) 
 			// the sibling of 0 bit should be the zero hash, since we are in the last node of the tree
 		}
 	}
+
+	mt.allLeaves[leaf] = struct{}{}
+
 	mt.currentRoot = cur
 	mt.count++
 	return cur, nil
+}
+
+func (mt *L1InfoTree) LeafExists(leaf [32]byte) bool {
+	_, ok := mt.allLeaves[leaf]
+	log.Info("All leaves: ", mt.allLeaves)
+	return ok
 }
 
 // initSiblings returns the siblings of the node at the given index.

--- a/zk/stages/stage_l1_sequencer_sync.go
+++ b/zk/stages/stage_l1_sequencer_sync.go
@@ -168,19 +168,14 @@ Loop:
 	return nil
 }
 
-func HandleL1InfoTreeUpdate(
-	syncer IL1Syncer,
-	hermezDb *hermez_db.HermezDb,
-	l ethTypes.Log,
-	latestUpdate *types.L1InfoTreeUpdate,
-	found bool,
-	header *ethTypes.Header,
-) (*types.L1InfoTreeUpdate, error) {
+func CreateL1InfoTreeUpdate(l ethTypes.Log, header *ethTypes.Header) (*types.L1InfoTreeUpdate, error) {
 	if len(l.Topics) != 3 {
-		log.Warn("Received log for info tree that did not have 3 topics")
-		return nil, nil
+		return nil, fmt.Errorf("received log for info tree that did not have 3 topics")
 	}
-	var err error
+
+	if l.BlockNumber != header.Number.Uint64() {
+		return nil, fmt.Errorf("received log for info tree that did not match the block number")
+	}
 
 	mainnetExitRoot := l.Topics[1]
 	rollupExitRoot := l.Topics[2]
@@ -190,35 +185,26 @@ func HandleL1InfoTreeUpdate(
 		GER:             common.BytesToHash(ger),
 		MainnetExitRoot: mainnetExitRoot,
 		RollupExitRoot:  rollupExitRoot,
+		BlockNumber:     l.BlockNumber,
+		Timestamp:       header.Time,
+		ParentHash:      header.ParentHash,
 	}
 
-	if !found {
-		// this is a special case, so we need to start at index 0
-		update.Index = 0
-	} else {
-		// increment the index from the previous entry
-		update.Index = latestUpdate.Index + 1
-	}
+	return update, nil
+}
 
-	// now we need the block timestamp and the parent hash information for the block tied
-	// to this event
-	if header == nil {
-		header, err = syncer.GetHeader(l.BlockNumber)
-		if err != nil {
-			return nil, err
-		}
-	}
-	update.ParentHash = header.ParentHash
-	update.Timestamp = header.Time
-	update.BlockNumber = l.BlockNumber
-
+func HandleL1InfoTreeUpdate(
+	hermezDb *hermez_db.HermezDb,
+	update *types.L1InfoTreeUpdate,
+) error {
+	var err error
 	if err = hermezDb.WriteL1InfoTreeUpdate(update); err != nil {
-		return nil, err
+		return err
 	}
 	if err = hermezDb.WriteL1InfoTreeUpdateToGer(update); err != nil {
-		return nil, err
+		return err
 	}
-	return update, nil
+	return nil
 }
 
 const (


### PR DESCRIPTION
In some cases, l1 info tree will receive l1 info logs which were processed before. It leads to the node creating a duplicated l1 info leaf, which results in invalid batch. This commit resolve this issue by checking l1 info leaf hash and skip the update if it already presents in the l1 info tree.