### PR TITLE
BatchL2Data Fix (zkevm_getBatchByNumber)

### DIFF
--- a/zk/debug_tools/rpc-batch-compare/main.go
+++ b/zk/debug_tools/rpc-batch-compare/main.go
@@ -10,8 +10,9 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-cmp/cmp"
 	"io"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func getBatchNumber(url string) (*big.Int, error) {
@@ -162,6 +163,7 @@ func main() {
 	log.Printf("Skipping %d batches\n", *skip)
 
 	for i := 0; i < *numBatches; i++ {
+		log.Println("Checking batch", i+1, "of", *numBatches)
 		batchNumber := new(big.Int).Sub(startBatch, big.NewInt(int64(i**skip)))
 		diff, err := compareBatches(*erigonURL, *legacyURL, batchNumber)
 		if err != nil {

--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -757,6 +757,7 @@ func (db *HermezDb) WriteBatchGlobalExitRoot(batchNumber uint64, ger dstypes.Ger
 	return db.tx.Put(GLOBAL_EXIT_ROOTS_BATCHES, Uint64ToBytes(batchNumber), ger.EncodeToBytes())
 }
 
+// deprecated: post etrog this will not work
 func (db *HermezDbReader) GetBatchGlobalExitRoots(fromBatchNum, toBatchNum uint64) (*[]dstypes.GerUpdate, error) {
 	c, err := db.tx.Cursor(GLOBAL_EXIT_ROOTS_BATCHES)
 	if err != nil {
@@ -784,6 +785,7 @@ func (db *HermezDbReader) GetBatchGlobalExitRoots(fromBatchNum, toBatchNum uint6
 	return &gers, err
 }
 
+// GetLastBatchGlobalExitRoot deprecated: post etrog this will not work
 func (db *HermezDbReader) GetLastBatchGlobalExitRoot(batchNum uint64) (*dstypes.GerUpdate, uint64, error) {
 	c, err := db.tx.Cursor(GLOBAL_EXIT_ROOTS_BATCHES)
 	if err != nil {
@@ -829,6 +831,7 @@ func (db *HermezDbReader) GetBatchGlobalExitRootsProto(fromBatchNum, toBatchNum 
 	return gersProto, nil
 }
 
+// GetBatchGlobalExitRoot deprecated: post etrog this will not work
 func (db *HermezDbReader) GetBatchGlobalExitRoot(batchNum uint64) (*dstypes.GerUpdate, error) {
 	gerUpdateBytes, err := db.tx.GetOne(GLOBAL_EXIT_ROOTS_BATCHES, Uint64ToBytes(batchNum))
 	if err != nil {

--- a/zk/tx/tx.go
+++ b/zk/tx/tx.go
@@ -322,7 +322,7 @@ func TransactionToL2Data(tx types.Transaction, forkId uint16, efficiencyPercenta
 		removeLeadingZeroesFromBytes(gas),
 		to, // don't remove leading 0s from addr
 		removeLeadingZeroesFromBytes(valueBytes),
-		removeLeadingZeroesFromBytes(tx.GetData()),
+		tx.GetData(),
 	}
 
 	if !tx.GetChainID().Eq(uint256.NewInt(0)) || !(v.Eq(uint256.NewInt(27)) || v.Eq(uint256.NewInt(28))) {


### PR DESCRIPTION
- fix l2 data (tx data with leading zeros)
- deprecated db func which doesn't return useful data beyond etrog (forkid 7)
- fix GER retrieval logic in getBatchByNumber - though this still needs work