### PR TITLE
Detect and handle rollbacks on the RPC nodes

### DIFF
--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -133,7 +133,7 @@ func (c *StreamClient) GetL2BlockByNumber(blockNum uint64) (*types.FullL2Block, 
 		default:
 		}
 
-		parsedEntry, err := c.readParsedProto()
+		parsedEntry, err := ReadParsedProto(c)
 		if err != nil {
 			return nil, -1, err
 		}
@@ -166,21 +166,21 @@ func (c *StreamClient) GetLatestL2Block() (l2Block *types.FullL2Block, err error
 	}
 
 	latestEntryNum := h.TotalEntries - 1
+	var ok bool
 
 	for l2Block == nil && latestEntryNum > 0 {
 		if err := c.sendEntryCmdWrapper(latestEntryNum); err != nil {
 			return nil, err
 		}
 
-		entry, err := c.readFileEntry()
+		parsedEntry, err := ReadParsedProto(c)
 		if err != nil {
 			return nil, err
 		}
 
-		if entry.EntryType == types.EntryTypeL2Block {
-			if l2Block, err = types.UnmarshalL2Block(entry.Data); err != nil {
-				return nil, err
-			}
+		l2Block, ok = parsedEntry.(*types.FullL2Block)
+		if ok {
+			return l2Block, nil
 		}
 
 		latestEntryNum--

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -29,15 +29,19 @@ const (
 	versionAddedBlockEnd = 3 // Added block end
 )
 
+var (
+	// ErrFileEntryNotFound denotes error that is returned when the certain file entry is not found in the datastream
+	ErrFileEntryNotFound = errors.New("file entry not found")
+)
+
 type StreamClient struct {
 	ctx          context.Context
 	server       string // Server address to connect IP:port
 	version      int
 	streamType   StreamType
 	conn         net.Conn
-	id           string            // Client id
-	Header       types.HeaderEntry // Header info received (from Header command)
-	checkTimeout time.Duration     // time to wait for data before reporting an error
+	id           string        // Client id
+	checkTimeout time.Duration // time to wait for data before reporting an error
 
 	// atomic
 	lastWrittenTime atomic.Int64
@@ -59,6 +63,7 @@ const (
 	PtPadding = 0
 	PtHeader  = 1    // Just for the header page
 	PtData    = 2    // Data entry
+	PtDataRsp = 0xfe // PtDataRsp is packet type for command response with data
 	PtResult  = 0xff // Not stored/present in file (just for client command result)
 )
 
@@ -86,6 +91,108 @@ func (c *StreamClient) IsVersion3() bool {
 func (c *StreamClient) GetEntryChan() chan interface{} {
 	return c.entryChan
 }
+
+// GetL2BlockByNumber queries the data stream by sending the L2 block start bookmark for the certain block number
+// and streams the changes for that block (including the transactions).
+// Note that this function is intended for on demand querying and it disposes the connection after it ends.
+func (c *StreamClient) GetL2BlockByNumber(blockNum uint64) (*types.FullL2Block, int, error) {
+	if _, err := c.EnsureConnected(); err != nil {
+		return nil, -1, err
+	}
+	defer c.Stop()
+
+	var (
+		l2Block   *types.FullL2Block
+		err       error
+		isL2Block bool
+	)
+
+	bookmark := types.NewBookmarkProto(blockNum, datastream.BookmarkType_BOOKMARK_TYPE_L2_BLOCK)
+	bookmarkRaw, err := bookmark.Marshal()
+	if err != nil {
+		return nil, -1, err
+	}
+
+	re, err := c.initiateDownloadBookmark(bookmarkRaw)
+	if err != nil {
+		errorCode := -1
+		if re != nil {
+			errorCode = int(re.ErrorNum)
+		}
+		return nil, errorCode, err
+	}
+
+	for l2Block == nil {
+		select {
+		case <-c.ctx.Done():
+			errorCode := -1
+			if re != nil {
+				errorCode = int(re.ErrorNum)
+			}
+			return l2Block, errorCode, nil
+		default:
+		}
+
+		parsedEntry, err := c.readParsedProto()
+		if err != nil {
+			return nil, -1, err
+		}
+
+		l2Block, isL2Block = parsedEntry.(*types.FullL2Block)
+		if isL2Block {
+			break
+		}
+	}
+
+	if l2Block.L2BlockNumber != blockNum {
+		return nil, -1, fmt.Errorf("expected block number %d but got %d", blockNum, l2Block.L2BlockNumber)
+	}
+
+	return l2Block, types.CmdErrOK, nil
+}
+
+// GetLatestL2Block queries the data stream by reading the header entry and based on total entries field,
+// it retrieves the latest File entry that is of EntryTypeL2Block type.
+// Note that this function is intended for on demand querying and it disposes the connection after it ends.
+func (c *StreamClient) GetLatestL2Block() (l2Block *types.FullL2Block, err error) {
+	if _, err := c.EnsureConnected(); err != nil {
+		return nil, err
+	}
+	defer c.Stop()
+
+	h, err := c.GetHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	latestEntryNum := h.TotalEntries - 1
+
+	for l2Block == nil && latestEntryNum > 0 {
+		if err := c.sendEntryCmdWrapper(latestEntryNum); err != nil {
+			return nil, err
+		}
+
+		entry, err := c.readFileEntry()
+		if err != nil {
+			return nil, err
+		}
+
+		if entry.EntryType == types.EntryTypeL2Block {
+			if l2Block, err = types.UnmarshalL2Block(entry.Data); err != nil {
+				return nil, err
+			}
+		}
+
+		latestEntryNum--
+	}
+
+	if latestEntryNum == 0 {
+		return nil, errors.New("failed to retrieve the latest block from the data stream")
+	}
+
+	return l2Block, nil
+}
+
 func (c *StreamClient) GetLastWrittenTimeAtomic() *atomic.Int64 {
 	return &c.lastWrittenTime
 }
@@ -111,10 +218,14 @@ func (c *StreamClient) Start() error {
 }
 
 func (c *StreamClient) Stop() {
+	if c.conn == nil {
+		return
+	}
 	if err := c.sendStopCmd(); err != nil {
 		log.Warn(fmt.Sprintf("Failed to send the stop command to the data stream server: %s", err))
 	}
 	c.conn.Close()
+	c.conn = nil
 
 	close(c.entryChan)
 }
@@ -122,45 +233,59 @@ func (c *StreamClient) Stop() {
 // Command header: Get status
 // Returns the current status of the header.
 // If started, terminate the connection.
-func (c *StreamClient) GetHeader() error {
+func (c *StreamClient) GetHeader() (*types.HeaderEntry, error) {
 	if err := c.sendHeaderCmd(); err != nil {
-		return fmt.Errorf("%s send header error: %v", c.id, err)
+		return nil, fmt.Errorf("%s send header error: %v", c.id, err)
 	}
 
 	// Read packet
 	packet, err := readBuffer(c.conn, 1)
 	if err != nil {
-		return fmt.Errorf("%s read buffer: %v", c.id, err)
+		return nil, fmt.Errorf("%s read buffer: %v", c.id, err)
 	}
 
 	// Check packet type
 	if packet[0] != PtResult {
-		return fmt.Errorf("%s error expecting result packet type %d and received %d", c.id, PtResult, packet[0])
+		return nil, fmt.Errorf("%s error expecting result packet type %d and received %d", c.id, PtResult, packet[0])
 	}
 
 	// Read server result entry for the command
 	r, err := c.readResultEntry(packet)
 	if err != nil {
-		return fmt.Errorf("%s read result entry error: %v", c.id, err)
+		return nil, fmt.Errorf("%s read result entry error: %v", c.id, err)
 	}
 	if err := r.GetError(); err != nil {
-		return fmt.Errorf("%s got Result error code %d: %v", c.id, r.ErrorNum, err)
+		return nil, fmt.Errorf("%s got Result error code %d: %v", c.id, r.ErrorNum, err)
 	}
 
 	// Read header entry
 	h, err := c.readHeaderEntry()
 	if err != nil {
-		return fmt.Errorf("%s read header entry error: %v", c.id, err)
+		return nil, fmt.Errorf("%s read header entry error: %v", c.id, err)
 	}
 
-	c.Header = *h
+	return h, nil
+}
+
+// sendEntryCmdWrapper sends CmdEntry command and reads packet type and decodes result entry.
+func (c *StreamClient) sendEntryCmdWrapper(entryNum uint64) error {
+	if err := c.sendEntryCmd(entryNum); err != nil {
+		return err
+	}
+
+	if re, err := c.readPacketAndDecodeResultEntry(); err != nil {
+		return fmt.Errorf("failed to retrieve the result entry: %w", err)
+	} else if err := re.GetError(); err != nil {
+		return err
+	}
 
 	return nil
 }
 
 func (c *StreamClient) ExecutePerFile(bookmark *types.BookmarkProto, function func(file *types.FileEntry) error) error {
 	// Get header from server
-	if err := c.GetHeader(); err != nil {
+	header, err := c.GetHeader()
+	if err != nil {
 		return fmt.Errorf("%s get header error: %v", c.id, err)
 	}
 
@@ -169,7 +294,7 @@ func (c *StreamClient) ExecutePerFile(bookmark *types.BookmarkProto, function fu
 		return fmt.Errorf("failed to marshal bookmark: %v", err)
 	}
 
-	if err := c.initiateDownloadBookmark(protoBookmark); err != nil {
+	if _, err := c.initiateDownloadBookmark(protoBookmark); err != nil {
 		return err
 	}
 	count := uint64(0)
@@ -181,7 +306,7 @@ func (c *StreamClient) ExecutePerFile(bookmark *types.BookmarkProto, function fu
 			fmt.Println("Entries read count: ", count)
 		default:
 		}
-		if c.Header.TotalEntries == count {
+		if header.TotalEntries == count {
 			break
 		}
 		file, err := c.NextFileEntry()
@@ -203,7 +328,7 @@ func (c *StreamClient) EnsureConnected() (bool, error) {
 		if err := c.tryReConnect(); err != nil {
 			return false, fmt.Errorf("failed to reconnect the datastream client: %w", err)
 		}
-		log.Info("[datastream_client] Datastream client connected.")
+		c.entryChan = make(chan interface{}, 100000)
 	}
 
 	return true, nil
@@ -229,7 +354,7 @@ func (c *StreamClient) ReadAllEntriesToChannel() error {
 	}
 
 	// send start command
-	if err := c.initiateDownloadBookmark(protoBookmark); err != nil {
+	if _, err := c.initiateDownloadBookmark(protoBookmark); err != nil {
 		return err
 	}
 
@@ -253,37 +378,31 @@ func (c *StreamClient) ReadAllEntriesToChannel() error {
 }
 
 // runs the prerequisites for entries download
-func (c *StreamClient) initiateDownloadBookmark(bookmark []byte) error {
-	// send start command
-	if err := c.sendStartBookmarkCmd(bookmark); err != nil {
-		return err
+func (c *StreamClient) initiateDownloadBookmark(bookmark []byte) (*types.ResultEntry, error) {
+	// send CmdStartBookmark command
+	if err := c.sendBookmarkCmd(bookmark, true); err != nil {
+		return nil, err
 	}
 
-	if err := c.afterStartCommand(); err != nil {
-		return fmt.Errorf("after start command error: %v", err)
+	re, err := c.afterStartCommand()
+	if err != nil {
+		return re, fmt.Errorf("after start command error: %v", err)
 	}
 
-	return nil
+	return re, nil
 }
 
-func (c *StreamClient) afterStartCommand() error {
-	// Read packet
-	packet, err := readBuffer(c.conn, 1)
+func (c *StreamClient) afterStartCommand() (*types.ResultEntry, error) {
+	re, err := c.readPacketAndDecodeResultEntry()
 	if err != nil {
-		return fmt.Errorf("read buffer error %v", err)
+		return nil, err
 	}
 
-	// Read server result entry for the command
-	r, err := c.readResultEntry(packet)
-	if err != nil {
-		return fmt.Errorf("read result entry error: %v", err)
+	if err := re.GetError(); err != nil {
+		return re, fmt.Errorf("got Result error code %d: %v", re.ErrorNum, err)
 	}
 
-	if err := r.GetError(); err != nil {
-		return fmt.Errorf("got Result error code %d: %v", r.ErrorNum, err)
-	}
-
-	return nil
+	return re, nil
 }
 
 // reads all entries from the server and sends them to a channel
@@ -339,11 +458,13 @@ func (c *StreamClient) tryReConnect() error {
 	for i := 0; i < 50; i++ {
 		if c.conn != nil {
 			if err := c.conn.Close(); err != nil {
+				log.Warn(fmt.Sprintf("[%d. iteration] failed to close the DS connection: %s", i+1, err))
 				return err
 			}
 			c.conn = nil
 		}
 		if err = c.Start(); err != nil {
+			log.Warn(fmt.Sprintf("[%d. iteration] failed to start the DS connection: %s", i+1, err))
 			time.Sleep(5 * time.Second)
 			continue
 		}
@@ -363,7 +484,7 @@ func ReadParsedProto(iterator FileEntryIterator) (
 ) {
 	file, err := iterator.NextFileEntry()
 	if err != nil {
-		err = fmt.Errorf("read file entry error: %v", err)
+		err = fmt.Errorf("read file entry error: %w", err)
 		return
 	}
 
@@ -436,8 +557,11 @@ func ReadParsedProto(iterator FileEntryIterator) (
 		l2Block.L2Txs = txs
 		parsedEntry = l2Block
 		return
+	case types.EntryTypeL2BlockEnd:
+		log.Debug(fmt.Sprintf("retrieved EntryTypeL2BlockEnd: %+v", file))
+		return
 	case types.EntryTypeL2Tx:
-		err = fmt.Errorf("unexpected l2Tx out of block")
+		err = errors.New("unexpected L2 tx entry, found outside of block")
 	default:
 		err = fmt.Errorf("unexpected entry type: %d", file.EntryType)
 	}
@@ -453,8 +577,9 @@ func (c *StreamClient) NextFileEntry() (file *types.FileEntry, err error) {
 		return file, fmt.Errorf("failed to read packet type: %v", err)
 	}
 
+	packetType := packet[0]
 	// Check packet type
-	if packet[0] == PtResult {
+	if packetType == PtResult {
 		// Read server result entry for the command
 		r, err := c.readResultEntry(packet)
 		if err != nil {
@@ -464,14 +589,18 @@ func (c *StreamClient) NextFileEntry() (file *types.FileEntry, err error) {
 			return file, fmt.Errorf("got Result error code %d: %v", r.ErrorNum, err)
 		}
 		return file, nil
-	} else if packet[0] != PtData {
-		return file, fmt.Errorf("error expecting data packet type %d and received %d", PtData, packet[0])
+	} else if packetType != PtData && packetType != PtDataRsp {
+		return file, fmt.Errorf("expected data packet type %d or %d and received %d", PtData, PtDataRsp, packetType)
 	}
 
 	// Read the rest of fixed size fields
 	buffer, err := readBuffer(c.conn, types.FileEntryMinSize-1)
 	if err != nil {
 		return file, fmt.Errorf("error reading file bytes: %v", err)
+	}
+
+	if packetType != PtData {
+		packet[0] = PtData
 	}
 	buffer = append(packet, buffer...)
 
@@ -491,6 +620,10 @@ func (c *StreamClient) NextFileEntry() (file *types.FileEntry, err error) {
 	// Decode binary data to data entry struct
 	if file, err = types.DecodeFileEntry(buffer); err != nil {
 		return file, fmt.Errorf("decode file entry error: %v", err)
+	}
+
+	if file.EntryType == types.EntryTypeNotFound {
+		return file, ErrFileEntryNotFound
 	}
 
 	return
@@ -557,4 +690,21 @@ func (c *StreamClient) readResultEntry(packet []byte) (re *types.ResultEntry, er
 	}
 
 	return re, nil
+}
+
+// readPacketAndDecodeResultEntry reads the packet from the connection and tries to decode the ResultEntry from it.
+func (c *StreamClient) readPacketAndDecodeResultEntry() (*types.ResultEntry, error) {
+	// Read packet
+	packet, err := readBuffer(c.conn, 1)
+	if err != nil {
+		return nil, fmt.Errorf("read buffer error: %w", err)
+	}
+
+	// Read server result entry for the command
+	r, err := c.readResultEntry(packet)
+	if err != nil {
+		return nil, fmt.Errorf("read result entry error: %w", err)
+	}
+
+	return r, nil
 }

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -166,21 +166,21 @@ func (c *StreamClient) GetLatestL2Block() (l2Block *types.FullL2Block, err error
 	}
 
 	latestEntryNum := h.TotalEntries - 1
-	var ok bool
 
 	for l2Block == nil && latestEntryNum > 0 {
 		if err := c.sendEntryCmdWrapper(latestEntryNum); err != nil {
 			return nil, err
 		}
 
-		parsedEntry, err := ReadParsedProto(c)
+		entry, err := c.NextFileEntry()
 		if err != nil {
 			return nil, err
 		}
 
-		l2Block, ok = parsedEntry.(*types.FullL2Block)
-		if ok {
-			return l2Block, nil
+		if entry.EntryType == types.EntryTypeL2Block {
+			if l2Block, err = types.UnmarshalL2Block(entry.Data); err != nil {
+				return nil, err
+			}
 		}
 
 		latestEntryNum--

--- a/zk/datastream/client/stream_client_test.go
+++ b/zk/datastream/client/stream_client_test.go
@@ -1,17 +1,28 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/gateway-fm/cdk-erigon-lib/common"
+	"github.com/ledgerwatch/erigon/zk/datastream/proto/github.com/0xPolygonHermez/zkevm-node/state/datastream"
 	"github.com/ledgerwatch/erigon/zk/datastream/types"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 )
 
-func Test_readHeaderEntry(t *testing.T) {
+const (
+	streamTypeFieldName = "stream type"
+)
+
+func TestStreamClientReadHeaderEntry(t *testing.T) {
 	type testCase struct {
 		name           string
 		input          []byte
@@ -35,7 +46,7 @@ func Test_readHeaderEntry(t *testing.T) {
 			name:           "Invalid byte array length",
 			input:          []byte{20, 21, 22, 23, 24, 20},
 			expectedResult: nil,
-			expectedError:  fmt.Errorf("failed to read header bytes reading from server: unexpected EOF"),
+			expectedError:  errors.New("failed to read header bytes reading from server: unexpected EOF"),
 		},
 	}
 
@@ -59,7 +70,7 @@ func Test_readHeaderEntry(t *testing.T) {
 	}
 }
 
-func Test_readResultEntry(t *testing.T) {
+func TestStreamClientReadResultEntry(t *testing.T) {
 	type testCase struct {
 		name           string
 		input          []byte
@@ -93,13 +104,13 @@ func Test_readResultEntry(t *testing.T) {
 			name:           "Invalid byte array length",
 			input:          []byte{20, 21, 22, 23, 24, 20},
 			expectedResult: nil,
-			expectedError:  fmt.Errorf("failed to read main result bytes reading from server: unexpected EOF"),
+			expectedError:  errors.New("failed to read main result bytes reading from server: unexpected EOF"),
 		},
 		{
 			name:           "Invalid error length",
 			input:          []byte{0, 0, 0, 12, 0, 0, 0, 0, 20, 21},
 			expectedResult: nil,
-			expectedError:  fmt.Errorf("failed to read result errStr bytes reading from server: unexpected EOF"),
+			expectedError:  errors.New("failed to read result errStr bytes reading from server: unexpected EOF"),
 		},
 	}
 
@@ -123,7 +134,7 @@ func Test_readResultEntry(t *testing.T) {
 	}
 }
 
-func Test_readFileEntry(t *testing.T) {
+func TestStreamClientReadFileEntry(t *testing.T) {
 	type testCase struct {
 		name           string
 		input          []byte
@@ -158,18 +169,18 @@ func Test_readFileEntry(t *testing.T) {
 			name:           "Invalid packet type",
 			input:          []byte{5, 0, 0, 0, 17, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 45},
 			expectedResult: nil,
-			expectedError:  fmt.Errorf("error expecting data packet type 2 and received 5"),
+			expectedError:  errors.New("expected data packet type 2 or 254 and received 5"),
 		},
 		{
 			name:           "Invalid byte array length",
 			input:          []byte{2, 21, 22, 23, 24, 20},
 			expectedResult: nil,
-			expectedError:  fmt.Errorf("error reading file bytes: reading from server: unexpected EOF"),
+			expectedError:  errors.New("error reading file bytes: reading from server: unexpected EOF"),
 		}, {
 			name:           "Invalid data length",
 			input:          []byte{2, 0, 0, 0, 31, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 45, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 64},
 			expectedResult: nil,
-			expectedError:  fmt.Errorf("error reading file data bytes: reading from server: unexpected EOF"),
+			expectedError:  errors.New("error reading file data bytes: reading from server: unexpected EOF"),
 		},
 	}
 	for _, testCase := range testCases {
@@ -190,4 +201,372 @@ func Test_readFileEntry(t *testing.T) {
 			assert.DeepEqual(t, testCase.expectedResult, result)
 		})
 	}
+}
+
+func TestStreamClientReadParsedProto(t *testing.T) {
+	c := NewClient(context.Background(), "", 0, 0, 0)
+	serverConn, clientConn := net.Pipe()
+	c.conn = clientConn
+	defer func() {
+		serverConn.Close()
+		clientConn.Close()
+	}()
+
+	l2Block, l2Txs := createL2BlockAndTransactions(t, 3, 1)
+	l2BlockProto := &types.L2BlockProto{L2Block: l2Block}
+	l2BlockRaw, err := l2BlockProto.Marshal()
+	require.NoError(t, err)
+
+	l2Tx := l2Txs[0]
+	l2TxProto := &types.TxProto{Transaction: l2Tx}
+	l2TxRaw, err := l2TxProto.Marshal()
+	require.NoError(t, err)
+
+	l2BlockEnd := &types.L2BlockEndProto{Number: l2Block.GetNumber()}
+	l2BlockEndRaw, err := l2BlockEnd.Marshal()
+	require.NoError(t, err)
+
+	var (
+		errCh = make(chan error)
+		wg    sync.WaitGroup
+	)
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		fileEntries := []*types.FileEntry{
+			createFileEntry(t, types.EntryTypeL2Block, 1, l2BlockRaw),
+			createFileEntry(t, types.EntryTypeL2Tx, 2, l2TxRaw),
+			createFileEntry(t, types.EntryTypeL2BlockEnd, 3, l2BlockEndRaw),
+		}
+		for _, fe := range fileEntries {
+			_, writeErr := serverConn.Write(fe.Encode())
+			if writeErr != nil {
+				errCh <- writeErr
+				break
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(errCh)
+	}()
+
+	parsedEntry, err := c.readParsedProto()
+	require.NoError(t, err)
+	serverErr := <-errCh
+	require.NoError(t, serverErr)
+	expectedL2Tx := types.ConvertToL2TransactionProto(l2Tx)
+	expectedL2Block := types.ConvertToFullL2Block(l2Block)
+	expectedL2Block.L2Txs = append(expectedL2Block.L2Txs, *expectedL2Tx)
+	require.Equal(t, expectedL2Block, parsedEntry)
+}
+
+func TestStreamClientGetLatestL2Block(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer func() {
+		serverConn.Close()
+		clientConn.Close()
+	}()
+
+	c := NewClient(context.Background(), "", 0, 0, 0)
+	c.conn = clientConn
+
+	expectedL2Block, _ := createL2BlockAndTransactions(t, 5, 0)
+	l2BlockProto := &types.L2BlockProto{L2Block: expectedL2Block}
+	l2BlockRaw, err := l2BlockProto.Marshal()
+	require.NoError(t, err)
+
+	var (
+		errCh = make(chan error)
+		wg    sync.WaitGroup
+	)
+	wg.Add(1)
+
+	// Prepare the server to send responses in a separate goroutine
+	go func() {
+		defer wg.Done()
+
+		// Read the Command
+		if err := readAndValidateUint(t, serverConn, uint64(CmdHeader), "command"); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Read the StreamType
+		if err := readAndValidateUint(t, serverConn, uint64(StSequencer), streamTypeFieldName); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Write ResultEntry
+		re := createResultEntry(t)
+		_, err = serverConn.Write(re.Encode())
+		if err != nil {
+			errCh <- fmt.Errorf("failed to write result entry to the connection: %w", err)
+		}
+
+		// Write HeaderEntry
+		he := &types.HeaderEntry{
+			PacketType:   uint8(CmdHeader),
+			HeadLength:   types.HeaderSize,
+			Version:      2,
+			SystemId:     1,
+			StreamType:   types.StreamType(StSequencer),
+			TotalEntries: 4,
+		}
+		_, err = serverConn.Write(he.Encode())
+		if err != nil {
+			errCh <- fmt.Errorf("failed to write header entry to the connection: %w", err)
+		}
+
+		// Read the Command
+		if err := readAndValidateUint(t, serverConn, uint64(CmdEntry), "command"); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Read the StreamType
+		if err := readAndValidateUint(t, serverConn, uint64(StSequencer), streamTypeFieldName); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Read the EntryNumber
+		if err := readAndValidateUint(t, serverConn, he.TotalEntries-1, "entry number"); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Write the ResultEntry
+		_, err = serverConn.Write(re.Encode())
+		if err != nil {
+			errCh <- fmt.Errorf("failed to write result entry to the connection: %w", err)
+			return
+		}
+
+		// Write the FileEntry containing the L2 block information
+		fe := createFileEntry(t, types.EntryTypeL2Block, 1, l2BlockRaw)
+		_, err = serverConn.Write(fe.Encode())
+		if err != nil {
+			errCh <- fmt.Errorf("failed to write the l2 block file entry to the connection: %w", err)
+			return
+		}
+
+		serverConn.Close()
+	}()
+
+	go func() {
+		wg.Wait()
+		close(errCh)
+	}()
+
+	// ACT
+	l2Block, err := c.GetLatestL2Block()
+	require.NoError(t, err)
+
+	// ASSERT
+	serverErr := <-errCh
+	require.NoError(t, serverErr)
+
+	expectedFullL2Block := types.ConvertToFullL2Block(expectedL2Block)
+	require.Equal(t, expectedFullL2Block, l2Block)
+}
+
+func TestStreamClientGetL2BlockByNumber(t *testing.T) {
+	const blockNum = uint64(5)
+
+	serverConn, clientConn := net.Pipe()
+	defer func() {
+		serverConn.Close()
+		clientConn.Close()
+	}()
+
+	c := NewClient(context.Background(), "", 0, 0, 0)
+	c.conn = clientConn
+
+	bookmark := types.NewBookmarkProto(blockNum, datastream.BookmarkType_BOOKMARK_TYPE_L2_BLOCK)
+	bookmarkRaw, err := bookmark.Marshal()
+	require.NoError(t, err)
+
+	expectedL2Block, l2Txs := createL2BlockAndTransactions(t, blockNum, 3)
+	l2BlockProto := &types.L2BlockProto{L2Block: expectedL2Block}
+	l2BlockRaw, err := l2BlockProto.Marshal()
+	require.NoError(t, err)
+
+	l2TxsRaw := make([][]byte, len(l2Txs))
+	for i, l2Tx := range l2Txs {
+		l2TxProto := &types.TxProto{Transaction: l2Tx}
+		l2TxRaw, err := l2TxProto.Marshal()
+		require.NoError(t, err)
+		l2TxsRaw[i] = l2TxRaw
+	}
+
+	l2BlockEnd := &types.L2BlockEndProto{Number: expectedL2Block.GetNumber()}
+	l2BlockEndRaw, err := l2BlockEnd.Marshal()
+	require.NoError(t, err)
+
+	errCh := make(chan error)
+
+	createServerResponses := func(t *testing.T, serverConn net.Conn, bookmarkRaw, l2BlockRaw []byte, l2TxsRaw [][]byte, l2BlockEndRaw []byte, errCh chan error) {
+		defer func() {
+			close(errCh)
+			serverConn.Close()
+		}()
+
+		// Read the command
+		if err := readAndValidateUint(t, serverConn, uint64(CmdStartBookmark), "command"); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Read the stream type
+		if err := readAndValidateUint(t, serverConn, uint64(StSequencer), streamTypeFieldName); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Read the bookmark length
+		if err := readAndValidateUint(t, serverConn, uint32(len(bookmarkRaw)), "bookmark length"); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Read the actual bookmark
+		actualBookmarkRaw, err := readBuffer(serverConn, uint32(len(bookmarkRaw)))
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if !bytes.Equal(bookmarkRaw, actualBookmarkRaw) {
+			errCh <- fmt.Errorf("mismatch between expected %v and actual bookmark %v", bookmarkRaw, actualBookmarkRaw)
+			return
+		}
+
+		// Write ResultEntry
+		re := createResultEntry(t)
+		if _, err := serverConn.Write(re.Encode()); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Write File entries (EntryTypeL2Block, EntryTypeL2Tx and EntryTypeL2BlockEnd)
+		fileEntries := make([]*types.FileEntry, 0, len(l2TxsRaw)+2)
+		fileEntries = append(fileEntries, createFileEntry(t, types.EntryTypeL2Block, 1, l2BlockRaw))
+		entryNum := uint64(2)
+		for _, l2TxRaw := range l2TxsRaw {
+			fileEntries = append(fileEntries, createFileEntry(t, types.EntryTypeL2Tx, entryNum, l2TxRaw))
+			entryNum++
+		}
+		fileEntries = append(fileEntries, createFileEntry(t, types.EntryTypeL2BlockEnd, entryNum, l2BlockEndRaw))
+
+		for _, fe := range fileEntries {
+			if _, err := serverConn.Write(fe.Encode()); err != nil {
+				errCh <- err
+				return
+			}
+		}
+
+	}
+
+	go createServerResponses(t, serverConn, bookmarkRaw, l2BlockRaw, l2TxsRaw, l2BlockEndRaw, errCh)
+
+	l2Block, errCode, err := c.GetL2BlockByNumber(blockNum)
+	require.NoError(t, err)
+	require.Equal(t, types.CmdErrOK, errCode)
+
+	serverErr := <-errCh
+	require.NoError(t, serverErr)
+
+	l2TxsProto := make([]types.L2TransactionProto, len(l2Txs))
+	for i, tx := range l2Txs {
+		l2TxProto := types.ConvertToL2TransactionProto(tx)
+		l2TxsProto[i] = *l2TxProto
+	}
+	expectedFullL2Block := types.ConvertToFullL2Block(expectedL2Block)
+	expectedFullL2Block.L2Txs = l2TxsProto
+	require.Equal(t, expectedFullL2Block, l2Block)
+}
+
+// readAndValidateUint reads the uint value and validates it against expected value from the connection in order to unblock future write operations
+func readAndValidateUint(t *testing.T, conn net.Conn, expected interface{}, paramName string) error {
+	t.Helper()
+
+	var length uint32
+	switch expected.(type) {
+	case uint64:
+		length = 8
+	case uint32:
+		length = 4
+	default:
+		return fmt.Errorf("unsupported expected type for %s: %T", paramName, expected)
+	}
+
+	valueRaw, err := readBuffer(conn, length)
+	if err != nil {
+		return fmt.Errorf("failed to read %s parameter: %w", paramName, err)
+	}
+
+	switch expectedValue := expected.(type) {
+	case uint64:
+		value := binary.BigEndian.Uint64(valueRaw)
+		if value != expectedValue {
+			return fmt.Errorf("%s parameter value mismatch between expected %d and actual %d", paramName, expectedValue, value)
+		}
+	case uint32:
+		value := binary.BigEndian.Uint32(valueRaw)
+		if value != expectedValue {
+			return fmt.Errorf("%s parameter value mismatch between expected %d and actual %d", paramName, expectedValue, value)
+		}
+	}
+
+	return nil
+}
+
+// createFileEntry is a helper function that creates FileEntry
+func createFileEntry(t *testing.T, entryType types.EntryType, num uint64, data []byte) *types.FileEntry {
+	t.Helper()
+	return &types.FileEntry{
+		PacketType: PtData,
+		Length:     types.FileEntryMinSize + uint32(len(data)),
+		EntryType:  entryType,
+		EntryNum:   num,
+		Data:       data,
+	}
+}
+
+func createResultEntry(t *testing.T) *types.ResultEntry {
+	t.Helper()
+	return &types.ResultEntry{
+		PacketType: PtResult,
+		ErrorNum:   types.CmdErrOK,
+		Length:     types.ResultEntryMinSize,
+		ErrorStr:   nil,
+	}
+}
+
+// createL2BlockAndTransactions creates a single L2 block with the transactions
+func createL2BlockAndTransactions(t *testing.T, blockNum uint64, txnCount int) (*datastream.L2Block, []*datastream.Transaction) {
+	t.Helper()
+	txns := make([]*datastream.Transaction, 0, txnCount)
+	l2Block := &datastream.L2Block{
+		Number:        blockNum,
+		BatchNumber:   1,
+		Timestamp:     uint64(time.Now().UnixMilli()),
+		Hash:          common.HexToHash("0x123456987654321").Bytes(),
+		BlockGasLimit: 1000000000,
+	}
+
+	for i := 0; i < txnCount; i++ {
+		txns = append(txns,
+			&datastream.Transaction{
+				L2BlockNumber: l2Block.GetNumber(),
+				Index:         uint64(i),
+				IsValid:       true,
+				Debug:         &datastream.Debug{Message: fmt.Sprintf("Hello %d. transaction!", i+1)},
+			})
+	}
+
+	return l2Block, txns
 }

--- a/zk/datastream/client/stream_client_test.go
+++ b/zk/datastream/client/stream_client_test.go
@@ -253,7 +253,7 @@ func TestStreamClientReadParsedProto(t *testing.T) {
 		close(errCh)
 	}()
 
-	parsedEntry, err := c.readParsedProto()
+	parsedEntry, err := ReadParsedProto(c)
 	require.NoError(t, err)
 	serverErr := <-errCh
 	require.NoError(t, serverErr)

--- a/zk/datastream/types/entry_type.go
+++ b/zk/datastream/types/entry_type.go
@@ -1,5 +1,7 @@
 package types
 
+import "math"
+
 type EntryType uint32
 
 var (
@@ -11,4 +13,5 @@ var (
 	EntryTypeGerUpdate   EntryType = 5
 	EntryTypeL2BlockEnd  EntryType = 6
 	BookmarkEntryType    EntryType = 176
+	EntryTypeNotFound    EntryType = math.MaxUint32
 )

--- a/zk/datastream/types/file.go
+++ b/zk/datastream/types/file.go
@@ -34,7 +34,7 @@ func (f *FileEntry) IsBookmarkBlock() bool {
 }
 
 func (f *FileEntry) IsL2BlockEnd() bool {
-	return uint32(f.EntryType) == uint32(6) //TODO: fix once it is added in the lib
+	return uint32(f.EntryType) == uint32(datastream.EntryType_ENTRY_TYPE_L2_BLOCK_END)
 }
 func (f *FileEntry) IsL2Block() bool {
 	return uint32(f.EntryType) == uint32(datastream.EntryType_ENTRY_TYPE_L2_BLOCK)
@@ -60,6 +60,17 @@ func (f *FileEntry) IsUpdateGer() bool {
 
 func (f *FileEntry) IsGerUpdate() bool {
 	return f.EntryType == EntryTypeGerUpdate
+}
+
+// Encode encodes file entry to the binary format
+func (f *FileEntry) Encode() []byte {
+	be := make([]byte, 1)
+	be[0] = f.PacketType
+	be = binary.BigEndian.AppendUint32(be, f.Length)
+	be = binary.BigEndian.AppendUint32(be, uint32(f.EntryType))
+	be = binary.BigEndian.AppendUint64(be, f.EntryNum)
+	be = append(be, f.Data...) //nolint:makezero
+	return be
 }
 
 // Decode/convert from binary bytes slice to FileEntry type

--- a/zk/datastream/types/header.go
+++ b/zk/datastream/types/header.go
@@ -5,19 +5,34 @@ import (
 	"fmt"
 )
 
-const HeaderSize = 38
-const HeaderSizePreEtrog = 29
+const (
+	HeaderSize         = 38
+	HeaderSizePreEtrog = 29
+)
 
 type StreamType uint64
 
 type HeaderEntry struct {
 	PacketType   uint8  // 1:Header
-	HeadLength   uint32 // 38 oe 29
+	HeadLength   uint32 // 38 or 29
 	Version      uint8
 	SystemId     uint64
 	StreamType   StreamType // 1:Sequencer
 	TotalLength  uint64     // Total bytes used in the file
 	TotalEntries uint64     // Total number of data entries (entry type 2)
+}
+
+// Encode encodes given HeaderEntry into a binary format
+func (e *HeaderEntry) Encode() []byte {
+	be := make([]byte, 1)
+	be[0] = e.PacketType
+	be = binary.BigEndian.AppendUint32(be, e.HeadLength)
+	be = append(be, e.Version) //nolint:makezero
+	be = binary.BigEndian.AppendUint64(be, e.SystemId)
+	be = binary.BigEndian.AppendUint64(be, uint64(e.StreamType))
+	be = binary.BigEndian.AppendUint64(be, e.TotalLength)
+	be = binary.BigEndian.AppendUint64(be, e.TotalEntries)
+	return be
 }
 
 // Decode/convert from binary bytes slice to a header entry type

--- a/zk/datastream/types/l2block_proto.go
+++ b/zk/datastream/types/l2block_proto.go
@@ -73,21 +73,24 @@ func UnmarshalL2Block(data []byte) (*FullL2Block, error) {
 		return nil, err
 	}
 
-	l2Block := &FullL2Block{
-		BatchNumber:     block.BatchNumber,
-		L2BlockNumber:   block.Number,
-		Timestamp:       int64(block.Timestamp),
-		DeltaTimestamp:  block.DeltaTimestamp,
-		L1InfoTreeIndex: block.L1InfotreeIndex,
-		GlobalExitRoot:  libcommon.BytesToHash(block.GlobalExitRoot),
-		Coinbase:        libcommon.BytesToAddress(block.Coinbase),
-		L1BlockHash:     libcommon.BytesToHash(block.L1Blockhash),
-		L2Blockhash:     libcommon.BytesToHash(block.Hash),
-		StateRoot:       libcommon.BytesToHash(block.StateRoot),
-		BlockGasLimit:   block.BlockGasLimit,
-		BlockInfoRoot:   libcommon.BytesToHash(block.BlockInfoRoot),
-		Debug:           ProcessDebug(block.Debug),
-	}
+	return ConvertToFullL2Block(&block), nil
+}
 
-	return l2Block, nil
+// ConvertToFullL2Block converts the datastream.L2Block to types.FullL2Block
+func ConvertToFullL2Block(block *datastream.L2Block) *FullL2Block {
+	return &FullL2Block{
+		BatchNumber:     block.GetBatchNumber(),
+		L2BlockNumber:   block.GetNumber(),
+		Timestamp:       int64(block.GetTimestamp()),
+		DeltaTimestamp:  block.GetDeltaTimestamp(),
+		L1InfoTreeIndex: block.GetL1InfotreeIndex(),
+		GlobalExitRoot:  libcommon.BytesToHash(block.GetGlobalExitRoot()),
+		Coinbase:        libcommon.BytesToAddress(block.GetCoinbase()),
+		L1BlockHash:     libcommon.BytesToHash(block.GetL1Blockhash()),
+		L2Blockhash:     libcommon.BytesToHash(block.GetHash()),
+		StateRoot:       libcommon.BytesToHash(block.GetStateRoot()),
+		BlockGasLimit:   block.GetBlockGasLimit(),
+		BlockInfoRoot:   libcommon.BytesToHash(block.GetBlockInfoRoot()),
+		Debug:           ProcessDebug(block.GetDebug()),
+	}
 }

--- a/zk/datastream/types/result_test.go
+++ b/zk/datastream/types/result_test.go
@@ -59,3 +59,17 @@ func TestResultDecode(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodeDecodeResult(t *testing.T) {
+	expectedResult := &ResultEntry{
+		PacketType: 1,
+		Length:     19,
+		ErrorNum:   5,
+		ErrorStr:   []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+	}
+
+	resultRaw := expectedResult.Encode()
+	actualResult, err := DecodeResultEntry(resultRaw)
+	require.NoError(t, err)
+	require.Equal(t, expectedResult, actualResult)
+}

--- a/zk/datastream/types/tx_proto.go
+++ b/zk/datastream/types/tx_proto.go
@@ -1,9 +1,9 @@
 package types
 
 import (
+	libcommon "github.com/gateway-fm/cdk-erigon-lib/common"
 	"github.com/ledgerwatch/erigon/zk/datastream/proto/github.com/0xPolygonHermez/zkevm-node/state/datastream"
 	"google.golang.org/protobuf/proto"
-	libcommon "github.com/gateway-fm/cdk-erigon-lib/common"
 )
 
 type TxProto struct {
@@ -35,15 +35,18 @@ func UnmarshalTx(data []byte) (*L2TransactionProto, error) {
 		return nil, err
 	}
 
-	l2Tx := &L2TransactionProto{
-		L2BlockNumber:               tx.L2BlockNumber,
-		Index:                       tx.Index,
-		IsValid:                     tx.IsValid,
-		Encoded:                     tx.Encoded,
-		EffectiveGasPricePercentage: uint8(tx.EffectiveGasPricePercentage),
-		IntermediateStateRoot:       libcommon.BytesToHash(tx.ImStateRoot),
-		Debug:                       ProcessDebug(tx.Debug),
-	}
+	return ConvertToL2TransactionProto(&tx), nil
+}
 
-	return l2Tx, nil
+// ConvertToL2TransactionProto converts transaction object from datastream.Transaction to types.L2TransactionProto
+func ConvertToL2TransactionProto(tx *datastream.Transaction) *L2TransactionProto {
+	return &L2TransactionProto{
+		L2BlockNumber:               tx.GetL2BlockNumber(),
+		Index:                       tx.GetIndex(),
+		IsValid:                     tx.GetIsValid(),
+		Encoded:                     tx.GetEncoded(),
+		EffectiveGasPricePercentage: uint8(tx.GetEffectiveGasPricePercentage()),
+		IntermediateStateRoot:       libcommon.BytesToHash(tx.GetImStateRoot()),
+		Debug:                       ProcessDebug(tx.GetDebug()),
+	}
 }

--- a/zk/erigon_db/db.go
+++ b/zk/erigon_db/db.go
@@ -13,6 +13,12 @@ import (
 
 var sha3UncleHash = common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
 
+type ReadOnlyErigonDb interface {
+	GetBodyTransactions(fromBlockNo, toBlockNo uint64) (*[]ethTypes.Transaction, error)
+	ReadCanonicalHash(blockNo uint64) (common.Hash, error)
+	GetHeader(blockNo uint64) (*ethTypes.Header, error)
+}
+
 type ErigonDb struct {
 	tx kv.RwTx
 }

--- a/zk/l1infotree/tree.go
+++ b/zk/l1infotree/tree.go
@@ -36,8 +36,8 @@ func NewL1InfoTree(height uint8, initialLeaves [][32]byte) (*L1InfoTree, error) 
 		mt.allLeaves[leaf] = struct{}{}
 	}
 
-	log.Debug("Initial count: ", mt.count)
-	log.Debug("Initial root: ", mt.currentRoot)
+	log.Debug(fmt.Sprintf("Initial count: %d", mt.count))
+	log.Debug(fmt.Sprintf("Initial root: %s", mt.currentRoot))
 	return mt, nil
 }
 

--- a/zk/stages/stage_batches_test.go
+++ b/zk/stages/stage_batches_test.go
@@ -3,15 +3,18 @@ package stages
 import (
 	"context"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/gateway-fm/cdk-erigon-lib/common"
 	"github.com/gateway-fm/cdk-erigon-lib/kv"
 	"github.com/gateway-fm/cdk-erigon-lib/kv/memdb"
+	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/smt/pkg/db"
 	"github.com/ledgerwatch/erigon/zk/datastream/types"
+	"github.com/ledgerwatch/erigon/zk/erigon_db"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
@@ -19,36 +22,9 @@ import (
 )
 
 func TestUnwindBatches(t *testing.T) {
-	fullL2Blocks := []types.FullL2Block{}
-	post155 := "0xf86780843b9aca00826163941275fbb540c8efc58b812ba83b0d0b8b9917ae98808464fbb77c1ba0b7d2a666860f3c6b8f5ef96f86c7ec5562e97fd04c2e10f3755ff3a0456f9feba0246df95217bf9082f84f9e40adb0049c6664a5bb4c9cbe34ab1a73e77bab26ed"
-	post155Bytes, err := hex.DecodeString(post155[2:])
 	currentBlockNumber := 10
+	fullL2Blocks := createTestL2Blocks(t, currentBlockNumber)
 
-	require.NoError(t, err)
-	for i := 1; i <= currentBlockNumber; i++ {
-		fullL2Blocks = append(fullL2Blocks, types.FullL2Block{
-			BatchNumber:     1 + uint64(i/2),
-			L2BlockNumber:   uint64(i),
-			Timestamp:       int64(i) * 10000,
-			DeltaTimestamp:  uint32(i) * 10,
-			L1InfoTreeIndex: uint32(i) + 20,
-			GlobalExitRoot:  common.Hash{byte(i)},
-			Coinbase:        common.Address{byte(i)},
-			ForkId:          1 + uint64(i)/3,
-			L1BlockHash:     common.Hash{byte(i)},
-			L2Blockhash:     common.Hash{byte(i)},
-			StateRoot:       common.Hash{byte(i)},
-			L2Txs: []types.L2TransactionProto{
-				{
-					EffectiveGasPricePercentage: 255,
-					IsValid:                     true,
-					IntermediateStateRoot:       common.Hash{byte(i + 1)},
-					Encoded:                     post155Bytes,
-				},
-			},
-			ParentHash: common.Hash{byte(i - 1)},
-		})
-	}
 	gerUpdates := []types.GerUpdate{}
 	for i := currentBlockNumber + 1; i <= currentBlockNumber+5; i++ {
 		gerUpdates = append(gerUpdates, types.GerUpdate{
@@ -64,14 +40,18 @@ func TestUnwindBatches(t *testing.T) {
 
 	ctx, db1 := context.Background(), memdb.NewTestDB(t)
 	tx := memdb.BeginRw(t, db1)
-	err = hermez_db.CreateHermezBuckets(tx)
+	err := hermez_db.CreateHermezBuckets(tx)
 	require.NoError(t, err)
 
 	err = db.CreateEriDbBuckets(tx)
 	require.NoError(t, err)
 
 	dsClient := NewTestDatastreamClient(fullL2Blocks, gerUpdates)
-	cfg := StageBatchesCfg(db1, dsClient, &ethconfig.Zk{})
+
+	tmpDSClientCreator := func(_ context.Context, _ *ethconfig.Zk, _ uint64) (DatastreamClient, error) {
+		return NewTestDatastreamClient(fullL2Blocks, gerUpdates), nil
+	}
+	cfg := StageBatchesCfg(db1, dsClient, &ethconfig.Zk{}, WithDSClientCreator(tmpDSClientCreator))
 
 	s := &stagedsync.StageState{ID: stages.Batches, BlockNumber: 0}
 	u := &stagedsync.Sync{}
@@ -128,6 +108,134 @@ func TestUnwindBatches(t *testing.T) {
 		}
 		size, err := tx3.BucketSize(bucket)
 		require.NoError(t, err)
-		require.Equal(t, bucketSized[bucket], size, "butcket %s is not empty", bucket)
+		require.Equal(t, bucketSized[bucket], size, "bucket %s is not empty", bucket)
 	}
+}
+
+func TestFindCommonAncestor(t *testing.T) {
+	blocksCount := 40
+	l2Blocks := createTestL2Blocks(t, blocksCount)
+
+	testCases := []struct {
+		name                  string
+		dbBlocksCount         int
+		dsBlocksCount         int
+		latestBlockNum        uint64
+		divergentBlockHistory bool
+		expectedBlockNum      uint64
+		expectedHash          common.Hash
+		expectedError         error
+	}{
+		{
+			name:             "Successful search (db lagging behind the data stream)",
+			dbBlocksCount:    5,
+			dsBlocksCount:    10,
+			latestBlockNum:   5,
+			expectedBlockNum: 5,
+			expectedHash:     common.Hash{byte(5)},
+			expectedError:    nil,
+		},
+		{
+			name:             "Successful search (db leading the data stream)",
+			dbBlocksCount:    20,
+			dsBlocksCount:    10,
+			latestBlockNum:   10,
+			expectedBlockNum: 10,
+			expectedHash:     common.Hash{byte(10)},
+			expectedError:    nil,
+		},
+		{
+			name:           "Failed to find common ancestor block (latest block number is 0)",
+			dbBlocksCount:  10,
+			dsBlocksCount:  10,
+			latestBlockNum: 0,
+			expectedError:  ErrFailedToFindCommonAncestor,
+		},
+		{
+			name:                  "Failed to find common ancestor block (different blocks in the data stream and db)",
+			dbBlocksCount:         10,
+			dsBlocksCount:         10,
+			divergentBlockHistory: true,
+			latestBlockNum:        20,
+			expectedError:         ErrFailedToFindCommonAncestor,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ARRANGE
+			testDb, tx := memdb.NewTestTx(t)
+			defer testDb.Close()
+			defer tx.Rollback()
+			err := hermez_db.CreateHermezBuckets(tx)
+			require.NoError(t, err)
+
+			err = db.CreateEriDbBuckets(tx)
+			require.NoError(t, err)
+
+			hermezDb := hermez_db.NewHermezDb(tx)
+			erigonDb := erigon_db.NewErigonDb(tx)
+
+			dsBlocks := l2Blocks[:tc.dsBlocksCount]
+			dbBlocks := l2Blocks[:tc.dbBlocksCount]
+			if tc.divergentBlockHistory {
+				dbBlocks = l2Blocks[tc.dsBlocksCount : tc.dbBlocksCount+tc.dsBlocksCount]
+			}
+
+			dsClient := NewTestDatastreamClient(dsBlocks, nil)
+			for _, l2Block := range dbBlocks {
+				require.NoError(t, hermezDb.WriteBlockBatch(l2Block.L2BlockNumber, l2Block.BatchNumber))
+				require.NoError(t, rawdb.WriteCanonicalHash(tx, l2Block.L2Blockhash, l2Block.L2BlockNumber))
+			}
+
+			// ACT
+			ancestorNum, ancestorHash, err := findCommonAncestor(erigonDb, hermezDb, dsClient, tc.latestBlockNum)
+
+			// ASSERT
+			if tc.expectedError != nil {
+				require.Error(t, err)
+				require.Equal(t, tc.expectedError.Error(), err.Error())
+				require.Equal(t, uint64(0), ancestorNum)
+				require.Equal(t, emptyHash, ancestorHash)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedBlockNum, ancestorNum)
+				require.Equal(t, tc.expectedHash, ancestorHash)
+			}
+		})
+	}
+}
+
+func createTestL2Blocks(t *testing.T, blocksCount int) []types.FullL2Block {
+	post155 := "0xf86780843b9aca00826163941275fbb540c8efc58b812ba83b0d0b8b9917ae98808464fbb77c1ba0b7d2a666860f3c6b8f5ef96f86c7ec5562e97fd04c2e10f3755ff3a0456f9feba0246df95217bf9082f84f9e40adb0049c6664a5bb4c9cbe34ab1a73e77bab26ed"
+	post155Bytes, err := hex.DecodeString(strings.TrimPrefix(post155, "0x"))
+	require.NoError(t, err)
+
+	l2Blocks := make([]types.FullL2Block, 0, blocksCount)
+	for i := 1; i <= blocksCount; i++ {
+		l2Blocks = append(l2Blocks, types.FullL2Block{
+			BatchNumber:     1 + uint64(i/2),
+			L2BlockNumber:   uint64(i),
+			Timestamp:       int64(i) * 10000,
+			DeltaTimestamp:  uint32(i) * 10,
+			L1InfoTreeIndex: uint32(i) + 20,
+			GlobalExitRoot:  common.Hash{byte(i)},
+			Coinbase:        common.Address{byte(i)},
+			ForkId:          1 + uint64(i)/3,
+			L1BlockHash:     common.Hash{byte(i)},
+			L2Blockhash:     common.Hash{byte(i)},
+			StateRoot:       common.Hash{byte(i)},
+			L2Txs: []types.L2TransactionProto{
+				{
+					EffectiveGasPricePercentage: 255,
+					IsValid:                     true,
+					IntermediateStateRoot:       common.Hash{byte(i + 1)},
+					Encoded:                     post155Bytes,
+				},
+			},
+			ParentHash: common.Hash{byte(i - 1)},
+		})
+	}
+
+	return l2Blocks
 }

--- a/zk/stages/stage_interhashes.go
+++ b/zk/stages/stage_interhashes.go
@@ -405,9 +405,6 @@ func zkIncrementIntermediateHashes(ctx context.Context, logPrefix string, s *sta
 			if len(ach) > 0 {
 				hexcc := "0x" + ach
 				codeChanges[addr] = hexcc
-				if err != nil {
-					return trie.EmptyRoot, err
-				}
 			}
 		}
 

--- a/zk/stages/test_utils.go
+++ b/zk/stages/test_utils.go
@@ -14,6 +14,7 @@ type TestDatastreamClient struct {
 	progress              atomic.Uint64
 	entriesChan           chan interface{}
 	errChan               chan error
+	isStarted             bool
 }
 
 func NewTestDatastreamClient(fullL2Blocks []types.FullL2Block, gerUpdates []types.GerUpdate) *TestDatastreamClient {
@@ -33,11 +34,12 @@ func (c *TestDatastreamClient) EnsureConnected() (bool, error) {
 
 func (c *TestDatastreamClient) ReadAllEntriesToChannel() error {
 	c.streamingAtomic.Store(true)
+	defer c.streamingAtomic.Swap(false)
 
-	for i, _ := range c.fullL2Blocks {
+	for i := range c.fullL2Blocks {
 		c.entriesChan <- &c.fullL2Blocks[i]
 	}
-	for i, _ := range c.gerUpdates {
+	for i := range c.gerUpdates {
 		c.entriesChan <- &c.gerUpdates[i]
 	}
 
@@ -52,16 +54,44 @@ func (c *TestDatastreamClient) GetErrChan() chan error {
 	return c.errChan
 }
 
+func (c *TestDatastreamClient) GetL2BlockByNumber(blockNum uint64) (*types.FullL2Block, int, error) {
+	for _, l2Block := range c.fullL2Blocks {
+		if l2Block.L2BlockNumber == blockNum {
+			return &l2Block, types.CmdErrOK, nil
+		}
+	}
+
+	return nil, -1, nil
+}
+
+func (c *TestDatastreamClient) GetLatestL2Block() (*types.FullL2Block, error) {
+	if len(c.fullL2Blocks) == 0 {
+		return nil, nil
+	}
+	return &c.fullL2Blocks[len(c.fullL2Blocks)-1], nil
+}
+
 func (c *TestDatastreamClient) GetLastWrittenTimeAtomic() *atomic.Int64 {
 	return &c.lastWrittenTimeAtomic
 }
+
 func (c *TestDatastreamClient) GetStreamingAtomic() *atomic.Bool {
 	return &c.streamingAtomic
 }
+
 func (c *TestDatastreamClient) GetProgressAtomic() *atomic.Uint64 {
 	return &c.progress
 }
 
 func (c *TestDatastreamClient) ReadBatches(start uint64, end uint64) ([][]*types.FullL2Block, error) {
 	return nil, nil
+}
+
+func (c *TestDatastreamClient) Start() error {
+	c.isStarted = true
+	return nil
+}
+
+func (c *TestDatastreamClient) Stop() {
+	c.isStarted = false
 }


### PR DESCRIPTION
Addresses #667 for the RPC nodes.

This PR checks for block hashes and batch numbers mismatch during batches stage and triggers rollback immediately if inconsistencies are detected. 

## Verification steps
This could be tested using a Kurtosis, with one RPC node + another sequencer outside of kurtosis. 

Here are roughly the steps:
1. start a kurtosis cdk stack as usual
`kurtosis run --enclave cdk-v1 --args-file params.yml .`
Then, we need to run two cdk-erigon nodes, one as a sequencer that creates a new fork, and another one as an RPC node who syncs initially from the sequencer within kurtosis, and then switched off to the new sequencer that runs on its own fork.
2. collect the config files from kurtosis to local, for running the local cdk-erigon nodes:
```bash
e9dd04e13924   cdk-erigon-node-chain-allocs
8bcc8f21261a   cdk-erigon-node-chain-config
0fe6dadd740d   cdk-erigon-node-chain-spec-artifact
64eaece75701   cdk-erigon-node-chain-spec-artifact-sequencer
4fdf83e16899   cdk-erigon-node-config-artifact
c0b4d9fd0114   cdk-erigon-node-config-artifact-sequencer
```
Here is a dumb script to do so:
```bash
#!/bin/bash

# Create directories
mkdir -p rpc sequencer

# Download files
kurtosis files download cdk-v1 cdk-erigon-node-chain-allocs
kurtosis files download cdk-v1 cdk-erigon-node-chain-config
kurtosis files download cdk-v1 cdk-erigon-node-chain-spec-artifact
kurtosis files download cdk-v1 cdk-erigon-node-config-artifact
kurtosis files download cdk-v1 cdk-erigon-node-config-artifact-sequencer

# Move files to RPC folder
cp cdk-erigon-node-chain-allocs/* rpc/
cp cdk-erigon-node-chain-config/* rpc/
cp cdk-erigon-node-chain-spec-artifact/* rpc/
cp cdk-erigon-node-config-artifact/* rpc/

# Move files to Sequencer folder
cp cdk-erigon-node-chain-allocs/* sequencer/
cp cdk-erigon-node-chain-config/* sequencer/
cp cdk-erigon-node-chain-spec-artifact/* sequencer/
cp cdk-erigon-node-config-artifact-sequencer/* sequencer/

rm -rf cdk-erigon-node-chain-allocs
rm -rf cdk-erigon-node-chain-config
rm -rf cdk-erigon-node-chain-spec-artifact
rm -rf cdk-erigon-node-config-artifact
rm -rf cdk-erigon-node-config-artifact-sequencer
echo "Files have been downloaded and organized into rpc and sequencer folders."
```
3. adapt the configuration in the config.yaml for rpc:
```
zkevm.l2-sequencer-rpc-url -> output of $(kurtosis port print cdk-v1 cdk-erigon-sequencer-001 rpc)
zkevm.l2-datastreamer-url -> output of $(kurtosis port print cdk-v1 cdk-erigon-sequencer-001 data-streamer)
zkevm.l1-rpc-url -> output of $(kurtosis port print cdk-v1 el-1-geth-lighthouse rpc)
```
and sequencer:
```
zkevm.l1-rpc-url -> output of $(kurtosis port print cdk-v1 el-1-geth-lighthouse rpc)
zkevm.l1-sync-start-block: 1 # this flag will enable L1 recovery mode
```
Notice that you might need to change the `datadir` and service ports and assign unique values to them (`pprof.port`, `http.port`, `torrent.port`, `metrics.port`), otherwise both sequencer and rpc running on your local machine will have the same port and they will collide.
4. With configs modified, we can start local sequencer and rpc node.
Initially, we want to start sequencer in recovery mode:
```
CDK_ERIGON_SEQUENCER=1 build/bin/cdk-erigon  --config="path/to/sequencer/config.yaml" --maxpeers 0
```
It will sync from L1 in kurtosis and stay synced with kurtosis.
5. Then start RPC:
```
build/bin/cdk-erigon  --config="path/to/rpc/config.yaml" --maxpeers 0
```
6. After both nodes are in synced, we will prepare the fork.
Stop the local sequencer, delete this param `zkevm.l1-sync-start-block` from the sequencer config, and restart the sequencer. Now, the sequencer should be mining on its own fork.
7. Wait for a minute to make sure RPC node have synced certain number of blocks that will be re-sequenced.
8. To test the changes, stop RPC node, and change the data stream endpoint from the sequencer running in kurtosis to the one running locally, most likely it will be `zkevm.l2-datastreamer-url: 127.0.0.1:6900` . Then restart RPC node.
9. At this point, if everything works as expected, your RPC node should detect the fork and start rolling back.