### PR TITLE
L1 Cache 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ In order to retrieve data from the L1, the L1 syncer must be configured to know 
 
 - `zkevm.l1-highest-block-type` which defaults to retrieving the 'finalized' block, however there are cases where you may wish to pass 'safe' or 'latest'.
 
+### L1 Cache
+The node can cache the L1 requests/responses to speed up the sync and enable quicker responses to RPC requests requiring for example OldAccInputHash from the L1. This is enabled by default,
+but can be controlled via the following flags:
+
+- `zkevm.l1-cache-enabled` - defaults to true, set to false to disable the cache
+- `zkevm.l1-cache-port` - the port the cache server will run on, defaults to 6969
+
+To transplant the cache between datadirs, the `l1cache` dir can be copied. To use an upstream cdk-erigon node's L1 cache, the zkevm.l1-cache-enabled can be set to false, and the node provided the endpoint of the cache,
+instead of a regular L1 URL. e.g. `zkevm.l1-rpc-url=http://myerigonnode:6969?endpoint=http%3A%2F%2Fsepolia-rpc.com&chainid=2440`. NB: this node must be syncing the same network for any benefit!
+
 ## Sequencer (WIP)
 
 Enable Sequencer: `CDK_ERIGON_SEQUENCER=1 ./build/bin/cdk-erigon <flags>`

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -390,6 +390,16 @@ var (
 		Usage: "Ethereum L1 RPC endpoint",
 		Value: "",
 	}
+	L1CacheEnabledFlag = cli.BoolFlag{
+		Name:  "zkevm.l1-cache-enabled",
+		Usage: "Enable the L1 cache",
+		Value: true,
+	}
+	L1CachePortFlag = cli.UintFlag{
+		Name:  "zkevm.l1-cache-port",
+		Usage: "The port used for the L1 cache",
+		Value: 6969,
+	}
 	AddressSequencerFlag = cli.StringFlag{
 		Name:  "zkevm.address-sequencer",
 		Usage: "Sequencer address",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -120,6 +120,9 @@ import (
 	txpool2 "github.com/ledgerwatch/erigon/zk/txpool"
 	"github.com/ledgerwatch/erigon/zk/witness"
 	"github.com/ledgerwatch/erigon/zkevm/etherman"
+	"github.com/ledgerwatch/erigon/zk/l1_cache"
+	"net/url"
+	"path"
 )
 
 // Config contains the configuration options of the ETH protocol.
@@ -196,6 +199,7 @@ type Ethereum struct {
 	dataStream      *datastreamer.StreamServer
 	l1Syncer        *syncer.L1Syncer
 	etherManClients []*etherman.Client
+	l1Cache         *l1_cache.L1Cache
 
 	preStartTasks *PreStartTasks
 }
@@ -749,6 +753,23 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		backend.chainConfig.SupportGasless = cfg.Gasless
 
 		l1Urls := strings.Split(cfg.L1RpcUrl, ",")
+
+		if cfg.Zk.L1CacheEnabled {
+			l1Cache, err := l1_cache.NewL1Cache(ctx, path.Join(stack.DataDir(), "l1cache"), cfg.Zk.L1CachePort)
+			if err != nil {
+				return nil, err
+			}
+			backend.l1Cache = l1Cache
+
+			var cacheL1Urls []string
+			for _, l1Url := range l1Urls {
+				encoded := url.QueryEscape(l1Url)
+				cacheL1Url := fmt.Sprintf("http://localhost:%d?endpoint=%s&chainid=%d", cfg.Zk.L1CachePort, encoded, cfg.L2ChainId)
+				cacheL1Urls = append(cacheL1Urls, cacheL1Url)
+			}
+			l1Urls = cacheL1Urls
+		}
+
 		backend.etherManClients = make([]*etherman.Client, len(l1Urls))
 		for i, url := range l1Urls {
 			backend.etherManClients[i] = newEtherMan(cfg, chainConfig.ChainName, url)

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -27,6 +27,8 @@ type Zk struct {
 	L1HighestBlockType                     string
 	L1MaticContractAddress                 common.Address
 	L1FirstBlock                           uint64
+	L1CacheEnabled                         bool
+	L1CachePort                            uint
 	RpcRateLimits                          int
 	DatastreamVersion                      int
 	SequencerBlockSealTime                 time.Duration

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -173,6 +173,8 @@ var DefaultFlags = []cli.Flag{
 	&utils.L1SyncStopBatch,
 	&utils.L1ChainIdFlag,
 	&utils.L1RpcUrlFlag,
+	&utils.L1CacheEnabledFlag,
+	&utils.L1CachePortFlag,
 	&utils.AddressSequencerFlag,
 	&utils.AddressAdminFlag,
 	&utils.AddressRollupFlag,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -110,6 +110,8 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		L1SyncStopBatch:                        ctx.Uint64(utils.L1SyncStopBatch.Name),
 		L1ChainId:                              ctx.Uint64(utils.L1ChainIdFlag.Name),
 		L1RpcUrl:                               ctx.String(utils.L1RpcUrlFlag.Name),
+		L1CacheEnabled:                         ctx.Bool(utils.L1CacheEnabledFlag.Name),
+		L1CachePort:                            ctx.Uint(utils.L1CachePortFlag.Name),
 		AddressSequencer:                       libcommon.HexToAddress(ctx.String(utils.AddressSequencerFlag.Name)),
 		AddressAdmin:                           libcommon.HexToAddress(ctx.String(utils.AddressAdminFlag.Name)),
 		AddressRollup:                          libcommon.HexToAddress(ctx.String(utils.AddressRollupFlag.Name)),

--- a/zk/l1_cache/l1_cache.go
+++ b/zk/l1_cache/l1_cache.go
@@ -1,0 +1,268 @@
+package l1_cache
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gateway-fm/cdk-erigon-lib/kv"
+	"github.com/gateway-fm/cdk-erigon-lib/kv/mdbx"
+	"github.com/ledgerwatch/log/v3"
+	"errors"
+)
+
+const (
+	bucketName   = "Cache"
+	expiryBucket = "Expiry"
+)
+
+// methods we don't cache
+var methodsToIgnore = map[string]struct{}{}
+
+// methods we configure expiry for
+var methodsToExpire = map[string]time.Duration{
+	"eth_getBlockByNumber": 1 * time.Minute,
+}
+
+// params that trigger expiration
+var paramsToExpire = map[string]struct{}{
+	"latest":    {},
+	"finalized": {},
+}
+
+type L1Cache struct {
+	server *http.Server
+	db     kv.RwDB
+}
+
+func NewL1Cache(ctx context.Context, dbPath string, port uint) (*L1Cache, error) {
+	db := mdbx.NewMDBX(log.New()).Path(dbPath).MustOpen()
+
+	tx, err := db.BeginRw(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	if err := tx.CreateBucket(bucketName); err != nil {
+		return nil, err
+	}
+	if err := tx.CreateBucket(expiryBucket); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	http.HandleFunc("/", handleRequest(db))
+	addr := fmt.Sprintf(":%d", port)
+	server := &http.Server{
+		Addr:           addr,
+		Handler:        nil,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	go func() {
+		log.Info("Starting L1 Cache Server on port:", "port", port)
+		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			log.Error("L1 Cache Server stopped", "error", err)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		log.Info("Shutting down L1 Cache Server...")
+		if err := server.Shutdown(context.Background()); err != nil {
+			log.Error("Failed to shutdown L1 Cache Server", "error", err)
+		}
+		db.Close()
+	}()
+
+	return &L1Cache{
+		server: server,
+		db:     db,
+	}, nil
+}
+
+func fetchFromCache(tx kv.RwTx, key string) ([]byte, bool) {
+	data, err := tx.GetOne(bucketName, []byte(key))
+	if err != nil || data == nil {
+		return nil, false
+	}
+
+	expiry, err := tx.GetOne(expiryBucket, []byte(key))
+	if err == nil && expiry != nil {
+		expiryTime, err := time.Parse(time.RFC3339, string(expiry))
+		if err == nil && time.Now().After(expiryTime) {
+			// Cache entry has expired
+			evictFromCache(tx, key)
+			return nil, false
+		}
+	}
+
+	// Check if the cached response contains an error
+	var jsonResponse map[string]interface{}
+	if err := json.Unmarshal(data, &jsonResponse); err == nil {
+		if _, hasError := jsonResponse["error"]; hasError {
+			// Cache entry is an error, evict it
+			evictFromCache(tx, key)
+			return nil, false
+		}
+	}
+
+	return data, true
+}
+
+func evictFromCache(tx kv.RwTx, key string) {
+	if err := tx.Delete(bucketName, []byte(key)); err != nil {
+		log.Warn("Failed to evict from cache", "error", err)
+	}
+	if err := tx.Delete(expiryBucket, []byte(key)); err != nil {
+		log.Warn("Failed to evict from cache", "error", err)
+	}
+}
+
+func saveToCache(tx kv.RwTx, key string, response []byte, duration time.Duration) error {
+	if err := tx.Put(bucketName, []byte(key), response); err != nil {
+		return err
+	}
+	// Only set expiry if duration is not zero (indicating that it should expire)
+	if duration > 0 {
+		expiryTime := time.Now().Add(duration).Format(time.RFC3339)
+		if err := tx.Put(expiryBucket, []byte(key), []byte(expiryTime)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generateCacheKey(chainID string, body []byte) (string, error) {
+	var request map[string]interface{}
+	err := json.Unmarshal(body, &request)
+	if err != nil {
+		return "", err
+	}
+	delete(request, "id")
+	modifiedBody, err := json.Marshal(request)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s_%s", chainID, modifiedBody), nil
+}
+
+func handleRequest(db kv.RwDB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		endpoint := r.URL.Query().Get("endpoint")
+		chainID := r.URL.Query().Get("chainid")
+		if endpoint == "" || chainID == "" {
+			http.Error(w, "Missing endpoint or chainid parameter", http.StatusBadRequest)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+			return
+		}
+		defer r.Body.Close()
+
+		var request map[string]interface{}
+		if err := json.Unmarshal(body, &request); err != nil {
+			http.Error(w, "Invalid JSON-RPC request", http.StatusBadRequest)
+			return
+		}
+
+		method, ok := request["method"].(string)
+		if !ok {
+			http.Error(w, "Invalid JSON-RPC method", http.StatusBadRequest)
+			return
+		}
+
+		cacheKey, err := generateCacheKey(chainID, body)
+		if err != nil {
+			http.Error(w, "Failed to generate cache key", http.StatusInternalServerError)
+			return
+		}
+
+		if _, ignore := methodsToIgnore[method]; !ignore {
+			tx, err := db.BeginRw(r.Context())
+			if err != nil {
+				http.Error(w, "Failed to begin transaction", http.StatusInternalServerError)
+				return
+			}
+			if cachedResponse, found := fetchFromCache(tx, cacheKey); found {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Cache-Status", "HIT")
+				w.Write(cachedResponse)
+				tx.Commit()
+				return
+			}
+			tx.Rollback()
+		}
+
+		resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+		if err != nil {
+			http.Error(w, "Failed to fetch from upstream", http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+
+		responseBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			http.Error(w, "Failed to read upstream response", http.StatusInternalServerError)
+			return
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			// Check if the response contains a JSON-RPC error
+			var jsonResponse map[string]interface{}
+			if err := json.Unmarshal(responseBody, &jsonResponse); err == nil {
+				if _, hasError := jsonResponse["error"]; hasError {
+					fmt.Println("Received error response from upstream, not caching")
+				} else {
+					if _, ignore := methodsToIgnore[method]; !ignore {
+						cacheDuration := time.Duration(0)
+						if duration, found := methodsToExpire[method]; found {
+							if method == "eth_getBlockByNumber" {
+								params, ok := request["params"].([]interface{})
+								if ok && len(params) > 0 {
+									param, ok := params[0].(string)
+									if ok {
+										if _, shouldExpire := paramsToExpire[param]; shouldExpire {
+											cacheDuration = duration
+										}
+									}
+								}
+							} else {
+								cacheDuration = duration
+							}
+						}
+						tx, err := db.BeginRw(r.Context())
+						if err != nil {
+							http.Error(w, "Failed to begin transaction", http.StatusInternalServerError)
+							return
+						}
+						defer tx.Rollback()
+						if err := saveToCache(tx, cacheKey, responseBody, cacheDuration); err != nil {
+							http.Error(w, "Failed to save to cache", http.StatusInternalServerError)
+							return
+						}
+						tx.Commit()
+					}
+				}
+			} else {
+				fmt.Println("Failed to parse upstream response, not caching")
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Cache-Status", "MISS")
+		w.Write(responseBody)
+	}
+}


### PR DESCRIPTION
- allows l1 calls to be cached in datadir in l1cache directory (can copy this and transplant between datadirs)
- exposes cache on :6969 by default, but can be overridden
- other nodes can use the exposed cache
- defaults to enabled via flag (documented in README)