### PR TITLE
Fix non-sequential forkid

### DIFF
--- a/chain/chain_config.go
+++ b/chain/chain_config.go
@@ -146,6 +146,10 @@ func (c *Config) SetForkIdBlock(forkIdNumber constants.ForkId, blockNum uint64) 
 		c.ForkID88ElderberryBlock = new(big.Int).SetUint64(blockNum)
 	case constants.ForkID9Elderberry2:
 		c.ForkID9Elderberry2Block = new(big.Int).SetUint64(blockNum)
+	case constants.ForkID10:
+		c.ForkID10 = new(big.Int).SetUint64(blockNum)
+	case constants.ForkID11:
+		c.ForkID11 = new(big.Int).SetUint64(blockNum)
 	case constants.ForkID12Banana:
 		c.ForkID12BananaBlock = new(big.Int).SetUint64(blockNum)
 	default:


### PR DESCRIPTION
Without this change, sequencer won't be able to process initial injected batch with forkid12 correctly with the log similar to below:

```
[cdk-erigon-sequencer-001] [INFO] [08-09|16:54:14.397] [5/13 Execution] Starting sequencing stage
[cdk-erigon-sequencer-001] [INFO] [08-09|16:54:14.397] Upgrading fork id                        from=0 to=12 batch=1
[cdk-erigon-sequencer-001] [EROR] [08-09|16:54:14.397] [5/13 Execution] Error setting fork id 12 to block 1
[cdk-erigon-sequencer-001] [INFO] [08-09|16:54:14.397] [5/13 Execution] Finished sequencing stage
[cdk-erigon-sequencer-001] [EROR] [08-09|16:54:14.397] Error while executing stage              err="[5/13 Execution] unknown fork id number 11"
[cdk-erigon-sequencer-001] [EROR] [08-09|16:54:14.397] Staged Sync                              err="[5/13 Execution] unknown fork id number 11"
[cdk-erigon-sequencer-001] [INFO] [08-09|16:54:14.898] [5/13 Execution] Starting sequencing stage
```