### PR TITLE
set the mcp reduction via a flag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -642,6 +642,11 @@ var (
 		Usage: "The URL of the data availability service",
 		Value: "",
 	}
+	VirtualCountersSmtReduction = cli.Float64Flag{
+		Name:  "zkevm.virtual-counters-smt-reduction",
+		Usage: "The multiplier to reduce the SMT depth by when calculating virtual counters",
+		Value: 0.6,
+	}
 	DebugTimers = cli.BoolFlag{
 		Name:  "debug.timers",
 		Usage: "Enable debug timers",

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -228,4 +228,5 @@ var DefaultFlags = []cli.Flag{
 	&utils.PoolManagerUrl,
 	&utils.DisableVirtualCounters,
 	&utils.DAUrl,
+	&utils.VirtualCountersSmtReduction,
 }

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -164,6 +164,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		DataStreamPort:                         ctx.Uint(utils.DataStreamPort.Name),
 		DataStreamWriteTimeout:                 ctx.Duration(utils.DataStreamWriteTimeout.Name),
 		DataStreamInactivityTimeout:            ctx.Duration(utils.DataStreamInactivityTimeout.Name),
+		VirtualCountersSmtReduction:            ctx.Float64(utils.VirtualCountersSmtReduction.Name),
 	}
 
 	utils2.EnableTimer(cfg.DebugTimers)


### PR DESCRIPTION
previously this wasn't being set so was always 0 and created counter undershoots

Fixes #827 