### PR TITLE
feat(forkid): wait for finalised on l1 closes #849

### DIFF
--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -56,6 +56,13 @@ func SpawnSequencingStage(
 		return err
 	}
 
+	// stage loop should continue until we get the forkid from the L1 in a finalised block
+	if forkId == 0 {
+		log.Warn(fmt.Sprintf("[%s] ForkId is 0. Waiting for L1 to finalise a block...", logPrefix))
+		time.Sleep(10 * time.Second)
+		return nil
+	}
+
 	var block *types.Block
 	runLoopBlocks := true
 	batchContext := newBatchContext(ctx, &cfg, &historyCfg, s, sdb)

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -188,7 +188,8 @@ func prepareForkId(lastBatch, executionAt uint64, hermezDb forkDb) (uint64, erro
 	}
 
 	if latest == 0 {
-		return 0, fmt.Errorf("could not find a suitable fork for batch %v, cannot start sequencer, check contract configuration", lastBatch+1)
+		// not an error, need to wait for the block to finalize on the L1
+		return 0, nil
 	}
 
 	// now we need to check the last batch to see if we need to update the fork id


### PR DESCRIPTION
If forkid is 0, don't error, but pause the stage loop in an attempt to wait for it to appear on the L1 in a finalised block.