### PR TITLE
Fix OOM by recovering the sequencer

### DIFF
--- a/zk/datastream/server/datastream_populate.go
+++ b/zk/datastream/server/datastream_populate.go
@@ -192,6 +192,12 @@ LOOP:
 				return err
 			}
 			entries = make([]DataStreamEntryProto, 0, insertEntryCount)
+			if err = srv.stream.CommitAtomicOp(); err != nil {
+				return err
+			}
+			if err = srv.stream.StartAtomicOp(); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
There is an OOM issue by recovering the sequencer when calling CatchupDatastream.

### Reproduce Steps
Here are the steps to reproduce the oom on X Layer testnet
```
# Step 1
./build/bin/cdk-erigon --zkevm.sync-limit=12524591 --config="xlayerconfig-testnet.yaml"

# Step 2
CDK_ERIGON_SEQUENCER=1 ./build/bin/cdk-erigon --zkevm.l1-sync-start-block=4648290 --config="xlayerconfig-testnet.yaml"
```

### Root case
It will generate all ds file on step2 by `PreStart() --> CatchupDatastream() --> WriteBlocksToStreamConsecutively()` ,  as step1 is not config `zkevm.data-stream-port` and `zkevm.data-stream-host`.

It should call CommitAtomicOp while the lenght of entries larger than commitEntryCountLimit to release memory.

### Test results
**Before** 
![image](https://github.com/user-attachments/assets/8ac77603-8aa3-4c43-9d13-8eaaf974556f)
**After**
![image](https://github.com/user-attachments/assets/9b29b098-2e13-4d67-88e7-c566a73ae5b6)


