### PR TITLE
fix(l1syncer): acc input hash current batchno only

### DIFF
--- a/zk/syncer/l1_syncer.go
+++ b/zk/syncer/l1_syncer.go
@@ -16,7 +16,6 @@ import (
 
 	ethTypes "github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rpc"
-	types "github.com/ledgerwatch/erigon/zk/rpcdaemon"
 )
 
 var (
@@ -194,40 +193,12 @@ func (s *L1Syncer) GetTransaction(hash common.Hash) (ethTypes.Transaction, bool,
 }
 
 func (s *L1Syncer) GetOldAccInputHash(ctx context.Context, addr *common.Address, rollupId, batchNum uint64) (common.Hash, error) {
-	loopCount := 0
-	for {
-		if loopCount == 10 {
-			return common.Hash{}, fmt.Errorf("too many retries")
-		}
-
-		h, previousBatch, err := s.callGetRollupSequencedBatches(ctx, addr, rollupId, batchNum)
-		if err != nil {
-			// if there is an error previousBatch value is incorrect so we can just try a single batch behind
-			if batchNum > 0 && (err == errorShortResponseLT32 || err == errorShortResponseLT96) {
-				batchNum--
-				continue
-			}
-
-			log.Debug("Error getting rollup sequenced batch", "err", err)
-			time.Sleep(time.Duration(loopCount*2) * time.Second)
-			loopCount++
-			continue
-		}
-
-		if h != types.ZeroHash {
-			return h, nil
-		}
-
-		// h is 0 and if previousBatch is 0 then we can just try a single batch behind
-		if batchNum > 0 && previousBatch == 0 {
-			batchNum--
-			continue
-		}
-
-		// if the hash is zero, we need to go back to the previous batch
-		batchNum = previousBatch
-		loopCount++
+	h, _, err := s.callGetRollupSequencedBatches(ctx, addr, rollupId, batchNum)
+	if err != nil {
+		return common.Hash{}, err
 	}
+
+	return h, nil
 }
 
 func (s *L1Syncer) GetL1BlockTimeStampByTxHash(ctx context.Context, txHash common.Hash) (uint64, error) {


### PR DESCRIPTION
Only used by RPC so this change is safe to make and mimics the logic of the zkevm node.