### PR TITLE
feat(txpool): flag to enable rejecting txs with null to

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -627,6 +627,11 @@ var (
 		Usage: "The URL of the pool manager. If set, eth_sendRawTransaction will be redirected there.",
 		Value: "",
 	}
+	TxPoolRejectToNullFlag = cli.BoolFlag{
+		Name:  "zkevm.txpool-reject-to-null",
+		Usage: "Reject transactions to the null address",
+		Value: false,
+	}
 	DisableVirtualCounters = cli.BoolFlag{
 		Name:  "zkevm.disable-virtual-counters",
 		Usage: "Disable the virtual counters. This has an effect on on sequencer node and when external executor is not enabled.",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -76,6 +76,8 @@ type Zk struct {
 	DisableVirtualCounters      bool
 	VirtualCountersSmtReduction float64
 	ExecutorPayloadOutput       string
+
+	TxPoolRejectToNull bool
 }
 
 var DefaultZkConfig = &Zk{}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -227,6 +227,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.DebugStep,
 	&utils.DebugStepAfter,
 	&utils.PoolManagerUrl,
+	&utils.TxPoolRejectToNullFlag,
 	&utils.DisableVirtualCounters,
 	&utils.DAUrl,
 	&utils.VirtualCountersSmtReduction,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -158,6 +158,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		DebugStep:                              ctx.Uint64(utils.DebugStep.Name),
 		DebugStepAfter:                         ctx.Uint64(utils.DebugStepAfter.Name),
 		PoolManagerUrl:                         ctx.String(utils.PoolManagerUrl.Name),
+		TxPoolRejectToNull:                     ctx.Bool(utils.TxPoolRejectToNullFlag.Name),
 		DisableVirtualCounters:                 ctx.Bool(utils.DisableVirtualCounters.Name),
 		ExecutorPayloadOutput:                  ctx.String(utils.ExecutorPayloadOutput.Name),
 		DAUrl:                                  ctx.String(utils.DAUrl.Name),
@@ -214,4 +215,5 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	checkFlag(utils.RebuildTreeAfterFlag.Name, cfg.RebuildTreeAfter)
 	checkFlag(utils.L1BlockRangeFlag.Name, cfg.L1BlockRange)
 	checkFlag(utils.L1QueryDelayFlag.Name, cfg.L1QueryDelay)
+	checkFlag(utils.TxPoolRejectToNullFlag.Name, cfg.TxPoolRejectToNull)
 }

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -706,6 +706,12 @@ func (p *TxPool) validateTx(txn *types.TxSlot, isLocal bool, stateCache kvcache.
 		}
 	}
 
+	if p.ethCfg.Zk.TxPoolRejectToNull {
+		if txn.To == (common.Address{}) {
+			return UnsupportedTx
+		}
+	}
+
 	isLondon := p.isLondon()
 	if !isLondon && txn.Type == 0x2 {
 		return UnsupportedTx


### PR DESCRIPTION
- when flag is true, `zkevm.txpool-reject-to-null` the txpool will reject txs with to == null (i.e. common.Address{})