### PR TITLE
Delete rolled back L1 sequence on sequence rollback event

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -799,6 +799,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		seqAndVerifTopics := [][]libcommon.Hash{{
 			contracts.SequencedBatchTopicPreEtrog,
 			contracts.SequencedBatchTopicEtrog,
+			contracts.RollbackSequenceTopic,
 			contracts.VerificationTopicPreEtrog,
 			contracts.VerificationTopicEtrog,
 			contracts.VerificationValidiumTopicEtrog,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -799,7 +799,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		seqAndVerifTopics := [][]libcommon.Hash{{
 			contracts.SequencedBatchTopicPreEtrog,
 			contracts.SequencedBatchTopicEtrog,
-			contracts.RollbackSequenceTopic,
+			contracts.RollbackBatchesTopic,
 			contracts.VerificationTopicPreEtrog,
 			contracts.VerificationTopicEtrog,
 			contracts.VerificationValidiumTopicEtrog,

--- a/zk/contracts/l1_contracts.go
+++ b/zk/contracts/l1_contracts.go
@@ -16,4 +16,5 @@ var (
 	AddNewRollupTypeTopic          = common.HexToHash("0xa2970448b3bd66ba7e524e7b2a5b9cf94fa29e32488fb942afdfe70dd4b77b52")
 	CreateNewRollupTopic           = common.HexToHash("0x194c983456df6701c6a50830b90fe80e72b823411d0d524970c9590dc277a641")
 	UpdateRollupTopic              = common.HexToHash("0xf585e04c05d396901170247783d3e5f0ee9c1df23072985b50af089f5e48b19d")
+	RollbackSequenceTopic          = common.HexToHash("0x1125aaf62d132d8e2d02005114f8fc360ff204c3105e4f1a700a1340dc55d5b1")
 )

--- a/zk/contracts/l1_contracts.go
+++ b/zk/contracts/l1_contracts.go
@@ -16,5 +16,5 @@ var (
 	AddNewRollupTypeTopic          = common.HexToHash("0xa2970448b3bd66ba7e524e7b2a5b9cf94fa29e32488fb942afdfe70dd4b77b52")
 	CreateNewRollupTopic           = common.HexToHash("0x194c983456df6701c6a50830b90fe80e72b823411d0d524970c9590dc277a641")
 	UpdateRollupTopic              = common.HexToHash("0xf585e04c05d396901170247783d3e5f0ee9c1df23072985b50af089f5e48b19d")
-	RollbackSequenceTopic          = common.HexToHash("0x1125aaf62d132d8e2d02005114f8fc360ff204c3105e4f1a700a1340dc55d5b1")
+	RollbackBatchesTopic           = common.HexToHash("0x1125aaf62d132d8e2d02005114f8fc360ff204c3105e4f1a700a1340dc55d5b1")
 )

--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -536,7 +536,8 @@ func (db *HermezDb) WriteSequence(l1BlockNo, batchNo uint64, l1TxHash, stateRoot
 	return db.tx.Put(L1SEQUENCES, ConcatKey(l1BlockNo, batchNo), val)
 }
 
-func (db *HermezDb) RollbackSequence(batchNo uint64) error {
+// RollbackSequences deletes the sequences up to the given batch number
+func (db *HermezDb) RollbackSequences(batchNo uint64) error {
 	for {
 		latestSequence, err := db.GetLatestSequence()
 		if err != nil {

--- a/zk/stages/stage_l1syncer.go
+++ b/zk/stages/stage_l1syncer.go
@@ -144,6 +144,13 @@ Loop:
 						highestWrittenL1BlockNo = info.L1BlockNo
 					}
 					newSequencesCount++
+				case logRollbackSequence:
+					if err := hermezDb.RollbackSequence(info.BatchNo); err != nil {
+						return fmt.Errorf("failed to write rollback sequence, %w", err)
+					}
+					if info.L1BlockNo > highestWrittenL1BlockNo {
+						highestWrittenL1BlockNo = info.L1BlockNo
+					}
 				case logVerify:
 					if info.BatchNo > highestVerification.BatchNo {
 						highestVerification = info
@@ -214,6 +221,7 @@ var (
 	logSequence         BatchLogType = 1
 	logVerify           BatchLogType = 2
 	logL1InfoTreeUpdate BatchLogType = 4
+	logRollbackSequence BatchLogType = 5
 
 	logIncompatible BatchLogType = 100
 )
@@ -257,6 +265,9 @@ func parseLogType(l1RollupId uint64, log *ethTypes.Log) (l1BatchInfo types.L1Bat
 		}
 	case contracts.UpdateL1InfoTreeTopic:
 		batchLogType = logL1InfoTreeUpdate
+	case contracts.RollbackSequenceTopic:
+		batchLogType = logRollbackSequence
+		batchNum = new(big.Int).SetBytes(log.Topics[1].Bytes()).Uint64()
 	default:
 		batchLogType = logUnknown
 		batchNum = 0

--- a/zk/stages/stage_l1syncer.go
+++ b/zk/stages/stage_l1syncer.go
@@ -144,8 +144,8 @@ Loop:
 						highestWrittenL1BlockNo = info.L1BlockNo
 					}
 					newSequencesCount++
-				case logRollbackSequence:
-					if err := hermezDb.RollbackSequence(info.BatchNo); err != nil {
+				case logRollbackBatches:
+					if err := hermezDb.RollbackSequences(info.BatchNo); err != nil {
 						return fmt.Errorf("failed to write rollback sequence, %w", err)
 					}
 					if info.L1BlockNo > highestWrittenL1BlockNo {
@@ -221,7 +221,7 @@ var (
 	logSequence         BatchLogType = 1
 	logVerify           BatchLogType = 2
 	logL1InfoTreeUpdate BatchLogType = 4
-	logRollbackSequence BatchLogType = 5
+	logRollbackBatches  BatchLogType = 5
 
 	logIncompatible BatchLogType = 100
 )
@@ -265,8 +265,8 @@ func parseLogType(l1RollupId uint64, log *ethTypes.Log) (l1BatchInfo types.L1Bat
 		}
 	case contracts.UpdateL1InfoTreeTopic:
 		batchLogType = logL1InfoTreeUpdate
-	case contracts.RollbackSequenceTopic:
-		batchLogType = logRollbackSequence
+	case contracts.RollbackBatchesTopic:
+		batchLogType = logRollbackBatches
 		batchNum = new(big.Int).SetBytes(log.Topics[1].Bytes()).Uint64()
 	default:
 		batchLogType = logUnknown


### PR DESCRIPTION
Once approved, this PR is safe to be merged because it will only be effective when a sequence rollback event happens on L1. 

Tested on a kurtosis network where a rollback event was manually triggered. 