### PR TITLE
Optimisze coinbase address during recovery for the sequencer

### DIFF
--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -187,7 +187,8 @@ func SpawnSequencingStage(
 
 		ibs := state.New(sdb.stateReader)
 		getHashFn := core.GetHashFn(header, func(hash common.Hash, number uint64) *types.Header { return rawdb.ReadHeader(sdb.tx, hash, number) })
-		blockContext := core.NewEVMBlockContext(header, getHashFn, cfg.engine, &cfg.zk.AddressSequencer, parentBlock.ExcessDataGas())
+		coinbase := batchState.getCoinbase(&cfg)
+		blockContext := core.NewEVMBlockContext(header, getHashFn, cfg.engine, &coinbase, parentBlock.ExcessDataGas())
 		batchState.blockState.builtBlockElements.resetBlockBuildingArrays()
 
 		parentRoot := parentBlock.Root()

--- a/zk/stages/stage_sequence_execute_blocks.go
+++ b/zk/stages/stage_sequence_execute_blocks.go
@@ -196,7 +196,7 @@ func finaliseBlock(
 
 	finalHeader := finalBlock.HeaderNoCopy()
 	finalHeader.Root = newRoot
-	finalHeader.Coinbase = batchContext.cfg.zk.AddressSequencer
+	finalHeader.Coinbase = batchState.getCoinbase(batchContext.cfg)
 	finalHeader.GasLimit = utils.GetBlockGasLimitForFork(batchState.forkId)
 	finalHeader.ReceiptHash = types.DeriveSha(builtBlockElements.receipts)
 	finalHeader.Bloom = types.CreateBloom(builtBlockElements.receipts)

--- a/zk/stages/stage_sequence_execute_injected_batch.go
+++ b/zk/stages/stage_sequence_execute_injected_batch.go
@@ -31,8 +31,7 @@ func processInjectedInitialBatch(
 		return err
 	}
 
-	coinbase := batchState.getCoinbase(batchContext.cfg)
-	header, parentBlock, err := prepareHeader(batchContext.sdb.tx, 0, math.MaxUint64, math.MaxUint64, batchState.forkId, coinbase)
+	header, parentBlock, err := prepareHeader(batchContext.sdb.tx, 0, math.MaxUint64, math.MaxUint64, batchState.forkId, batchContext.cfg.zk.AddressSequencer)
 	if err != nil {
 		return err
 	}
@@ -41,7 +40,7 @@ func processInjectedInitialBatch(
 		return rawdb.ReadHeader(batchContext.sdb.tx, hash, number)
 	}
 	getHashFn := core.GetHashFn(header, getHeader)
-	blockContext := core.NewEVMBlockContext(header, getHashFn, batchContext.cfg.engine, &coinbase, parentBlock.ExcessDataGas())
+	blockContext := core.NewEVMBlockContext(header, getHashFn, batchContext.cfg.engine, &batchContext.cfg.zk.AddressSequencer, parentBlock.ExcessDataGas())
 
 	injected, err := batchContext.sdb.hermezDb.GetL1InjectedBatch(0)
 	if err != nil {

--- a/zk/stages/stage_sequence_execute_injected_batch.go
+++ b/zk/stages/stage_sequence_execute_injected_batch.go
@@ -31,7 +31,8 @@ func processInjectedInitialBatch(
 		return err
 	}
 
-	header, parentBlock, err := prepareHeader(batchContext.sdb.tx, 0, math.MaxUint64, math.MaxUint64, batchState.forkId, batchContext.cfg.zk.AddressSequencer)
+	coinbase := batchState.getCoinbase(batchContext.cfg)
+	header, parentBlock, err := prepareHeader(batchContext.sdb.tx, 0, math.MaxUint64, math.MaxUint64, batchState.forkId, coinbase)
 	if err != nil {
 		return err
 	}
@@ -40,7 +41,7 @@ func processInjectedInitialBatch(
 		return rawdb.ReadHeader(batchContext.sdb.tx, hash, number)
 	}
 	getHashFn := core.GetHashFn(header, getHeader)
-	blockContext := core.NewEVMBlockContext(header, getHashFn, batchContext.cfg.engine, &batchContext.cfg.zk.AddressSequencer, parentBlock.ExcessDataGas())
+	blockContext := core.NewEVMBlockContext(header, getHashFn, batchContext.cfg.engine, &coinbase, parentBlock.ExcessDataGas())
 
 	injected, err := batchContext.sdb.hermezDb.GetL1InjectedBatch(0)
 	if err != nil {


### PR DESCRIPTION
- It's preferable to use `batchState.getCoinbase` to obtain the coinbase address.
- The coinbase address has changed in X Layer testnet history. While recovering the sequencer data using the following steps, a mismatch issue may occur. 

```
# Step 1
./build/bin/cdk-erigon --zkevm.sync-limit=12524591 --config="xlayerconfig-testnet.yaml"

# Step 2
CDK_ERIGON_SEQUENCER=1 ./build/bin/cdk-erigon --zkevm.l1-sync-start-block=4648290 --config="xlayerconfig-testnet.yaml"
```