### PR TITLE
Include additional information to output batches MDBX browser tool

### DIFF
--- a/cmd/rpcdaemon/commands/zkevm_api.go
+++ b/cmd/rpcdaemon/commands/zkevm_api.go
@@ -300,6 +300,9 @@ func (api *ZkEvmAPIImpl) GetBatchDataByNumbers(ctx context.Context, batchNumbers
 	if syncing != nil && syncing != false {
 		bn := syncing.(map[string]interface{})["currentBlock"]
 		highestBatchNo, err = hermezDb.GetBatchNoByL2Block(uint64(bn.(hexutil.Uint64)))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	bds := make([]*types.BatchDataSlim, 0, len(batchNumbers.Numbers))
@@ -343,7 +346,6 @@ func (api *ZkEvmAPIImpl) GetBatchDataByNumbers(ctx context.Context, batchNumbers
 
 		// collect blocks in batch
 		var batchBlocks []*eritypes.Block
-		var batchTxs []eritypes.Transaction
 		// handle genesis - not in the hermez tables so requires special treament
 		if batchNumber == 0 {
 			blk, err := api.ethApi.BaseAPI.blockByNumberWithSenders(tx, 0)
@@ -359,9 +361,6 @@ func (api *ZkEvmAPIImpl) GetBatchDataByNumbers(ctx context.Context, batchNumbers
 				return nil, err
 			}
 			batchBlocks = append(batchBlocks, blk)
-			for _, btx := range blk.Transactions() {
-				batchTxs = append(batchTxs, btx)
-			}
 		}
 
 		// batch l2 data - must build on the fly

--- a/cmd/rpcdaemon/commands/zkevm_api.go
+++ b/cmd/rpcdaemon/commands/zkevm_api.go
@@ -369,7 +369,7 @@ func (api *ZkEvmAPIImpl) GetBatchDataByNumbers(ctx context.Context, batchNumbers
 			return nil, err
 		}
 
-		batchL2Data, err := generateBatchData(tx, hermezDb, batchBlocks, forkId)
+		batchL2Data, err := utils.GenerateBatchData(tx, hermezDb, batchBlocks, forkId)
 		if err != nil {
 			return nil, err
 		}
@@ -379,54 +379,6 @@ func (api *ZkEvmAPIImpl) GetBatchDataByNumbers(ctx context.Context, batchNumbers
 	}
 
 	return populateBatchDataSlimDetails(bds)
-}
-
-func generateBatchData(
-	tx kv.Tx,
-	hermezDb *hermez_db.HermezDbReader,
-	batchBlocks []*eritypes.Block,
-	forkId uint64,
-) (batchL2Data []byte, err error) {
-
-	lastBlockNoInPreviousBatch := uint64(0)
-	if batchBlocks[0].NumberU64() != 0 {
-		lastBlockNoInPreviousBatch = batchBlocks[0].NumberU64() - 1
-	}
-
-	lastBlockInPreviousBatch, err := rawdb.ReadBlockByNumber(tx, lastBlockNoInPreviousBatch)
-	if err != nil {
-		return nil, err
-	}
-
-	batchL2Data = []byte{}
-	for i := 0; i < len(batchBlocks); i++ {
-		var dTs uint32
-		if i == 0 {
-			dTs = uint32(batchBlocks[i].Time() - lastBlockInPreviousBatch.Time())
-		} else {
-			dTs = uint32(batchBlocks[i].Time() - batchBlocks[i-1].Time())
-		}
-		iti, err := hermezDb.GetBlockL1InfoTreeIndex(batchBlocks[i].NumberU64())
-		if err != nil {
-			return nil, err
-		}
-		egTx := make(map[common.Hash]uint8)
-		for _, txn := range batchBlocks[i].Transactions() {
-			eg, err := hermezDb.GetEffectiveGasPricePercentage(txn.Hash())
-			if err != nil {
-				return nil, err
-			}
-			egTx[txn.Hash()] = eg
-		}
-
-		bl2d, err := zktx.GenerateBlockBatchL2Data(uint16(forkId), dTs, uint32(iti), batchBlocks[i].Transactions(), egTx)
-		if err != nil {
-			return nil, err
-		}
-		batchL2Data = append(batchL2Data, bl2d...)
-	}
-
-	return batchL2Data, err
 }
 
 // GetBatchByNumber returns a batch from the current canonical chain. If number is nil, the
@@ -670,7 +622,7 @@ func (api *ZkEvmAPIImpl) GetBatchByNumber(ctx context.Context, batchNumber rpc.B
 		return nil, err
 	}
 
-	batchL2Data, err := generateBatchData(tx, hermezDb, batchBlocks, forkId)
+	batchL2Data, err := utils.GenerateBatchData(tx, hermezDb, batchBlocks, forkId)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/zkevm_api.go
+++ b/cmd/rpcdaemon/commands/zkevm_api.go
@@ -30,6 +30,7 @@ import (
 	smt "github.com/ledgerwatch/erigon/smt/pkg/smt"
 	smtUtils "github.com/ledgerwatch/erigon/smt/pkg/utils"
 	"github.com/ledgerwatch/erigon/turbo/rpchelper"
+	"github.com/ledgerwatch/erigon/zk/constants"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 	"github.com/ledgerwatch/erigon/zk/legacy_executor_verifier"
 	types "github.com/ledgerwatch/erigon/zk/rpcdaemon"
@@ -686,7 +687,7 @@ func (api *ZkEvmAPIImpl) GetBatchByNumber(ctx context.Context, batchNumber rpc.B
 	// forkid exit roots logic
 	// if forkid < 12 then we should only set the exit roots if they have changed, otherwise 0x00..00
 	// if forkid >= 12 then we should always set the exit roots
-	if forkId < 12 {
+	if forkId < uint64(constants.ForkID12Banana) {
 		// get the previous batches exit roots
 		prevBatchNo := batchNo - 1
 		prevBatchHighestBlock, err := hermezDb.GetHighestBlockInBatch(prevBatchNo)

--- a/core/state/intra_block_state_zkevm.go
+++ b/core/state/intra_block_state_zkevm.go
@@ -41,6 +41,7 @@ type ReadOnlyHermezDb interface {
 	GetVerificationByBatchNo(batchNo uint64) (*zktypes.L1BatchInfo, error)
 	GetL1BatchData(batchNumber uint64) ([]byte, error)
 	GetL1InfoTreeUpdateByGer(ger libcommon.Hash) (*zktypes.L1InfoTreeUpdate, error)
+	GetLastBlockGlobalExitRoot(l2BlockNo uint64) (libcommon.Hash, uint64, error)
 }
 
 func (sdb *IntraBlockState) GetTxCount() (uint64, error) {

--- a/core/state/intra_block_state_zkevm.go
+++ b/core/state/intra_block_state_zkevm.go
@@ -34,14 +34,20 @@ type ReadOnlyHermezDb interface {
 	GetIntermediateTxStateRoot(blockNum uint64, txhash libcommon.Hash) (libcommon.Hash, error)
 	GetReusedL1InfoTreeIndex(blockNum uint64) (bool, error)
 	GetSequenceByBatchNo(batchNo uint64) (*zktypes.L1BatchInfo, error)
+	GetSequenceByBatchNoOrHighest(batchNo uint64) (*zktypes.L1BatchInfo, error)
 	GetHighestBlockInBatch(batchNo uint64) (uint64, error)
 	GetLowestBlockInBatch(batchNo uint64) (uint64, bool, error)
 	GetL2BlockNosByBatch(batchNo uint64) ([]uint64, error)
 	GetBatchGlobalExitRoot(batchNum uint64) (*dstypes.GerUpdate, error)
 	GetVerificationByBatchNo(batchNo uint64) (*zktypes.L1BatchInfo, error)
+	GetVerificationByBatchNoOrHighest(batchNo uint64) (*zktypes.L1BatchInfo, error)
 	GetL1BatchData(batchNumber uint64) ([]byte, error)
 	GetL1InfoTreeUpdateByGer(ger libcommon.Hash) (*zktypes.L1InfoTreeUpdate, error)
+	GetBlockL1InfoTreeIndex(blockNumber uint64) (uint64, error)
+	GetBlockInfoRoot(blockNumber uint64) (libcommon.Hash, error)
+	GetLocalExitRootForBatchNo(batchNo uint64) (libcommon.Hash, error)
 	GetLastBlockGlobalExitRoot(l2BlockNo uint64) (libcommon.Hash, uint64, error)
+	GetForkId(batchNo uint64) (uint64, error)
 }
 
 func (sdb *IntraBlockState) GetTxCount() (uint64, error) {

--- a/core/state/intra_block_state_zkevm.go
+++ b/core/state/intra_block_state_zkevm.go
@@ -45,7 +45,6 @@ type ReadOnlyHermezDb interface {
 	GetL1InfoTreeUpdateByGer(ger libcommon.Hash) (*zktypes.L1InfoTreeUpdate, error)
 	GetBlockL1InfoTreeIndex(blockNumber uint64) (uint64, error)
 	GetBlockInfoRoot(blockNumber uint64) (libcommon.Hash, error)
-	GetLocalExitRootForBatchNo(batchNo uint64) (libcommon.Hash, error)
 	GetLastBlockGlobalExitRoot(l2BlockNo uint64) (libcommon.Hash, uint64, error)
 	GetForkId(batchNo uint64) (uint64, error)
 }

--- a/zk/debug_tools/mdbx-data-browser/README.md
+++ b/zk/debug_tools/mdbx-data-browser/README.md
@@ -60,6 +60,21 @@ In case `file-output` flag is provided, results are printed to a JSON file (othe
 
 **Note:** In case, `output-blocks` is ran with `verbose` flag provided, it is necessary to provide the proper chain id to the `params/chainspecs/mainnet.json`. This is the case, because CDK Erigon (for now) uses hardcoded data to recover transaction senders, and chain id information is read from the mentioned file.
 
+#### `output-batch-affiliation`
+It is used to output the batch numbers alongside with the blocks that affiliate to the certain batch.
+
+- **Name**: `output-batch-affiliation`
+- **Usage**: Outputs batch affiliation of certain blocks.
+- **Action**: `dumpBatchAffiliation`
+- **Flags**:
+  - `data-dir`: Specifies the data directory to use.
+  - `bn`: Block numbers.
+    - **Name**: `bn`
+    - **Usage**: Block numbers.
+    - **Destination**: `batchOrBlockNumbers`
+  - `verbose`: See [verbose](#verbose) flag.
+  - `file-output`: See [file-output](#file-output) flag.
+
 ### Example Usage
 
 **Pre-requisite:** Navigate to the `zk/debug_tools/mdbx-data-browser` folder and run `go build -o mdbx-data-browser`
@@ -74,4 +89,10 @@ In case `file-output` flag is provided, results are printed to a JSON file (othe
 
 ```sh
 ./mdbx-data-browser output-blocks --datadir chaindata/ --bn 100,101,102 [--verbose] [--file-output]
+```
+
+#### `output-batch-affiliation` Command
+
+```sh
+./mdbx-data-browser output-batch-affiliation --datadir chaindata/ --bn 100,101,102 [--verbose] [--file-output]
 ```

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever.go
@@ -111,7 +111,7 @@ func (d *DbDataRetriever) GetBatchByNumber(batchNum uint64, verboseOutput bool) 
 	}
 
 	// Get Local Exit Root
-	localExitRoot, err := utils.GetBatchLocalExitRoot(batchNum, d.dbReader, d.tx)
+	localExitRoot, err := utils.GetBatchLocalExitRootFromSCStorageForLatestBlock(batchNum, d.dbReader, d.tx)
 	if err != nil {
 		return nil, err
 	}

--- a/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
+++ b/zk/debug_tools/mdbx-data-browser/dbdata_retriever_test.go
@@ -63,17 +63,17 @@ func TestDbDataRetrieverGetBatchByNumber(t *testing.T) {
 func TestDbDataRetrieverGetBlockByNumber(t *testing.T) {
 	t.Run("querying an existing block", func(t *testing.T) {
 		// arrange
-		_, dbTx := memdb.NewTestTx(t)
+		_, tx := memdb.NewTestTx(t)
 		tx1 := types.NewTransaction(1, libcommon.HexToAddress("0x1050"), u256.Num1, 1, u256.Num1, nil)
 		tx2 := types.NewTransaction(2, libcommon.HexToAddress("0x100"), u256.Num27, 2, u256.Num2, nil)
 
 		block := createBlock(t, 5, types.Transactions{tx1, tx2})
 
-		require.NoError(t, rawdb.WriteCanonicalHash(dbTx, block.Hash(), block.NumberU64()))
-		require.NoError(t, rawdb.WriteBlock(dbTx, block))
+		require.NoError(t, rawdb.WriteCanonicalHash(tx, block.Hash(), block.NumberU64()))
+		require.NoError(t, rawdb.WriteBlock(tx, block))
 
 		// act and assert
-		dbReader := NewDbDataRetriever(dbTx)
+		dbReader := NewDbDataRetriever(tx)
 		result, err := dbReader.GetBlockByNumber(block.NumberU64(), true, true)
 		require.NoError(t, err)
 		require.Equal(t, block.Hash(), result.Hash)
@@ -89,6 +89,83 @@ func TestDbDataRetrieverGetBlockByNumber(t *testing.T) {
 		require.ErrorContains(t, err, fmt.Sprintf("block %d not found", blockNum))
 		require.Nil(t, result)
 	})
+}
+
+func TestDbDataRetrieverGetBatchAffiliation(t *testing.T) {
+	testCases := []struct {
+		name           string
+		blocksInBatch  int
+		batchesCount   int
+		blockNums      []uint64
+		expectedErrMsg string
+		expectedResult []*BatchAffiliationInfo
+	}{
+		{
+			name:          "Basic case with three blocks and two requested",
+			blocksInBatch: 3,
+			batchesCount:  2,
+			blockNums:     []uint64{1, 3},
+			expectedResult: []*BatchAffiliationInfo{
+				{Number: 1, Blocks: []uint64{1, 3}},
+			},
+		},
+		{
+			name:          "All blocks in batch requested",
+			blocksInBatch: 3,
+			batchesCount:  2,
+			blockNums:     []uint64{4, 5, 6},
+			expectedResult: []*BatchAffiliationInfo{
+				{Number: 2, Blocks: []uint64{4, 5, 6}},
+			},
+		},
+		{
+			name:          "Request multiple batches",
+			blocksInBatch: 2,
+			batchesCount:  3,
+			blockNums:     []uint64{1, 2, 6},
+			expectedResult: []*BatchAffiliationInfo{
+				{Number: 1, Blocks: []uint64{1, 2}},
+				{Number: 3, Blocks: []uint64{6}},
+			},
+		},
+		{
+			name:           "Request non-existent block",
+			blocksInBatch:  2,
+			batchesCount:   2,
+			blockNums:      []uint64{5},
+			expectedErrMsg: "batch is not found for block num 5",
+			expectedResult: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, dbTx := memdb.NewTestTx(t)
+			require.NoError(t, hermez_db.CreateHermezBuckets(dbTx))
+			db := hermez_db.NewHermezDb(dbTx)
+
+			// Write the blocks according to the test case
+			blockNum := uint64(1)
+			for batchNum := uint64(1); batchNum <= uint64(tc.batchesCount); batchNum++ {
+				for i := 0; i < tc.blocksInBatch; i++ {
+					require.NoError(t, db.WriteBlockBatch(blockNum, batchNum))
+					blockNum++
+				}
+			}
+
+			dbReader := NewDbDataRetriever(dbTx)
+			batchAffiliation, err := dbReader.GetBatchAffiliation(tc.blockNums)
+
+			// Check if an error was expected
+			if tc.expectedErrMsg != "" {
+				require.ErrorContains(t, err, tc.expectedErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedResult, batchAffiliation)
+		})
+	}
 }
 
 // createBlock is a helper function, that allows creating block

--- a/zk/debug_tools/mdbx-data-browser/main.go
+++ b/zk/debug_tools/mdbx-data-browser/main.go
@@ -16,6 +16,7 @@ func main() {
 	app.Commands = []*cli.Command{
 		getBatchByNumberCmd,
 		getBlockByNumberCmd,
+		getBatchAffiliationCmd,
 	}
 
 	logging.SetupLogger("mdbx data browser")

--- a/zk/utils/utils.go
+++ b/zk/utils/utils.go
@@ -3,14 +3,18 @@ package utils
 import (
 	"fmt"
 
+	"github.com/gateway-fm/cdk-erigon-lib/common"
 	libcommon "github.com/gateway-fm/cdk-erigon-lib/common"
 	"github.com/gateway-fm/cdk-erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/chain"
+	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/systemcontracts"
+	eritypes "github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/zk/constants"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
+	zktx "github.com/ledgerwatch/erigon/zk/tx"
 	"github.com/ledgerwatch/log/v3"
 )
 
@@ -157,4 +161,52 @@ func GetBatchLocalExitRootFromSCStorageByBlock(blockNumber uint64, db DbReader, 
 	}
 
 	return libcommon.Hash{}, nil
+}
+
+func GenerateBatchData(
+	tx kv.Tx,
+	hermezDb state.ReadOnlyHermezDb,
+	batchBlocks []*eritypes.Block,
+	forkId uint64,
+) (batchL2Data []byte, err error) {
+	lastBlockNoInPreviousBatch := uint64(0)
+	firstBlockInBatch := batchBlocks[0]
+	if firstBlockInBatch.NumberU64() != 0 {
+		lastBlockNoInPreviousBatch = firstBlockInBatch.NumberU64() - 1
+	}
+
+	lastBlockInPreviousBatch, err := rawdb.ReadBlockByNumber(tx, lastBlockNoInPreviousBatch)
+	if err != nil {
+		return nil, err
+	}
+
+	batchL2Data = []byte{}
+	for i := 0; i < len(batchBlocks); i++ {
+		var dTs uint32
+		if i == 0 {
+			dTs = uint32(batchBlocks[i].Time() - lastBlockInPreviousBatch.Time())
+		} else {
+			dTs = uint32(batchBlocks[i].Time() - batchBlocks[i-1].Time())
+		}
+		iti, err := hermezDb.GetBlockL1InfoTreeIndex(batchBlocks[i].NumberU64())
+		if err != nil {
+			return nil, err
+		}
+		egTx := make(map[common.Hash]uint8)
+		for _, txn := range batchBlocks[i].Transactions() {
+			eg, err := hermezDb.GetEffectiveGasPricePercentage(txn.Hash())
+			if err != nil {
+				return nil, err
+			}
+			egTx[txn.Hash()] = eg
+		}
+
+		bl2d, err := zktx.GenerateBlockBatchL2Data(uint16(forkId), dTs, uint32(iti), batchBlocks[i].Transactions(), egTx)
+		if err != nil {
+			return nil, err
+		}
+		batchL2Data = append(batchL2Data, bl2d...)
+	}
+
+	return batchL2Data, err
 }


### PR DESCRIPTION
This PR aligns (as much as possible, since it is an offline tool) output of `output-batches` CLI command in the MDBX DB browser tool with the `zkevm_getBatchByNumber`.

It also implements new command called `output-batch-affiliation`, that prints the batch numbers, for the provided block numbers.