### PR TITLE
replaced maps with arrays in counters for optimization

### DIFF
--- a/core/vm/zk_counters.go
+++ b/core/vm/zk_counters.go
@@ -67,38 +67,53 @@ func (c *Counter) AsMap() map[string]int {
 	}
 }
 
-type Counters map[CounterKey]*Counter
+type Counters []*Counter
 
-func NewCountersFromUsedMap(used map[string]int) *Counters {
+func NewCounters() Counters {
+	array := make(Counters, counterTypesCount)
+	return array
+}
+
+func NewCountersFromUsedArray(used []int) *Counters {
 	res := Counters{}
 	for k, v := range used {
-		res[CounterKey(k)] = &Counter{used: v}
+		res[k] = &Counter{used: v}
 	}
 	return &res
 }
 
 func (c Counters) UsedAsString() string {
-	res := fmt.Sprintf("[SHA: %v]", c[SHA].used)
-	res += fmt.Sprintf("[A: %v]", c[A].used)
-	res += fmt.Sprintf("[B: %v]", c[B].used)
-	res += fmt.Sprintf("[K: %v]", c[K].used)
-	res += fmt.Sprintf("[M: %v]", c[M].used)
-	res += fmt.Sprintf("[P: %v]", c[P].used)
-	res += fmt.Sprintf("[S: %v]", c[S].used)
-	res += fmt.Sprintf("[D: %v]", c[D].used)
+	res := fmt.Sprintf("[%s: %v]", SHAName, c[SHA].used)
+	res += fmt.Sprintf("[%s: %v]", AName, c[A].used)
+	res += fmt.Sprintf("[%s: %v]", BName, c[B].used)
+	res += fmt.Sprintf("[%s: %v]", KName, c[K].used)
+	res += fmt.Sprintf("[%s: %v]", MName, c[M].used)
+	res += fmt.Sprintf("[%s: %v]", PName, c[P].used)
+	res += fmt.Sprintf("[%s: %v]", SName, c[S].used)
+	res += fmt.Sprintf("[%s: %v]", DName, c[D].used)
 	return res
+}
+
+func (c Counters) UsedAsArray() []int {
+	array := make([]int, len(c))
+
+	for i, v := range c {
+		array[i] = v.used
+	}
+
+	return array
 }
 
 func (c Counters) UsedAsMap() map[string]int {
 	return map[string]int{
-		"SHA": c[SHA].used,
-		"A":   c[A].used,
-		"B":   c[B].used,
-		"K":   c[K].used,
-		"M":   c[M].used,
-		"P":   c[P].used,
-		"S":   c[S].used,
-		"D":   c[D].used,
+		string(SName):   c[S].used,
+		string(AName):   c[A].used,
+		string(BName):   c[B].used,
+		string(MName):   c[M].used,
+		string(KName):   c[K].used,
+		string(DName):   c[D].used,
+		string(PName):   c[P].used,
+		string(SHAName): c[SHA].used,
 	}
 }
 
@@ -144,17 +159,29 @@ func (cc Counters) Clone() Counters {
 	return clonedCounters
 }
 
-type CounterKey string
+type CounterKey int
+type CounterName string
 
 var (
-	S   CounterKey = "S"
-	A   CounterKey = "A"
-	B   CounterKey = "B"
-	M   CounterKey = "M"
-	K   CounterKey = "K"
-	D   CounterKey = "D"
-	P   CounterKey = "P"
-	SHA CounterKey = "SHA"
+	SName   CounterName = "S"
+	AName   CounterName = "A"
+	BName   CounterName = "B"
+	MName   CounterName = "M"
+	KName   CounterName = "K"
+	DName   CounterName = "D"
+	PName   CounterName = "P"
+	SHAName CounterName = "SHA"
+
+	S   CounterKey = 0
+	A   CounterKey = 1
+	B   CounterKey = 2
+	M   CounterKey = 3
+	K   CounterKey = 4
+	D   CounterKey = 5
+	P   CounterKey = 6
+	SHA CounterKey = 7
+
+	counterTypesCount = 8
 )
 
 type CounterCollector struct {

--- a/core/vm/zk_counters_limits.go
+++ b/core/vm/zk_counters_limits.go
@@ -36,48 +36,49 @@ type counterLimits struct {
 }
 
 func createCountrsByLimits(c counterLimits) *Counters {
-	return &Counters{
-		S: {
-			remaining:     c.totalSteps,
-			name:          "defaultTotalSteps",
-			initialAmount: c.totalSteps,
-		},
-		A: {
-			remaining:     c.arith,
-			name:          "arith",
-			initialAmount: c.arith,
-		},
-		B: {
-			remaining:     c.binary,
-			name:          "binary",
-			initialAmount: c.binary,
-		},
-		M: {
-			remaining:     c.memAlign,
-			name:          "memAlign",
-			initialAmount: c.memAlign,
-		},
-		K: {
-			remaining:     c.keccaks,
-			name:          "keccaks",
-			initialAmount: c.keccaks,
-		},
-		D: {
-			remaining:     c.padding,
-			name:          "padding",
-			initialAmount: c.padding,
-		},
-		P: {
-			remaining:     c.poseidon,
-			name:          "poseidon",
-			initialAmount: c.poseidon,
-		},
-		SHA: {
-			remaining:     c.sha256,
-			name:          "sha256",
-			initialAmount: c.sha256,
-		},
+	counters := NewCounters()
+
+	counters[S] = &Counter{
+		remaining:     c.totalSteps,
+		name:          "defaultTotalSteps",
+		initialAmount: c.totalSteps,
 	}
+	counters[A] = &Counter{
+		remaining:     c.arith,
+		name:          "arith",
+		initialAmount: c.arith,
+	}
+	counters[B] = &Counter{
+		remaining:     c.binary,
+		name:          "binary",
+		initialAmount: c.binary,
+	}
+	counters[M] = &Counter{
+		remaining:     c.memAlign,
+		name:          "memAlign",
+		initialAmount: c.memAlign,
+	}
+	counters[K] = &Counter{
+		remaining:     c.keccaks,
+		name:          "keccaks",
+		initialAmount: c.keccaks,
+	}
+	counters[D] = &Counter{
+		remaining:     c.padding,
+		name:          "padding",
+		initialAmount: c.padding,
+	}
+	counters[P] = &Counter{
+		remaining:     c.poseidon,
+		name:          "poseidon",
+		initialAmount: c.poseidon,
+	}
+	counters[SHA] = &Counter{
+		remaining:     c.sha256,
+		name:          "sha256",
+		initialAmount: c.sha256,
+	}
+	return &counters
 }
 
 // tp ne used on next forkid counters

--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -1360,7 +1360,7 @@ func (db *HermezDbReader) GetWitness(batchNumber uint64) ([]byte, error) {
 	return v, nil
 }
 
-func (db *HermezDb) WriteBatchCounters(blockNumber uint64, counters map[string]int) error {
+func (db *HermezDb) WriteBatchCounters(blockNumber uint64, counters []int) error {
 	countersJson, err := json.Marshal(counters)
 	if err != nil {
 		return err
@@ -1368,7 +1368,7 @@ func (db *HermezDb) WriteBatchCounters(blockNumber uint64, counters map[string]i
 	return db.tx.Put(BATCH_COUNTERS, Uint64ToBytes(blockNumber), countersJson)
 }
 
-func (db *HermezDbReader) GetLatestBatchCounters(batchNumber uint64) (countersMap map[string]int, found bool, err error) {
+func (db *HermezDbReader) GetLatestBatchCounters(batchNumber uint64) (countersMap []int, found bool, err error) {
 	batchBlockNumbers, err := db.GetL2BlockNosByBatch(batchNumber)
 	if err != nil {
 		return nil, false, err

--- a/zk/stages/stage_sequence_execute_batch.go
+++ b/zk/stages/stage_sequence_execute_batch.go
@@ -62,7 +62,7 @@ func doCheckForBadBatch(batchContext *BatchContext, batchState *BatchState, this
 	if err = batchContext.sdb.hermezDb.WriteInvalidBatch(batchState.batchNumber); err != nil {
 		return false, err
 	}
-	if err = batchContext.sdb.hermezDb.WriteBatchCounters(currentBlock.NumberU64(), map[string]int{}); err != nil {
+	if err = batchContext.sdb.hermezDb.WriteBatchCounters(currentBlock.NumberU64(), []int{}); err != nil {
 		return false, err
 	}
 	if err = stages.SaveStageProgress(batchContext.sdb.tx, stages.HighestSeenBatchNumber, batchState.batchNumber); err != nil {

--- a/zk/stages/stage_sequence_execute_blocks.go
+++ b/zk/stages/stage_sequence_execute_blocks.go
@@ -242,7 +242,7 @@ func finaliseBlock(
 	}
 
 	// write batch counters
-	err = batchContext.sdb.hermezDb.WriteBatchCounters(newNum.Uint64(), batchCounters.CombineCollectorsNoChanges().UsedAsMap())
+	err = batchContext.sdb.hermezDb.WriteBatchCounters(newNum.Uint64(), batchCounters.CombineCollectorsNoChanges().UsedAsArray())
 	if err != nil {
 		return nil, err
 	}

--- a/zk/txpool/pool_zk_limbo_processor.go
+++ b/zk/txpool/pool_zk_limbo_processor.go
@@ -79,8 +79,8 @@ func (_this *LimboSubPoolProcessor) run() {
 	// we just need some counter variable with large used values in order verify not to complain
 	batchCounters := vm.NewBatchCounterCollector(256, 1, _this.zkCfg.VirtualCountersSmtReduction, true, nil)
 	unlimitedCounters := batchCounters.NewCounters().UsedAsMap()
-	for k := range unlimitedCounters {
-		unlimitedCounters[k] = math.MaxInt32
+	for i, _ := range unlimitedCounters {
+		unlimitedCounters[i] = math.MaxInt32
 	}
 
 	blockNumbers := []uint64{1} // let's assume that there is a just single block number 1, because the number itself does not matter


### PR DESCRIPTION
The majority of the time used to deduct in counters was used to access and change map values. By replacing the map with an array and constant indexes for the counters, deducting becomes 4 times faster.
Before:
![image](https://github.com/user-attachments/assets/0873fc18-1c68-4fe4-bcbd-9aede61d52f3)

After:
![image](https://github.com/user-attachments/assets/9d7bb3ea-2d61-43bf-a449-553c42db5f93)
