### PR TITLE
Disable blob tx

### DIFF
--- a/turbo/jsonrpc/send_transaction.go
+++ b/turbo/jsonrpc/send_transaction.go
@@ -57,6 +57,10 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutility
 		if !cc.IsLondon(latestBlock.NumberU64()) {
 			return common.Hash{}, errors.New("only legacy transactions are supported")
 		}
+
+		if txn.Type() == types.BlobTxType {
+			return common.Hash{}, errors.New("blob transactions are not supported")
+		}
 	}
 
 	// If the transaction fee cap is already specified, ensure the


### PR DESCRIPTION
Blob tx should be always disabled because L2 won't be supporting blob in the near future. 