### PR TITLE
Fix: ACL bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ COPY --from=builder /app/build/bin/sentry /usr/local/bin/sentry
 COPY --from=builder /app/build/bin/state /usr/local/bin/state
 COPY --from=builder /app/build/bin/txpool /usr/local/bin/txpool
 COPY --from=builder /app/build/bin/verkle /usr/local/bin/verkle
-
+COPY --from=builder /app/build/bin/acl /usr/local/bin/acl
 
 
 EXPOSE 8545 \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -74,6 +74,7 @@ COPY --from=builder /app/build/bin/sentry /usr/local/bin/sentry
 COPY --from=builder /app/build/bin/state /usr/local/bin/state
 COPY --from=builder /app/build/bin/txpool /usr/local/bin/txpool
 COPY --from=builder /app/build/bin/verkle /usr/local/bin/verkle
+COPY --from=builder /app/build/bin/acl /usr/local/bin/acl
 
 COPY --from=builder /go/pkg/mod /go/pkg/mod
 

--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -97,7 +97,7 @@ func checkIfAccountHasPolicy(ctx context.Context, aclDB kv.RwDB, addr common.Add
 		policyBytes = value
 		if policyBytes != nil && containsPolicy(policyBytes, policy) {
 			// If address is in the allowlist and has the policy, return true
-			// If address is in the blacklist and has the policy, return false
+			// If address is in the blocklist and has the policy, return false
 			hasPolicy = true
 		}
 

--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -53,14 +53,23 @@ func containsPolicy(policies []byte, policy Policy) bool {
 	return bytes.Contains(policies, policy.ToByteArray())
 }
 
-// CheckPolicy checks if the given address has the given policy for the online ACL mode
-func CheckPolicy(ctx context.Context, aclDB kv.RwDB, addr common.Address, policy Policy) (bool, error) {
+// DoesAccountHavePolicy checks if the given account has the given policy for the online ACL mode
+func DoesAccountHavePolicy(ctx context.Context, aclDB kv.RwDB, addr common.Address, policy Policy) (bool, error) {
+	hasPolicy, _, err := checkIfAccountHasPolicy(ctx, aclDB, addr, policy)
+	return hasPolicy, err
+}
+
+func checkIfAccountHasPolicy(ctx context.Context, aclDB kv.RwDB, addr common.Address, policy Policy) (bool, ACLMode, error) {
 	if !IsSupportedPolicy(policy) {
-		return false, errUnknownPolicy
+		return false, DisabledMode, errUnknownPolicy
 	}
 
 	// Retrieve the mode configuration
-	var hasPolicy bool
+	var (
+		hasPolicy bool
+		mode      ACLMode = DisabledMode
+	)
+
 	err := aclDB.View(ctx, func(tx kv.Tx) error {
 		value, err := tx.GetOne(Config, []byte("mode"))
 		if err != nil {
@@ -72,7 +81,7 @@ func CheckPolicy(ctx context.Context, aclDB kv.RwDB, addr common.Address, policy
 			return nil
 		}
 
-		mode := string(value)
+		mode = ACLMode(value)
 
 		table := BlockList
 		if mode == AllowlistMode {
@@ -87,7 +96,7 @@ func CheckPolicy(ctx context.Context, aclDB kv.RwDB, addr common.Address, policy
 
 		policyBytes = value
 		if policyBytes != nil && containsPolicy(policyBytes, policy) {
-			// If address is in the whitelist and has the policy, return true
+			// If address is in the allowlist and has the policy, return true
 			// If address is in the blacklist and has the policy, return false
 			hasPolicy = true
 		}
@@ -95,10 +104,10 @@ func CheckPolicy(ctx context.Context, aclDB kv.RwDB, addr common.Address, policy
 		return nil
 	})
 	if err != nil {
-		return false, err
+		return false, mode, err
 	}
 
-	return hasPolicy, nil
+	return hasPolicy, mode, nil
 }
 
 // UpdatePolicies sets a policy for an address
@@ -251,7 +260,19 @@ func resolvePolicy(txn *types.TxSlot) Policy {
 	return SendTx
 }
 
-// create a method checkpolicy to check an address according to passed policy in the method
-func (p *TxPool) checkPolicy(ctx context.Context, addr common.Address, policy Policy) (bool, error) {
-	return CheckPolicy(ctx, p.aclDB, addr, policy)
+// isActionAllowed checks if the given action is allowed for the given address
+func (p *TxPool) isActionAllowed(ctx context.Context, addr common.Address, policy Policy) (bool, error) {
+	hasPolicy, mode, err := checkIfAccountHasPolicy(ctx, p.aclDB, addr, policy)
+	if err != nil {
+		return false, err
+	}
+
+	switch mode {
+	case BlocklistMode:
+		// If the mode is blocklist, and address has a certain policy, then invert the result
+		// because, for example, if it has sendTx policy, it means it is not allowed to sendTx
+		return !hasPolicy, nil
+	default:
+		return hasPolicy, nil
+	}
 }

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -782,7 +782,7 @@ func (p *TxPool) validateTx(txn *types.TxSlot, isLocal bool, stateCache kvcache.
 	switch resolvePolicy(txn) {
 	case SendTx:
 		var allow bool
-		allow, err := p.checkPolicy(context.TODO(), from, SendTx)
+		allow, err := p.isActionAllowed(context.TODO(), from, SendTx)
 		if err != nil {
 			panic(err)
 		}
@@ -792,7 +792,7 @@ func (p *TxPool) validateTx(txn *types.TxSlot, isLocal bool, stateCache kvcache.
 	case Deploy:
 		var allow bool
 		// check that sender may deploy contracts
-		allow, err := p.checkPolicy(context.TODO(), from, Deploy)
+		allow, err := p.isActionAllowed(context.TODO(), from, Deploy)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This PR fixes two bugs on the `Access List` feature on `cdk-erigon`:

1. It missed a copy of the `acl` command binary in the docker files.
2. There was a bug on the block list feature, where it misinterpreted the block list policies. For example, if `block list` mode is on, and an address has a certain policy, like `sendTx` it means that given address can do that action in the `block list` which doesn't make sense because it is a block list, not allow list. It also means we can not block a single action in block list for an address, so this has to be inverted in this case. For example, if an address has a policy `sendTx` in a block list, it means it can not do that action.