### PR TITLE
fix batch end local exit root

### DIFF
--- a/zk/datastream/server/data_stream_server.go
+++ b/zk/datastream/server/data_stream_server.go
@@ -197,7 +197,7 @@ func createBlockWithBatchCheckStreamEntriesProto(
 		}
 		// the genesis we insert fully, so we would have to skip closing it
 		if !shouldSkipBatchEndEntry {
-			localExitRoot, err := utils.GetBatchLocalExitRootFromSCStorageForLatestBlock(batchNumber, reader, tx)
+			localExitRoot, err := utils.GetBatchLocalExitRootFromSCStorageForLatestBlock(lastBatchNumber, reader, tx)
 			if err != nil {
 				return nil, err
 			}

--- a/zk/utils/utils.go
+++ b/zk/utils/utils.go
@@ -147,7 +147,7 @@ func GetBatchLocalExitRootFromSCStorageForLatestBlock(batchNo uint64, db DbReade
 
 func GetBatchLocalExitRootFromSCStorageByBlock(blockNumber uint64, db DbReader, tx kv.Tx) (libcommon.Hash, error) {
 	if blockNumber > 0 {
-		stateReader := state.NewPlainState(tx, blockNumber+1, systemcontracts.SystemContractCodeLookup["hermez"])
+		stateReader := state.NewPlainState(tx, blockNumber, systemcontracts.SystemContractCodeLookup["hermez"])
 		defer stateReader.Close()
 		rawLer, err := stateReader.ReadAccountStorage(state.GER_MANAGER_ADDRESS, 1, &state.GLOBAL_EXIT_ROOT_POS_1)
 		if err != nil {


### PR DESCRIPTION
we reading the batch end for the next batch rather than the current one.

updated utility to use the block number rather than +1 as this is how the witness uses it and we'd have serious problems if that didn't work as expected.