### PR TITLE
write the batch fork id when we detect an upgrade

### DIFF
--- a/smt/pkg/smt/smt_create.go
+++ b/smt/pkg/smt/smt_create.go
@@ -64,7 +64,7 @@ func (s *SMT) GenerateFromKVBulk(ctx context.Context, logPrefix string, nodeKeys
 
 	maxReachedLevel := 0
 
-	deletesWorker := utils.NewWorker(ctx, "smt_save_finished", 1000)
+	deletesWorker := utils.NewWorker(ctx, "smt_save_finished", 5)
 
 	// start a worker to delete finished parts of the tree and return values to save to the db
 	wg := sync.WaitGroup{}

--- a/zk/legacy_executor_verifier/legacy_executor_verifier.go
+++ b/zk/legacy_executor_verifier/legacy_executor_verifier.go
@@ -443,7 +443,7 @@ func (v *LegacyExecutorVerifier) GetWholeBatchStreamBytes(
 		txsPerBlock[blockNumber] = filteredTransactions
 	}
 
-	entries, err := server.BuildWholeBatchStreamEntriesProto(tx, hermezDb, v.streamServer.GetChainId(), batchNumber, previousBatch, blocks, txsPerBlock, l1InfoTreeMinTimestamps)
+	entries, err := server.BuildWholeBatchStreamEntriesProto(tx, hermezDb, v.streamServer.GetChainId(), previousBatch, batchNumber, blocks, txsPerBlock, l1InfoTreeMinTimestamps)
 	if err != nil {
 		return nil, err
 	}

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -204,11 +204,6 @@ func prepareForkId(lastBatch, executionAt uint64, hermezDb forkDb) (uint64, erro
 		if err := hermezDb.WriteForkIdBlockOnce(latest, executionAt+1); err != nil {
 			return latest, err
 		}
-		// write the fork id for this batch now so that the remote executor receives
-		// the correct fork id for the batch
-		if err = hermezDb.WriteForkId(nextBatch, latest); err != nil {
-			return latest, err
-		}
 	}
 
 	return latest, nil

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -204,6 +204,11 @@ func prepareForkId(lastBatch, executionAt uint64, hermezDb forkDb) (uint64, erro
 		if err := hermezDb.WriteForkIdBlockOnce(latest, executionAt+1); err != nil {
 			return latest, err
 		}
+		// write the fork id for this batch now so that the remote executor receives
+		// the correct fork id for the batch
+		if err = hermezDb.WriteForkId(nextBatch, latest); err != nil {
+			return latest, err
+		}
 	}
 
 	return latest, nil


### PR DESCRIPTION
without this we use the previous fork when sending this first batch in the new fork id to the executors.

tested with a cardona shadowfork and integration server executor.