### PR TITLE
chore: enhance zkevm flags

### DIFF
--- a/cmd/hack/hack_zkevm.go
+++ b/cmd/hack/hack_zkevm.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	ethereum "github.com/ledgerwatch/erigon"
+	"sort"
+	"strings"
+
 	libcommon "github.com/gateway-fm/cdk-erigon-lib/common"
 	"github.com/gateway-fm/cdk-erigon-lib/kv"
 	"github.com/gateway-fm/cdk-erigon-lib/kv/mdbx"
+	ethereum "github.com/ledgerwatch/erigon"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/zkevm/etherman"
-	"sort"
-	"strings"
 )
 
 func formatBucketKVPair(k, v []byte, bucket string) string {
@@ -116,7 +117,7 @@ func newEtherMan(cfg *ethconfig.Zk) *etherman.Client {
 		L1ChainID:                 cfg.L1ChainId,
 		L2ChainID:                 cfg.L2ChainId,
 		PoEAddr:                   cfg.AddressRollupManager,
-		MaticAddr:                 cfg.L1MaticContractAddress,
+		MaticAddr:                 cfg.MaticContractAddress,
 		GlobalExitRootManagerAddr: cfg.AddressGerManager,
 	}
 

--- a/cmd/hack/hack_zkevm.go
+++ b/cmd/hack/hack_zkevm.go
@@ -115,7 +115,7 @@ func newEtherMan(cfg *ethconfig.Zk) *etherman.Client {
 		URL:                       cfg.L1RpcUrl,
 		L1ChainID:                 cfg.L1ChainId,
 		L2ChainID:                 cfg.L2ChainId,
-		PoEAddr:                   cfg.AddressRollup,
+		PoEAddr:                   cfg.AddressRollupManager,
 		MaticAddr:                 cfg.L1MaticContractAddress,
 		GlobalExitRootManagerAddr: cfg.AddressGerManager,
 	}

--- a/cmd/rpcdaemon/commands/zkevm_api.go
+++ b/cmd/rpcdaemon/commands/zkevm_api.go
@@ -695,7 +695,7 @@ func (api *ZkEvmAPIImpl) GetBatchByNumber(ctx context.Context, batchNumber rpc.B
 	}
 	batch.BatchL2Data = batchL2Data
 
-	oldAccInputHash, err := api.l1Syncer.GetOldAccInputHash(ctx, &api.config.AddressRollup, api.config.L1RollupId, batchNo)
+	oldAccInputHash, err := api.l1Syncer.GetOldAccInputHash(ctx, &api.config.AddressRollupManager, api.config.L1RollupId, batchNo)
 	if err != nil {
 		log.Warn("Failed to get old acc input hash", "err", err)
 		batch.AccInputHash = common.Hash{}
@@ -1067,7 +1067,7 @@ func (api *ZkEvmAPIImpl) GetProverInput(ctx context.Context, batchNumber uint64,
 		return nil, err
 	}
 
-	oldAccInputHash, err := api.l1Syncer.GetOldAccInputHash(ctx, &api.config.AddressRollup, api.config.L1RollupId, batchNumber)
+	oldAccInputHash, err := api.l1Syncer.GetOldAccInputHash(ctx, &api.config.AddressRollupManager, api.config.L1RollupId, batchNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/zkevm_api.go
+++ b/cmd/rpcdaemon/commands/zkevm_api.go
@@ -695,7 +695,7 @@ func (api *ZkEvmAPIImpl) GetBatchByNumber(ctx context.Context, batchNumber rpc.B
 	}
 	batch.BatchL2Data = batchL2Data
 
-	oldAccInputHash, err := api.l1Syncer.GetOldAccInputHash(ctx, &api.config.AddressRollupManager, api.config.L1RollupId, batchNo)
+	oldAccInputHash, err := api.l1Syncer.GetOldAccInputHash(ctx, &api.config.AddressRollupManager, api.config.RollupId, batchNo)
 	if err != nil {
 		log.Warn("Failed to get old acc input hash", "err", err)
 		batch.AccInputHash = common.Hash{}
@@ -1067,7 +1067,7 @@ func (api *ZkEvmAPIImpl) GetProverInput(ctx context.Context, batchNumber uint64,
 		return nil, err
 	}
 
-	oldAccInputHash, err := api.l1Syncer.GetOldAccInputHash(ctx, &api.config.AddressRollupManager, api.config.L1RollupId, batchNumber)
+	oldAccInputHash, err := api.l1Syncer.GetOldAccInputHash(ctx, &api.config.AddressRollupManager, api.config.RollupId, batchNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/zkevm_api_test.go
+++ b/cmd/rpcdaemon/commands/zkevm_api_test.go
@@ -376,7 +376,7 @@ func TestGetBatchByNumber(t *testing.T) {
 		"latest",
 	)
 	cfg := &ethconfig.Defaults
-	cfg.Zk.L1RollupId = 1
+	cfg.Zk.RollupId = 1
 	zkEvmImpl := NewZkEvmAPI(ethImpl, db, 100_000, &ethconfig.Defaults, l1Syncer, "")
 	tx, err := db.BeginRw(ctx)
 	assert.NoError(err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -425,9 +425,9 @@ var (
 		Usage: "Ger Manager address",
 		Value: "",
 	}
-	L1RollupIdFlag = cli.Uint64Flag{
-		Name:  "zkevm.l1-rollup-id",
-		Usage: "Ethereum L1 Rollup ID",
+	RollupIdFlag = cli.Uint64Flag{
+		Name:  "zkevm.rollup-id",
+		Usage: "Rollup ID",
 		Value: 1,
 	}
 	L1BlockRangeFlag = cli.Uint64Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -402,27 +402,27 @@ var (
 	}
 	AddressSequencerFlag = cli.StringFlag{
 		Name:  "zkevm.address-sequencer",
-		Usage: "Sequencer address",
+		Usage: "The sequencer EOA address on L1",
 		Value: "",
 	}
 	AddressAdminFlag = cli.StringFlag{
 		Name:  "zkevm.address-admin",
-		Usage: "Admin address",
+		Usage: "The admin EOA address on L1",
 		Value: "",
 	}
 	AddressRollupManagerFlag = cli.StringFlag{
 		Name:  "zkevm.address-rollup-manager",
-		Usage: "Rollup manager address",
+		Usage: "The rollup manager contract address",
 		Value: "",
 	}
 	AddressRollupFlag = cli.StringFlag{
 		Name:  "zkevm.address-rollup",
-		Usage: "Rollup address",
+		Usage: "The rollup contract address",
 		Value: "",
 	}
 	AddressGerManagerFlag = cli.StringFlag{
 		Name:  "zkevm.address-ger-manager",
-		Usage: "Ger Manager address",
+		Usage: "The gloabl exit root manager contract address",
 		Value: "",
 	}
 	RollupIdFlag = cli.Uint64Flag{
@@ -448,7 +448,7 @@ var (
 	}
 	L1MaticContractAddressFlag = cli.StringFlag{
 		Name:  "zkevm.address-matic",
-		Usage: "Matic contract address",
+		Usage: "The MATIC contract address on L1",
 		Value: "0x0",
 	}
 	L1FirstBlockFlag = cli.Uint64Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -432,13 +432,13 @@ var (
 	}
 	L1BlockRangeFlag = cli.Uint64Flag{
 		Name:  "zkevm.l1-block-range",
-		Usage: "Ethereum L1 block range used to filter verifications and sequences",
+		Usage: "Ethereum L1 block range used to filter verifications and sequences, in milliseconds",
 		Value: 20000,
 	}
 	L1QueryDelayFlag = cli.Uint64Flag{
 		Name:     "zkevm.l1-query-delay",
 		Required: false,
-		Usage:    "Ethereum L1 delay between queries for verifications and sequences - in milliseconds",
+		Usage:    "Ethereum L1 delay between queries for verifications and sequences, in milliseconds",
 		Value:    6000,
 	}
 	L1HighestBlockTypeFlag = cli.StringFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -415,9 +415,9 @@ var (
 		Usage: "Rollup manager address",
 		Value: "",
 	}
-	AddressZkevmFlag = cli.StringFlag{
-		Name:  "zkevm.address-zkevm",
-		Usage: "Zkevm address",
+	AddressRollupFlag = cli.StringFlag{
+		Name:  "zkevm.address-rollup",
+		Usage: "Rollup address",
 		Value: "",
 	}
 	AddressGerManagerFlag = cli.StringFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -447,8 +447,8 @@ var (
 		Value: "finalized",
 	}
 	L1MaticContractAddressFlag = cli.StringFlag{
-		Name:  "zkevm.l1-matic-contract-address",
-		Usage: "Ethereum L1 Matic contract address",
+		Name:  "zkevm.address-matic",
+		Usage: "Matic contract address",
 		Value: "0x0",
 	}
 	L1FirstBlockFlag = cli.Uint64Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -410,9 +410,9 @@ var (
 		Usage: "Admin address",
 		Value: "",
 	}
-	AddressRollupFlag = cli.StringFlag{
-		Name:  "zkevm.address-rollup",
-		Usage: "Rollup address",
+	AddressRollupManagerFlag = cli.StringFlag{
+		Name:  "zkevm.address-rollup-manager",
+		Usage: "Rollup manager address",
 		Value: "",
 	}
 	AddressZkevmFlag = cli.StringFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -446,7 +446,7 @@ var (
 		Usage: "The type of the highest block in the L1 chain. latest, safe, or finalized",
 		Value: "finalized",
 	}
-	L1MaticContractAddressFlag = cli.StringFlag{
+	MaticContractAddressFlag = cli.StringFlag{
 		Name:  "zkevm.address-matic",
 		Usage: "The MATIC contract address on L1",
 		Value: "0x0",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -804,8 +804,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			contracts.VerificationTopicEtrog,
 			contracts.VerificationValidiumTopicEtrog,
 		}}
-
-		seqAndVerifL1Contracts := []libcommon.Address{cfg.AddressRollupManager, cfg.AddressAdmin, cfg.AddressZkevm}
+		seqAndVerifL1Contracts := []libcommon.Address{cfg.AddressAdmin, cfg.AddressRollupManager, cfg.AddressRollup}
 
 		var l1Topics [][]libcommon.Hash
 		var l1Contracts []libcommon.Address
@@ -816,7 +815,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 				contracts.CreateNewRollupTopic,
 				contracts.UpdateRollupTopic,
 			}}
-			l1Contracts = []libcommon.Address{cfg.AddressZkevm, cfg.AddressRollupManager}
+			l1Contracts = []libcommon.Address{cfg.AddressRollupManager, cfg.AddressRollup}
 		} else {
 			l1Topics = seqAndVerifTopics
 			l1Contracts = seqAndVerifL1Contracts
@@ -918,7 +917,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			l1BlockSyncer := syncer.NewL1Syncer(
 				ctx,
 				ethermanClients,
-				[]libcommon.Address{cfg.AddressZkevm, cfg.AddressRollupManager},
+				[]libcommon.Address{cfg.AddressRollup, cfg.AddressRollupManager},
 				[][]libcommon.Hash{{
 					contracts.SequenceBatchesTopic,
 				}},
@@ -1556,7 +1555,7 @@ func checkPortIsFree(addr string) (free bool) {
 }
 
 func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSyncer *syncer.L1Syncer) (bool, error) {
-	l1AddrRollup, err := l1BlockSyncer.CallRollupManager(ctx, &cfg.AddressZkevm)
+	l1AddrRollup, err := l1BlockSyncer.CallRollupManager(ctx, &cfg.AddressRollup)
 	if err != nil {
 		return false, err
 	}
@@ -1565,7 +1564,7 @@ func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSynce
 		return false, nil
 	}
 
-	l1AddrAdmin, err := l1BlockSyncer.CallAdmin(ctx, &cfg.AddressZkevm)
+	l1AddrAdmin, err := l1BlockSyncer.CallAdmin(ctx, &cfg.AddressRollup)
 	if err != nil {
 		return false, err
 	}
@@ -1574,7 +1573,7 @@ func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSynce
 		return false, nil
 	}
 
-	l1AddrGerManager, err := l1BlockSyncer.CallGlobalExitRootManager(ctx, &cfg.AddressZkevm)
+	l1AddrGerManager, err := l1BlockSyncer.CallGlobalExitRootManager(ctx, &cfg.AddressRollup)
 	if err != nil {
 		return false, err
 	}
@@ -1583,7 +1582,7 @@ func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSynce
 		return false, nil
 	}
 
-	l1AddrSequencer, err := l1BlockSyncer.CallTrustedSequencer(ctx, &cfg.AddressZkevm)
+	l1AddrSequencer, err := l1BlockSyncer.CallTrustedSequencer(ctx, &cfg.AddressRollup)
 	if err != nil {
 		return false, err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1037,7 +1037,7 @@ func newEtherMan(cfg *ethconfig.Config, l2ChainName, url string) *etherman.Clien
 		L2ChainID:                 cfg.L2ChainId,
 		L2ChainName:               l2ChainName,
 		PoEAddr:                   cfg.AddressRollupManager,
-		MaticAddr:                 cfg.L1MaticContractAddress,
+		MaticAddr:                 cfg.MaticContractAddress,
 		GlobalExitRootManagerAddr: cfg.AddressGerManager,
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1555,12 +1555,12 @@ func checkPortIsFree(addr string) (free bool) {
 }
 
 func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSyncer *syncer.L1Syncer) (bool, error) {
-	l1AddrRollup, err := l1BlockSyncer.CallRollupManager(ctx, &cfg.AddressRollup)
+	l1AddrRollupManager, err := l1BlockSyncer.CallRollupManager(ctx, &cfg.AddressRollup)
 	if err != nil {
 		return false, err
 	}
-	if l1AddrRollup != cfg.AddressRollupManager {
-		log.Warn("L1 contract address check failed (AddressRollupManager)", "expected", cfg.AddressRollupManager, "actual", l1AddrRollup)
+	if l1AddrRollupManager != cfg.AddressRollupManager {
+		log.Warn("L1 contract address check failed (AddressRollupManager)", "expected", cfg.AddressRollupManager, "actual", l1AddrRollupManager)
 		return false, nil
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -805,7 +805,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			contracts.VerificationValidiumTopicEtrog,
 		}}
 
-		seqAndVerifL1Contracts := []libcommon.Address{cfg.AddressRollup, cfg.AddressAdmin, cfg.AddressZkevm}
+		seqAndVerifL1Contracts := []libcommon.Address{cfg.AddressRollupManager, cfg.AddressAdmin, cfg.AddressZkevm}
 
 		var l1Topics [][]libcommon.Hash
 		var l1Contracts []libcommon.Address
@@ -816,7 +816,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 				contracts.CreateNewRollupTopic,
 				contracts.UpdateRollupTopic,
 			}}
-			l1Contracts = []libcommon.Address{cfg.AddressZkevm, cfg.AddressRollup}
+			l1Contracts = []libcommon.Address{cfg.AddressZkevm, cfg.AddressRollupManager}
 		} else {
 			l1Topics = seqAndVerifTopics
 			l1Contracts = seqAndVerifL1Contracts
@@ -918,7 +918,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			l1BlockSyncer := syncer.NewL1Syncer(
 				ctx,
 				ethermanClients,
-				[]libcommon.Address{cfg.AddressZkevm, cfg.AddressRollup},
+				[]libcommon.Address{cfg.AddressZkevm, cfg.AddressRollupManager},
 				[][]libcommon.Hash{{
 					contracts.SequenceBatchesTopic,
 				}},
@@ -1037,7 +1037,7 @@ func newEtherMan(cfg *ethconfig.Config, l2ChainName, url string) *etherman.Clien
 		L1ChainID:                 cfg.L1ChainId,
 		L2ChainID:                 cfg.L2ChainId,
 		L2ChainName:               l2ChainName,
-		PoEAddr:                   cfg.AddressRollup,
+		PoEAddr:                   cfg.AddressRollupManager,
 		MaticAddr:                 cfg.L1MaticContractAddress,
 		GlobalExitRootManagerAddr: cfg.AddressGerManager,
 	}
@@ -1560,8 +1560,8 @@ func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSynce
 	if err != nil {
 		return false, err
 	}
-	if l1AddrRollup != cfg.AddressRollup {
-		log.Warn("L1 contract address check failed (AddressRollup)", "expected", cfg.AddressRollup, "actual", l1AddrRollup)
+	if l1AddrRollup != cfg.AddressRollupManager {
+		log.Warn("L1 contract address check failed (AddressRollupManager)", "expected", cfg.AddressRollupManager, "actual", l1AddrRollup)
 		return false, nil
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -846,7 +846,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			cfg.L1HighestBlockType,
 		)
 
-		log.Info("Rollup ID", "rollupId", cfg.L1RollupId)
+		log.Info("Rollup ID", "rollupId", cfg.RollupId)
 
 		// check contract addresses in config against L1
 		if cfg.Zk.L1ContractAddressCheck {

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -18,7 +18,7 @@ type Zk struct {
 	L1RpcUrl                               string
 	AddressSequencer                       common.Address
 	AddressAdmin                           common.Address
-	AddressRollup                          common.Address
+	AddressRollupManager                   common.Address
 	AddressZkevm                           common.Address
 	AddressGerManager                      common.Address
 	L1ContractAddressCheck                 bool

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -22,7 +22,7 @@ type Zk struct {
 	AddressRollup                          common.Address
 	AddressGerManager                      common.Address
 	L1ContractAddressCheck                 bool
-	L1RollupId                             uint64
+	RollupId                               uint64
 	L1BlockRange                           uint64
 	L1QueryDelay                           uint64
 	L1HighestBlockType                     string

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -26,7 +26,7 @@ type Zk struct {
 	L1BlockRange                           uint64
 	L1QueryDelay                           uint64
 	L1HighestBlockType                     string
-	L1MaticContractAddress                 common.Address
+	MaticContractAddress                   common.Address
 	L1FirstBlock                           uint64
 	L1FinalizedBlockRequirement            uint64
 	L1CacheEnabled                         bool

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -19,7 +19,7 @@ type Zk struct {
 	AddressSequencer                       common.Address
 	AddressAdmin                           common.Address
 	AddressRollupManager                   common.Address
-	AddressZkevm                           common.Address
+	AddressRollup                          common.Address
 	AddressGerManager                      common.Address
 	L1ContractAddressCheck                 bool
 	L1RollupId                             uint64

--- a/hermezconfig-bali.yaml.example
+++ b/hermezconfig-bali.yaml.example
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: https://rpc.sepolia.org
 zkevm.address-sequencer: "0x9aeCf44E36f20DC407d1A580630c9a2419912dcB"
 zkevm.address-zkevm: "0x89BA0Ed947a88fe43c22Ae305C0713eC8a7Eb361"
 zkevm.address-admin: "0x229A5bDBb09d8555f9214F7a6784804999BA4E0D"
-zkevm.address-rollup: "0xE2EF6215aDc132Df6913C8DD16487aBF118d1764"
+zkevm.address-rollup-manager: "0xE2EF6215aDc132Df6913C8DD16487aBF118d1764"
 zkevm.address-ger-manager: "0x2968D6d736178f8FE7393CC33C87f29D9C287e78"
 
 zkevm.default-gas-price: 1000000000

--- a/hermezconfig-bali.yaml.example
+++ b/hermezconfig-bali.yaml.example
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: https://rpc.sepolia.org
 
 zkevm.address-sequencer: "0x9aeCf44E36f20DC407d1A580630c9a2419912dcB"
-zkevm.address-zkevm: "0x89BA0Ed947a88fe43c22Ae305C0713eC8a7Eb361"
+zkevm.address-rollup: "0x89BA0Ed947a88fe43c22Ae305C0713eC8a7Eb361"
 zkevm.address-admin: "0x229A5bDBb09d8555f9214F7a6784804999BA4E0D"
 zkevm.address-rollup-manager: "0xE2EF6215aDc132Df6913C8DD16487aBF118d1764"
 zkevm.address-ger-manager: "0x2968D6d736178f8FE7393CC33C87f29D9C287e78"

--- a/hermezconfig-bali.yaml.example
+++ b/hermezconfig-bali.yaml.example
@@ -18,7 +18,7 @@ zkevm.default-gas-price: 1000000000
 zkevm.max-gas-price: 0
 zkevm.gas-price-factor: 0.12
 
-zkevm.l1-rollup-id: 1
+zkevm.rollup-id: 1
 zkevm.l1-first-block: 4794475
 zkevm.rpc-ratelimit: 250
 txpool.disable: true

--- a/hermezconfig-cardona.yaml.example
+++ b/hermezconfig-cardona.yaml.example
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: https://rpc.sepolia.org
 
 zkevm.address-sequencer: "0x761d53b47334bee6612c0bd1467fb881435375b2"
-zkevm.address-zkevm: "0xA13Ddb14437A8F34897131367ad3ca78416d6bCa"
+zkevm.address-rollup: "0xA13Ddb14437A8F34897131367ad3ca78416d6bCa"
 zkevm.address-admin: "0xff6250d0e86a2465b0c1bf8e36409503d6a26963"
 zkevm.address-rollup-manager: "0x32d33d5137a7cffb54c5bf8371172bcec5f310ff"
 zkevm.address-ger-manager: "0xAd1490c248c5d3CbAE399Fd529b79B42984277DF"

--- a/hermezconfig-cardona.yaml.example
+++ b/hermezconfig-cardona.yaml.example
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: https://rpc.sepolia.org
 zkevm.address-sequencer: "0x761d53b47334bee6612c0bd1467fb881435375b2"
 zkevm.address-zkevm: "0xA13Ddb14437A8F34897131367ad3ca78416d6bCa"
 zkevm.address-admin: "0xff6250d0e86a2465b0c1bf8e36409503d6a26963"
-zkevm.address-rollup: "0x32d33d5137a7cffb54c5bf8371172bcec5f310ff"
+zkevm.address-rollup-manager: "0x32d33d5137a7cffb54c5bf8371172bcec5f310ff"
 zkevm.address-ger-manager: "0xAd1490c248c5d3CbAE399Fd529b79B42984277DF"
 
 zkevm.default-gas-price: 1000000000

--- a/hermezconfig-cardona.yaml.example
+++ b/hermezconfig-cardona.yaml.example
@@ -18,7 +18,7 @@ zkevm.default-gas-price: 1000000000
 zkevm.max-gas-price: 0
 zkevm.gas-price-factor: 0.12
 
-zkevm.l1-rollup-id: 1
+zkevm.rollup-id: 1
 zkevm.l1-block-range: 20000
 zkevm.l1-query-delay: 6000
 zkevm.l1-first-block: 4789190

--- a/hermezconfig-dev.yaml.example
+++ b/hermezconfig-dev.yaml.example
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: https://rpc.eu-central-1.gateway.fm/v4/ethereum/non-archival/sepolia?apikey=IkrTRMPAlsjfgTyKz1Xfa5ldS8XSc0PN.En5aU2Gwdxvf3zk2
 
 zkevm.address-sequencer: "0xfa3b44587990f97ba8b6ba7e230a5f0e95d14b3d"
-zkevm.address-zkevm: "0x31A6ae85297DD0EeBD66D7556941c33Bd41d565C"
+zkevm.address-rollup: "0x31A6ae85297DD0EeBD66D7556941c33Bd41d565C"
 zkevm.address-admin: "0x9EA9db6af0FEfd30d22F813bE32E4E17A3189E6a"
 zkevm.address-rollup-manager: "0x9fB0B4A5d4d60aaCfa8DC20B8DF5528Ab26848d3"
 zkevm.address-ger-manager: "0x76216E45Bdd20022eEcC07999e50228d7829534B"

--- a/hermezconfig-dev.yaml.example
+++ b/hermezconfig-dev.yaml.example
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: https://rpc.eu-central-1.gateway.fm/v4/ethereum/non-archival/s
 zkevm.address-sequencer: "0xfa3b44587990f97ba8b6ba7e230a5f0e95d14b3d"
 zkevm.address-zkevm: "0x31A6ae85297DD0EeBD66D7556941c33Bd41d565C"
 zkevm.address-admin: "0x9EA9db6af0FEfd30d22F813bE32E4E17A3189E6a"
-zkevm.address-rollup: "0x9fB0B4A5d4d60aaCfa8DC20B8DF5528Ab26848d3"
+zkevm.address-rollup-manager: "0x9fB0B4A5d4d60aaCfa8DC20B8DF5528Ab26848d3"
 zkevm.address-ger-manager: "0x76216E45Bdd20022eEcC07999e50228d7829534B"
 
 zkevm.l1-block-range: 20000

--- a/hermezconfig-estest-syncer.yaml.example
+++ b/hermezconfig-estest-syncer.yaml.example
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: "https://rpc.eu-central-1.gateway.fm/v4/ethereum/non-archival/
 zkevm.address-sequencer: "0x7597b12b953bffe1457d89e7e4fe3da149b45d88"
 zkevm.address-zkevm: "0x9b2e7dC74B5a1Ecb894F0BAAe99a9F3CB60FC455"
 zkevm.address-admin: "0xa0ee057f2746d3282a10b8cd26a351b5ca121e8d"
-zkevm.address-rollup: "0x7DFba61a337741a3d2F99Cc73069c9D0De8aa933"
+zkevm.address-rollup-manager: "0x7DFba61a337741a3d2F99Cc73069c9D0De8aa933"
 zkevm.address-ger-manager: "0x0FE6A2FcF455b9B8004fd625909857933d3c7494"
 
 zkevm.l1-block-range: 20000

--- a/hermezconfig-estest-syncer.yaml.example
+++ b/hermezconfig-estest-syncer.yaml.example
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: "https://rpc.eu-central-1.gateway.fm/v4/ethereum/non-archival/sepolia?apikey=IkrTRMPAlsjfgTyKz1Xfa5ldS8XSc0PN.En5aU2Gwdxvf3zk2"
 
 zkevm.address-sequencer: "0x7597b12b953bffe1457d89e7e4fe3da149b45d88"
-zkevm.address-zkevm: "0x9b2e7dC74B5a1Ecb894F0BAAe99a9F3CB60FC455"
+zkevm.address-rollup: "0x9b2e7dC74B5a1Ecb894F0BAAe99a9F3CB60FC455"
 zkevm.address-admin: "0xa0ee057f2746d3282a10b8cd26a351b5ca121e8d"
 zkevm.address-rollup-manager: "0x7DFba61a337741a3d2F99Cc73069c9D0De8aa933"
 zkevm.address-ger-manager: "0x0FE6A2FcF455b9B8004fd625909857933d3c7494"

--- a/hermezconfig-mainnet-shadowfork.yaml.example
+++ b/hermezconfig-mainnet-shadowfork.yaml.example
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: https://rpc.eu-central-1.gateway.fm/v4/ethereum/non-archival/sepolia?apikey=IkrTRMPAlsjfgTyKz1Xfa5ldS8XSc0PN.En5aU2Gwdxvf3zk2
 
 zkevm.address-sequencer: ""
-zkevm.address-zkevm: ""
+zkevm.address-rollup: ""
 zkevm.address-admin: "0x9fB0B4A5d4d60aaCfa8DC20B8DF5528Ab26848d3"
 zkevm.address-rollup-manager: "0x31A6ae85297DD0EeBD66D7556941c33Bd41d565C"
 zkevm.address-ger-manager: "0x76216E45Bdd20022eEcC07999e50228d7829534B"

--- a/hermezconfig-mainnet-shadowfork.yaml.example
+++ b/hermezconfig-mainnet-shadowfork.yaml.example
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: https://rpc.eu-central-1.gateway.fm/v4/ethereum/non-archival/s
 zkevm.address-sequencer: ""
 zkevm.address-zkevm: ""
 zkevm.address-admin: "0x9fB0B4A5d4d60aaCfa8DC20B8DF5528Ab26848d3"
-zkevm.address-rollup: "0x31A6ae85297DD0EeBD66D7556941c33Bd41d565C"
+zkevm.address-rollup-manager: "0x31A6ae85297DD0EeBD66D7556941c33Bd41d565C"
 zkevm.address-ger-manager: "0x76216E45Bdd20022eEcC07999e50228d7829534B"
 
 zkevm.l1-block-range: 20000

--- a/hermezconfig-mainnet.yaml.example
+++ b/hermezconfig-mainnet.yaml.example
@@ -18,7 +18,7 @@ zkevm.default-gas-price: 1000000000
 zkevm.max-gas-price: 0
 zkevm.gas-price-factor: 0.0375
 
-zkevm.l1-rollup-id: 1
+zkevm.rollup-id: 1
 zkevm.l1-block-range: 20000
 zkevm.l1-query-delay: 6000
 zkevm.l1-first-block: 16896700

--- a/hermezconfig-mainnet.yaml.example
+++ b/hermezconfig-mainnet.yaml.example
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: https://rpc.eth.gateway.fm/
 zkevm.address-sequencer: "0x148Ee7dAF16574cD020aFa34CC658f8F3fbd2800"
 zkevm.address-zkevm: "0x519E42c24163192Dca44CD3fBDCEBF6be9130987"
 zkevm.address-admin: "0x242daE44F5d8fb54B198D03a94dA45B5a4413e21"
-zkevm.address-rollup: "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
+zkevm.address-rollup-manager: "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
 zkevm.address-ger-manager: "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb"
 
 zkevm.default-gas-price: 1000000000

--- a/hermezconfig-mainnet.yaml.example
+++ b/hermezconfig-mainnet.yaml.example
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 1
 zkevm.l1-rpc-url: https://rpc.eth.gateway.fm/
 
 zkevm.address-sequencer: "0x148Ee7dAF16574cD020aFa34CC658f8F3fbd2800"
-zkevm.address-zkevm: "0x519E42c24163192Dca44CD3fBDCEBF6be9130987"
+zkevm.address-rollup: "0x519E42c24163192Dca44CD3fBDCEBF6be9130987"
 zkevm.address-admin: "0x242daE44F5d8fb54B198D03a94dA45B5a4413e21"
 zkevm.address-rollup-manager: "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
 zkevm.address-ger-manager: "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb"

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -184,7 +184,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.L1BlockRangeFlag,
 	&utils.L1QueryDelayFlag,
 	&utils.L1HighestBlockTypeFlag,
-	&utils.L1MaticContractAddressFlag,
+	&utils.MaticContractAddressFlag,
 	&utils.L1FirstBlockFlag,
 	&utils.L1FinalizedBlockRequirementFlag,
 	&utils.L1ContractAddressCheckFlag,

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -180,7 +180,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.AddressRollupManagerFlag,
 	&utils.AddressRollupFlag,
 	&utils.AddressGerManagerFlag,
-	&utils.L1RollupIdFlag,
+	&utils.RollupIdFlag,
 	&utils.L1BlockRangeFlag,
 	&utils.L1QueryDelayFlag,
 	&utils.L1HighestBlockTypeFlag,

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -177,7 +177,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.L1CachePortFlag,
 	&utils.AddressSequencerFlag,
 	&utils.AddressAdminFlag,
-	&utils.AddressRollupFlag,
+	&utils.AddressRollupManagerFlag,
 	&utils.AddressZkevmFlag,
 	&utils.AddressGerManagerFlag,
 	&utils.L1RollupIdFlag,

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -178,7 +178,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.AddressSequencerFlag,
 	&utils.AddressAdminFlag,
 	&utils.AddressRollupManagerFlag,
-	&utils.AddressZkevmFlag,
+	&utils.AddressRollupFlag,
 	&utils.AddressGerManagerFlag,
 	&utils.L1RollupIdFlag,
 	&utils.L1BlockRangeFlag,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -120,7 +120,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		L1CachePort:                            ctx.Uint(utils.L1CachePortFlag.Name),
 		AddressSequencer:                       libcommon.HexToAddress(ctx.String(utils.AddressSequencerFlag.Name)),
 		AddressAdmin:                           libcommon.HexToAddress(ctx.String(utils.AddressAdminFlag.Name)),
-		AddressRollup:                          libcommon.HexToAddress(ctx.String(utils.AddressRollupFlag.Name)),
+		AddressRollupManager:                        libcommon.HexToAddress(ctx.String(utils.AddressRollupManagerFlag.Name)),
 		AddressZkevm:                           libcommon.HexToAddress(ctx.String(utils.AddressZkevmFlag.Name)),
 		AddressGerManager:                      libcommon.HexToAddress(ctx.String(utils.AddressGerManagerFlag.Name)),
 		L1RollupId:                             ctx.Uint64(utils.L1RollupIdFlag.Name),
@@ -211,7 +211,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 
 	checkFlag(utils.AddressSequencerFlag.Name, cfg.AddressSequencer)
 	checkFlag(utils.AddressAdminFlag.Name, cfg.AddressAdmin)
-	checkFlag(utils.AddressRollupFlag.Name, cfg.AddressRollup)
+	checkFlag(utils.AddressRollupManagerFlag.Name, cfg.AddressRollupManager)
 	checkFlag(utils.AddressZkevmFlag.Name, cfg.AddressZkevm)
 	checkFlag(utils.AddressGerManagerFlag.Name, cfg.AddressGerManager)
 

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -127,7 +127,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		L1BlockRange:                           ctx.Uint64(utils.L1BlockRangeFlag.Name),
 		L1QueryDelay:                           ctx.Uint64(utils.L1QueryDelayFlag.Name),
 		L1HighestBlockType:                     ctx.String(utils.L1HighestBlockTypeFlag.Name),
-		L1MaticContractAddress:                 libcommon.HexToAddress(ctx.String(utils.L1MaticContractAddressFlag.Name)),
+		MaticContractAddress:                   libcommon.HexToAddress(ctx.String(utils.MaticContractAddressFlag.Name)),
 		L1FirstBlock:                           ctx.Uint64(utils.L1FirstBlockFlag.Name),
 		L1FinalizedBlockRequirement:            ctx.Uint64(utils.L1FinalizedBlockRequirementFlag.Name),
 		L1ContractAddressCheck:                 ctx.Bool(utils.L1ContractAddressCheckFlag.Name),
@@ -217,7 +217,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 
 	checkFlag(utils.L1ChainIdFlag.Name, cfg.L1ChainId)
 	checkFlag(utils.L1RpcUrlFlag.Name, cfg.L1RpcUrl)
-	checkFlag(utils.L1MaticContractAddressFlag.Name, cfg.L1MaticContractAddress.Hex())
+	checkFlag(utils.MaticContractAddressFlag.Name, cfg.MaticContractAddress.Hex())
 	checkFlag(utils.L1FirstBlockFlag.Name, cfg.L1FirstBlock)
 	checkFlag(utils.RpcRateLimitsFlag.Name, cfg.RpcRateLimits)
 	checkFlag(utils.RpcGetBatchWitnessConcurrencyLimitFlag.Name, cfg.RpcGetBatchWitnessConcurrencyLimit)

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -123,7 +123,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		AddressRollupManager:                   libcommon.HexToAddress(ctx.String(utils.AddressRollupManagerFlag.Name)),
 		AddressRollup:                          libcommon.HexToAddress(ctx.String(utils.AddressRollupFlag.Name)),
 		AddressGerManager:                      libcommon.HexToAddress(ctx.String(utils.AddressGerManagerFlag.Name)),
-		L1RollupId:                             ctx.Uint64(utils.L1RollupIdFlag.Name),
+		RollupId:                               ctx.Uint64(utils.RollupIdFlag.Name),
 		L1BlockRange:                           ctx.Uint64(utils.L1BlockRangeFlag.Name),
 		L1QueryDelay:                           ctx.Uint64(utils.L1QueryDelayFlag.Name),
 		L1HighestBlockType:                     ctx.String(utils.L1HighestBlockTypeFlag.Name),

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -120,7 +120,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		L1CachePort:                            ctx.Uint(utils.L1CachePortFlag.Name),
 		AddressSequencer:                       libcommon.HexToAddress(ctx.String(utils.AddressSequencerFlag.Name)),
 		AddressAdmin:                           libcommon.HexToAddress(ctx.String(utils.AddressAdminFlag.Name)),
-		AddressRollupManager:                        libcommon.HexToAddress(ctx.String(utils.AddressRollupManagerFlag.Name)),
+		AddressRollupManager:                   libcommon.HexToAddress(ctx.String(utils.AddressRollupManagerFlag.Name)),
 		AddressZkevm:                           libcommon.HexToAddress(ctx.String(utils.AddressZkevmFlag.Name)),
 		AddressGerManager:                      libcommon.HexToAddress(ctx.String(utils.AddressGerManagerFlag.Name)),
 		L1RollupId:                             ctx.Uint64(utils.L1RollupIdFlag.Name),

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -121,7 +121,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		AddressSequencer:                       libcommon.HexToAddress(ctx.String(utils.AddressSequencerFlag.Name)),
 		AddressAdmin:                           libcommon.HexToAddress(ctx.String(utils.AddressAdminFlag.Name)),
 		AddressRollupManager:                   libcommon.HexToAddress(ctx.String(utils.AddressRollupManagerFlag.Name)),
-		AddressZkevm:                           libcommon.HexToAddress(ctx.String(utils.AddressZkevmFlag.Name)),
+		AddressRollup:                          libcommon.HexToAddress(ctx.String(utils.AddressRollupFlag.Name)),
 		AddressGerManager:                      libcommon.HexToAddress(ctx.String(utils.AddressGerManagerFlag.Name)),
 		L1RollupId:                             ctx.Uint64(utils.L1RollupIdFlag.Name),
 		L1BlockRange:                           ctx.Uint64(utils.L1BlockRangeFlag.Name),
@@ -212,7 +212,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	checkFlag(utils.AddressSequencerFlag.Name, cfg.AddressSequencer)
 	checkFlag(utils.AddressAdminFlag.Name, cfg.AddressAdmin)
 	checkFlag(utils.AddressRollupManagerFlag.Name, cfg.AddressRollupManager)
-	checkFlag(utils.AddressZkevmFlag.Name, cfg.AddressZkevm)
+	checkFlag(utils.AddressRollupFlag.Name, cfg.AddressRollup)
 	checkFlag(utils.AddressGerManagerFlag.Name, cfg.AddressGerManager)
 
 	checkFlag(utils.L1ChainIdFlag.Name, cfg.L1ChainId)

--- a/xlayerconfig-mainnet.yaml.example
+++ b/xlayerconfig-mainnet.yaml.example
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 1
 zkevm.l1-rpc-url: https://rpc.ankr.com/eth/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 zkevm.address-sequencer: "0xAF9d27ffe4d51eD54AC8eEc78f2785D7E11E5ab1"
-zkevm.address-zkevm: "0x2B0ee28D4D51bC9aDde5E58E295873F61F4a0507"
+zkevm.address-rollup: "0x2B0ee28D4D51bC9aDde5E58E295873F61F4a0507"
 zkevm.address-admin: "0x491619874b866c3cDB7C8553877da223525ead01"
 zkevm.address-rollup-manager: "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
 zkevm.address-ger-manager: "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb"

--- a/xlayerconfig-mainnet.yaml.example
+++ b/xlayerconfig-mainnet.yaml.example
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: https://rpc.ankr.com/eth/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 zkevm.address-sequencer: "0xAF9d27ffe4d51eD54AC8eEc78f2785D7E11E5ab1"
 zkevm.address-zkevm: "0x2B0ee28D4D51bC9aDde5E58E295873F61F4a0507"
 zkevm.address-admin: "0x491619874b866c3cDB7C8553877da223525ead01"
-zkevm.address-rollup: "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
+zkevm.address-rollup-manager: "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
 zkevm.address-ger-manager: "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb"
 
 zkevm.rollup-id: 3

--- a/xlayerconfig-mainnet.yaml.example
+++ b/xlayerconfig-mainnet.yaml.example
@@ -14,7 +14,7 @@ zkevm.address-admin: "0x491619874b866c3cDB7C8553877da223525ead01"
 zkevm.address-rollup: "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
 zkevm.address-ger-manager: "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb"
 
-zkevm.l1-rollup-id: 3
+zkevm.rollup-id: 3
 zkevm.l1-first-block: 19218658
 zkevm.l1-block-range: 2000
 zkevm.l1-query-delay: 1000

--- a/xlayerconfig-testnet.yaml.example
+++ b/xlayerconfig-testnet.yaml.example
@@ -14,7 +14,7 @@ zkevm.address-admin: "0xC432168eF74A83c6E6C76f2c1b42F875E1A223CD"
 zkevm.address-rollup: "0x6662621411A8DACC3cA7049C8BddABaa9a999ce3"
 zkevm.address-ger-manager: "0x66E61bA00F58b857A9DD2C500F3aBc424A46BD20"
 
-zkevm.l1-rollup-id: 1
+zkevm.rollup-id: 1
 zkevm.l1-first-block: 4648290
 zkevm.l1-block-range: 2000
 zkevm.l1-query-delay: 1000

--- a/xlayerconfig-testnet.yaml.example
+++ b/xlayerconfig-testnet.yaml.example
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: https://rpc.ankr.com/eth_sepolia/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 zkevm.address-sequencer: "0xD6DdA5AA7749142B7fDa3Fe4662C9f346101B8A6"
-zkevm.address-zkevm: "0x01469dACfDDA885D68Ff0f8628F2629c14F95a20"
+zkevm.address-rollup: "0x01469dACfDDA885D68Ff0f8628F2629c14F95a20"
 zkevm.address-admin: "0xC432168eF74A83c6E6C76f2c1b42F875E1A223CD"
 zkevm.address-rollup-manager: "0x6662621411A8DACC3cA7049C8BddABaa9a999ce3"
 zkevm.address-ger-manager: "0x66E61bA00F58b857A9DD2C500F3aBc424A46BD20"

--- a/xlayerconfig-testnet.yaml.example
+++ b/xlayerconfig-testnet.yaml.example
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: https://rpc.ankr.com/eth_sepolia/xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 zkevm.address-sequencer: "0xD6DdA5AA7749142B7fDa3Fe4662C9f346101B8A6"
 zkevm.address-zkevm: "0x01469dACfDDA885D68Ff0f8628F2629c14F95a20"
 zkevm.address-admin: "0xC432168eF74A83c6E6C76f2c1b42F875E1A223CD"
-zkevm.address-rollup: "0x6662621411A8DACC3cA7049C8BddABaa9a999ce3"
+zkevm.address-rollup-manager: "0x6662621411A8DACC3cA7049C8BddABaa9a999ce3"
 zkevm.address-ger-manager: "0x66E61bA00F58b857A9DD2C500F3aBc424A46BD20"
 
 zkevm.rollup-id: 1

--- a/zk/stages/stage_l1_sequencer_sync.go
+++ b/zk/stages/stage_l1_sequencer_sync.go
@@ -129,7 +129,7 @@ Loop:
 					}
 				case contracts.CreateNewRollupTopic:
 					rollupId := l.Topics[1].Big().Uint64()
-					if rollupId != cfg.zkCfg.L1RollupId {
+					if rollupId != cfg.zkCfg.RollupId {
 						continue
 					}
 					rollupTypeBytes := l.Data[0:32]
@@ -147,7 +147,7 @@ Loop:
 					}
 				case contracts.UpdateRollupTopic:
 					rollupId := l.Topics[1].Big().Uint64()
-					if rollupId != cfg.zkCfg.L1RollupId {
+					if rollupId != cfg.zkCfg.RollupId {
 						continue
 					}
 					newRollupBytes := l.Data[0:32]

--- a/zk/tests/nightly-l1-recovery/network5-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network5-config.yaml
@@ -1,18 +1,17 @@
-datadir : './datadir'
-chain : "dynamic-integration"
-http : true
-private.api.addr : "localhost:9096"
+datadir: "./datadir"
+chain: "dynamic-integration"
+http: true
+private.api.addr: "localhost:9096"
 zkevm.l2-chain-id: 8282
 zkevm.l2-sequencer-rpc-url: "http://34.175.214.161:8123"
 zkevm.l2-datastreamer-url: "34.175.214.161:6915"
 zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: "http://cache:6969?endpoint=https://rpc.sepolia.org&chainid=8282"
 
-
 zkevm.address-sequencer: "0xC9c0DDBAD778A58ac078975Cc7847dD1DEaF2B0A"
 zkevm.address-zkevm: "0x1FAC2D008A7987ED9Eb3eBCd2d95791cC341AB6f"
 zkevm.address-admin: "0x406C6e412895f32573442365d0BA5027ae369cC7"
-zkevm.address-rollup: "0xBFA50869D87f5Fdee35F60ab31Dc5a347ab6d7f4"
+zkevm.address-rollup-manager: "0xBFA50869D87f5Fdee35F60ab31Dc5a347ab6d7f4"
 zkevm.address-ger-manager: "0x3134D060b2b2B47477e8f75537B2047606c5a8cc"
 
 zkevm.l1-matic-contract-address: "0x0f25eE4CA85Db4362a9749782872c558873566e4"
@@ -39,11 +38,11 @@ log.console.verbosity: warn
 zkevm.l1-sync-start-block: 6032365
 
 externalcl: true
-http.api : ["eth","debug","net","trace","web3","erigon","txpool","zkevm"]
+http.api: ["eth", "debug", "net", "trace", "web3", "erigon", "txpool", "zkevm"]
 http.addr: "0.0.0.0"
 http.port: 8123
-http.vhosts: '*'
-http.corsdomain: '*'
+http.vhosts: "*"
+http.corsdomain: "*"
 
 ws: true
 rpc.batch.limit: 500

--- a/zk/tests/nightly-l1-recovery/network5-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network5-config.yaml
@@ -14,7 +14,7 @@ zkevm.address-admin: "0x406C6e412895f32573442365d0BA5027ae369cC7"
 zkevm.address-rollup-manager: "0xBFA50869D87f5Fdee35F60ab31Dc5a347ab6d7f4"
 zkevm.address-ger-manager: "0x3134D060b2b2B47477e8f75537B2047606c5a8cc"
 
-zkevm.l1-matic-contract-address: "0x0f25eE4CA85Db4362a9749782872c558873566e4"
+zkevm.address-matic: "0x0f25eE4CA85Db4362a9749782872c558873566e4"
 zkevm.l1-block-range: 20000
 zkevm.l1-query-delay: 6000
 zkevm.l1-first-block: 6032365

--- a/zk/tests/nightly-l1-recovery/network5-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network5-config.yaml
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: "http://cache:6969?endpoint=https://rpc.sepolia.org&chainid=8282"
 
 zkevm.address-sequencer: "0xC9c0DDBAD778A58ac078975Cc7847dD1DEaF2B0A"
-zkevm.address-zkevm: "0x1FAC2D008A7987ED9Eb3eBCd2d95791cC341AB6f"
+zkevm.address-rollup: "0x1FAC2D008A7987ED9Eb3eBCd2d95791cC341AB6f"
 zkevm.address-admin: "0x406C6e412895f32573442365d0BA5027ae369cC7"
 zkevm.address-rollup-manager: "0xBFA50869D87f5Fdee35F60ab31Dc5a347ab6d7f4"
 zkevm.address-ger-manager: "0x3134D060b2b2B47477e8f75537B2047606c5a8cc"

--- a/zk/tests/nightly-l1-recovery/network5-sync-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network5-sync-config.yaml
@@ -1,7 +1,7 @@
-datadir : './datadir'
-chain : "dynamic-integration"
-http : true
-private.api.addr : "localhost:9096"
+datadir: "./datadir"
+chain: "dynamic-integration"
+http: true
+private.api.addr: "localhost:9096"
 zkevm.l2-chain-id: 8282
 zkevm.l2-sequencer-rpc-url: "http://erigon:8545"
 zkevm.l2-datastreamer-url: "erigon:6900"
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: "http://cache:6969?endpoint=https://rpc.sepolia.org&chainid=82
 zkevm.address-sequencer: "0xC9c0DDBAD778A58ac078975Cc7847dD1DEaF2B0A"
 zkevm.address-zkevm: "0x1FAC2D008A7987ED9Eb3eBCd2d95791cC341AB6f"
 zkevm.address-admin: "0x406C6e412895f32573442365d0BA5027ae369cC7"
-zkevm.address-rollup: "0xBFA50869D87f5Fdee35F60ab31Dc5a347ab6d7f4"
+zkevm.address-rollup-manager: "0xBFA50869D87f5Fdee35F60ab31Dc5a347ab6d7f4"
 zkevm.address-ger-manager: "0x3134D060b2b2B47477e8f75537B2047606c5a8cc"
 
 zkevm.l1-matic-contract-address: "0x0f25eE4CA85Db4362a9749782872c558873566e4"
@@ -33,11 +33,11 @@ zkevm.gas-price-factor: 0.12
 txpool.disable: true
 
 externalcl: true
-http.api : ["eth","debug","net","trace","web3","erigon","txpool","zkevm"]
+http.api: ["eth", "debug", "net", "trace", "web3", "erigon", "txpool", "zkevm"]
 http.addr: "0.0.0.0"
 http.port: 8123
-http.vhosts: '*'
-http.corsdomain: '*'
+http.vhosts: "*"
+http.corsdomain: "*"
 
 ws: true
 rpc.batch.limit: 500

--- a/zk/tests/nightly-l1-recovery/network5-sync-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network5-sync-config.yaml
@@ -14,7 +14,7 @@ zkevm.address-admin: "0x406C6e412895f32573442365d0BA5027ae369cC7"
 zkevm.address-rollup-manager: "0xBFA50869D87f5Fdee35F60ab31Dc5a347ab6d7f4"
 zkevm.address-ger-manager: "0x3134D060b2b2B47477e8f75537B2047606c5a8cc"
 
-zkevm.l1-matic-contract-address: "0x0f25eE4CA85Db4362a9749782872c558873566e4"
+zkevm.address-matic: "0x0f25eE4CA85Db4362a9749782872c558873566e4"
 zkevm.l1-block-range: 20000
 zkevm.l1-query-delay: 6000
 zkevm.l1-first-block: 6032365

--- a/zk/tests/nightly-l1-recovery/network5-sync-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network5-sync-config.yaml
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: "http://cache:6969?endpoint=https://rpc.sepolia.org&chainid=8282"
 
 zkevm.address-sequencer: "0xC9c0DDBAD778A58ac078975Cc7847dD1DEaF2B0A"
-zkevm.address-zkevm: "0x1FAC2D008A7987ED9Eb3eBCd2d95791cC341AB6f"
+zkevm.address-rollup: "0x1FAC2D008A7987ED9Eb3eBCd2d95791cC341AB6f"
 zkevm.address-admin: "0x406C6e412895f32573442365d0BA5027ae369cC7"
 zkevm.address-rollup-manager: "0xBFA50869D87f5Fdee35F60ab31Dc5a347ab6d7f4"
 zkevm.address-ger-manager: "0x3134D060b2b2B47477e8f75537B2047606c5a8cc"

--- a/zk/tests/nightly-l1-recovery/network8-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network8-config.yaml
@@ -1,7 +1,7 @@
-datadir : './datadir'
-chain : "dynamic-integration8"
-http : true
-private.api.addr : "localhost:9096"
+datadir: "./datadir"
+chain: "dynamic-integration8"
+http: true
+private.api.addr: "localhost:9096"
 zkevm.l2-chain-id: 779
 zkevm.l2-sequencer-rpc-url: "http://34.175.214.161:18123"
 zkevm.l2-datastreamer-url: "34.175.214.161:16900"
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: "http://cache:6969?endpoint=https://rpc.sepolia.org&chainid=77
 zkevm.address-sequencer: "0x153724F17B1eb206e31CAbA82f6b45E865879D94"
 zkevm.address-zkevm: "0xA24686d989DCd70fBb4D8311694820d74872f061"
 zkevm.address-admin: "0xe859276098f208D003ca6904C6cC26629Ee364Ce"
-zkevm.address-rollup: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
+zkevm.address-rollup-manager: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
 zkevm.address-ger-manager: "0x33ff0546a9ce00D9b2B43Fe52Eab336D919eAD36"
 
 zkevm.l1-matic-contract-address: "0xdC66C280f5E8bBbd2F2d92FaD1489863c8F55915"
@@ -35,11 +35,11 @@ log.console.verbosity: warn
 zkevm.l1-sync-start-block: 6032365
 
 externalcl: true
-http.api : ["eth","debug","net","trace","web3","erigon","txpool","zkevm"]
+http.api: ["eth", "debug", "net", "trace", "web3", "erigon", "txpool", "zkevm"]
 http.addr: "0.0.0.0"
 http.port: 8123
-http.vhosts: '*'
-http.corsdomain: '*'
+http.vhosts: "*"
+http.corsdomain: "*"
 
 ws: true
 rpc.batch.limit: 500

--- a/zk/tests/nightly-l1-recovery/network8-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network8-config.yaml
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: "http://cache:6969?endpoint=https://rpc.sepolia.org&chainid=779"
 
 zkevm.address-sequencer: "0x153724F17B1eb206e31CAbA82f6b45E865879D94"
-zkevm.address-zkevm: "0xA24686d989DCd70fBb4D8311694820d74872f061"
+zkevm.address-rollup: "0xA24686d989DCd70fBb4D8311694820d74872f061"
 zkevm.address-admin: "0xe859276098f208D003ca6904C6cC26629Ee364Ce"
 zkevm.address-rollup-manager: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
 zkevm.address-ger-manager: "0x33ff0546a9ce00D9b2B43Fe52Eab336D919eAD36"

--- a/zk/tests/nightly-l1-recovery/network8-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network8-config.yaml
@@ -14,7 +14,7 @@ zkevm.address-admin: "0xe859276098f208D003ca6904C6cC26629Ee364Ce"
 zkevm.address-rollup-manager: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
 zkevm.address-ger-manager: "0x33ff0546a9ce00D9b2B43Fe52Eab336D919eAD36"
 
-zkevm.l1-matic-contract-address: "0xdC66C280f5E8bBbd2F2d92FaD1489863c8F55915"
+zkevm.address-matic: "0xdC66C280f5E8bBbd2F2d92FaD1489863c8F55915"
 zkevm.l1-block-range: 20000
 zkevm.l1-query-delay: 6000
 zkevm.l1-first-block: 6411787

--- a/zk/tests/nightly-l1-recovery/network8-sync-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network8-sync-config.yaml
@@ -1,7 +1,7 @@
-datadir : './datadir'
-chain : "dynamic-integration8"
-http : true
-private.api.addr : "localhost:9096"
+datadir: "./datadir"
+chain: "dynamic-integration8"
+http: true
+private.api.addr: "localhost:9096"
 zkevm.l2-chain-id: 779
 zkevm.l2-sequencer-rpc-url: "http://erigon:8545"
 zkevm.l2-datastreamer-url: "erigon:6900"
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: "http://cache:6969?endpoint=https://rpc.sepolia.org&chainid=77
 zkevm.address-sequencer: "0x153724F17B1eb206e31CAbA82f6b45E865879D94"
 zkevm.address-zkevm: "0xA24686d989DCd70fBb4D8311694820d74872f061"
 zkevm.address-admin: "0xe859276098f208D003ca6904C6cC26629Ee364Ce"
-zkevm.address-rollup: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
+zkevm.address-rollup-manager: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
 zkevm.address-ger-manager: "0x33ff0546a9ce00D9b2B43Fe52Eab336D919eAD36"
 
 zkevm.l1-matic-contract-address: "0xdC66C280f5E8bBbd2F2d92FaD1489863c8F55915"
@@ -33,11 +33,11 @@ zkevm.disable-virtual-counters: true
 txpool.disable: true
 
 externalcl: true
-http.api : ["eth","debug","net","trace","web3","erigon","txpool","zkevm"]
+http.api: ["eth", "debug", "net", "trace", "web3", "erigon", "txpool", "zkevm"]
 http.addr: "0.0.0.0"
 http.port: 8123
-http.vhosts: '*'
-http.corsdomain: '*'
+http.vhosts: "*"
+http.corsdomain: "*"
 
 ws: true
 rpc.batch.limit: 500

--- a/zk/tests/nightly-l1-recovery/network8-sync-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network8-sync-config.yaml
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: "http://cache:6969?endpoint=https://rpc.sepolia.org&chainid=779"
 
 zkevm.address-sequencer: "0x153724F17B1eb206e31CAbA82f6b45E865879D94"
-zkevm.address-zkevm: "0xA24686d989DCd70fBb4D8311694820d74872f061"
+zkevm.address-rollup: "0xA24686d989DCd70fBb4D8311694820d74872f061"
 zkevm.address-admin: "0xe859276098f208D003ca6904C6cC26629Ee364Ce"
 zkevm.address-rollup-manager: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
 zkevm.address-ger-manager: "0x33ff0546a9ce00D9b2B43Fe52Eab336D919eAD36"

--- a/zk/tests/nightly-l1-recovery/network8-sync-config.yaml
+++ b/zk/tests/nightly-l1-recovery/network8-sync-config.yaml
@@ -14,7 +14,7 @@ zkevm.address-admin: "0xe859276098f208D003ca6904C6cC26629Ee364Ce"
 zkevm.address-rollup-manager: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
 zkevm.address-ger-manager: "0x33ff0546a9ce00D9b2B43Fe52Eab336D919eAD36"
 
-zkevm.l1-matic-contract-address: "0xdC66C280f5E8bBbd2F2d92FaD1489863c8F55915"
+zkevm.address-matic: "0xdC66C280f5E8bBbd2F2d92FaD1489863c8F55915"
 zkevm.l1-block-range: 20000
 zkevm.l1-query-delay: 6000
 zkevm.l1-first-block: 6411787

--- a/zk/tests/unwinds/config/dynamic-integration8.yaml
+++ b/zk/tests/unwinds/config/dynamic-integration8.yaml
@@ -11,7 +11,7 @@ zkevm.l1-rpc-url: "https://rpc.eu-central-1.gateway.fm/v4/ethereum/non-archival/
 zkevm.address-sequencer: "0x153724F17B1eb206e31CAbA82f6b45E865879D94"
 zkevm.address-zkevm: "0xA24686d989DCd70fBb4D8311694820d74872f061"
 zkevm.address-admin: "0xe859276098f208D003ca6904C6cC26629Ee364Ce"
-zkevm.address-rollup: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
+zkevm.address-rollup-manager: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
 zkevm.address-ger-manager: "0x33ff0546a9ce00D9b2B43Fe52Eab336D919eAD36"
 
 zkevm.l1-matic-contract-address: "0xdC66C280f5E8bBbd2F2d92FaD1489863c8F55915"

--- a/zk/tests/unwinds/config/dynamic-integration8.yaml
+++ b/zk/tests/unwinds/config/dynamic-integration8.yaml
@@ -9,7 +9,7 @@ zkevm.l1-chain-id: 11155111
 zkevm.l1-rpc-url: "https://rpc.eu-central-1.gateway.fm/v4/ethereum/non-archival/sepolia"
 
 zkevm.address-sequencer: "0x153724F17B1eb206e31CAbA82f6b45E865879D94"
-zkevm.address-zkevm: "0xA24686d989DCd70fBb4D8311694820d74872f061"
+zkevm.address-rollup: "0xA24686d989DCd70fBb4D8311694820d74872f061"
 zkevm.address-admin: "0xe859276098f208D003ca6904C6cC26629Ee364Ce"
 zkevm.address-rollup-manager: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
 zkevm.address-ger-manager: "0x33ff0546a9ce00D9b2B43Fe52Eab336D919eAD36"

--- a/zk/tests/unwinds/config/dynamic-integration8.yaml
+++ b/zk/tests/unwinds/config/dynamic-integration8.yaml
@@ -14,7 +14,7 @@ zkevm.address-admin: "0xe859276098f208D003ca6904C6cC26629Ee364Ce"
 zkevm.address-rollup-manager: "0xeE6F5B532b67ee594B372f7a3eBD276A45Ea6777"
 zkevm.address-ger-manager: "0x33ff0546a9ce00D9b2B43Fe52Eab336D919eAD36"
 
-zkevm.l1-matic-contract-address: "0xdC66C280f5E8bBbd2F2d92FaD1489863c8F55915"
+zkevm.address-matic: "0xdC66C280f5E8bBbd2F2d92FaD1489863c8F55915"
 zkevm.l1-block-range: 20000
 zkevm.l1-query-delay: 6000
 zkevm.l1-first-block: 6411787


### PR DESCRIPTION
## Description

### Flags Update

- Rename `zkevm.address-rollup` into `zkevm.address-rollup-manager`
- Rename `zkevm.adress-zkevm` into `zkevm.address-rollup`
- Rename `zkevm.l1-rollup-id` intof `zkevm.rollup-id`

Current config:

```yml
zkevm.address-rollup: 0xA
zkevm.address-zkevm: 0xB
zkevm.l1-rollup-id: 1
```

New config:

```yml
zkevm.address-rollup-manager: 0xA
zkevm.address-rollup: 0xB
zkevm.rollup-id: 1
```

### Other

- Rename `AddressRollup` into `AddressRollupManager`
- Rename `AddressZkevm` into `AddressRollup`
- Rename `L1RollupId` into `RollupId`
