### PR TITLE
Fix panic in debug_traceTransaction

### DIFF
--- a/.github/workflows/ci_zkevm.yml
+++ b/.github/workflows/ci_zkevm.yml
@@ -21,9 +21,9 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-13 ] # list of os: https://github.com/actions/virtual-environments
+        os: [ ubuntu-20.04, macos-13-xlarge ] # list of os: https://github.com/actions/virtual-environments
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.os == 'macos-14' && 40 || 30 }}
+    timeout-minutes: ${{ matrix.os == 'macos-14-xlarge' && 40 || 30 }}
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ db-tools:
 
 ## test:                              run unit tests with a 100s timeout
 test:
-	$(GOTEST) --timeout 200s
+	$(GOTEST) --timeout 10m
 
 test3:
 	$(GOTEST) --timeout 200s -tags $(BUILD_TAGS),erigon3


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/0xPolygonHermez/cdk-erigon/pull/1142

Error on calling `debug_traceTransaction`:
```
[cdk-erigon-node-001] [EROR] [09-19|16:16:55.763] RPC method debug_traceTransaction crashed: runtime error: invalid memory address or nil pointer dereference
[cdk-erigon-node-001] [service.go:217 panic.go:884 panic.go:260 signal_unix.go:841 zk_transaction_counters.go:206 tracing.go:198 tracing.go:267 value.go:586 value.go:370 service.go:227 handler.go:511 handler.go:444 handler.go:392 handler.go:223 handler.go:316 asm_amd64.s:1598]
```
