### PR TITLE
Smt increment db access opt

### DIFF
--- a/smt/pkg/smt/smt.go
+++ b/smt/pkg/smt/smt.go
@@ -542,6 +542,18 @@ func prepareHashValueForSave(in [8]uint64, capacity [4]uint64) utils.NodeValue12
 	return v
 }
 
+func prepareHashValueForSaveByPointers(in *[8]uint64, capacity *[4]uint64) *utils.NodeValue12 {
+	v := utils.NodeValue12{}
+	for i, val := range in {
+		v[i] = new(big.Int).SetUint64(val)
+	}
+	for i, val := range capacity {
+		v[i+8] = new(big.Int).SetUint64(val)
+	}
+
+	return &v
+}
+
 func (s *SMT) hashSave(in [8]uint64, capacity, h [4]uint64) error {
 	if s.noSaveOnInsert {
 		return nil
@@ -559,6 +571,11 @@ func (s *SMT) hashcalcAndSave(in [8]uint64, capacity [4]uint64) ([4]uint64, erro
 func hashCalcAndPrepareForSave(in [8]uint64, capacity [4]uint64) ([4]uint64, utils.NodeValue12) {
 	h := utils.Hash(in, capacity)
 	return h, prepareHashValueForSave(in, capacity)
+}
+
+func hashCalcAndPrepareForSaveByPointers(in *[8]uint64, capacity *[4]uint64) (*[4]uint64, *utils.NodeValue12) {
+	h := utils.HashByPointers(in, capacity)
+	return h, prepareHashValueForSaveByPointers(in, capacity)
 }
 
 func (s *RoSMT) getLastRoot() (utils.NodeKey, error) {

--- a/smt/pkg/smt/smt.go
+++ b/smt/pkg/smt/smt.go
@@ -257,9 +257,6 @@ func (s *SMT) insert(k utils.NodeKey, v utils.NodeValue8, newValH [4]uint64, old
 			foundVal = foundValA
 
 			foundKey = utils.JoinKey(usedKey, foundRKey)
-			if err != nil {
-				return nil, err
-			}
 		} else {
 			oldRoot = utils.NodeKeyFromBigIntArray(siblings[level][keys[level]*4 : keys[level]*4+4])
 			usedKey = append(usedKey, keys[level])
@@ -559,9 +556,9 @@ func (s *SMT) hashcalcAndSave(in [8]uint64, capacity [4]uint64) ([4]uint64, erro
 	return h, s.hashSave(in, capacity, h)
 }
 
-func hashCalcAndPrepareForSave(in [8]uint64, capacity [4]uint64) ([4]uint64, utils.NodeValue12, error) {
+func hashCalcAndPrepareForSave(in [8]uint64, capacity [4]uint64) ([4]uint64, utils.NodeValue12) {
 	h := utils.Hash(in, capacity)
-	return h, prepareHashValueForSave(in, capacity), nil
+	return h, prepareHashValueForSave(in, capacity)
 }
 
 func (s *RoSMT) getLastRoot() (utils.NodeKey, error) {

--- a/smt/pkg/smt/smt.go
+++ b/smt/pkg/smt/smt.go
@@ -530,52 +530,29 @@ func (s *SMT) insert(k utils.NodeKey, v utils.NodeValue8, newValH [4]uint64, old
 	return smtResponse, nil
 }
 
-func prepareHashValueForSave(in [8]uint64, capacity [4]uint64) utils.NodeValue12 {
-	v := utils.NodeValue12{}
-	for i, val := range in {
-		v[i] = new(big.Int).SetUint64(val)
-	}
-	for i, val := range capacity {
-		v[i+8] = new(big.Int).SetUint64(val)
-	}
-
-	return v
-}
-
-func prepareHashValueForSaveByPointers(in *[8]uint64, capacity *[4]uint64) *utils.NodeValue12 {
-	v := utils.NodeValue12{}
-	for i, val := range in {
-		v[i] = new(big.Int).SetUint64(val)
-	}
-	for i, val := range capacity {
-		v[i+8] = new(big.Int).SetUint64(val)
-	}
-
-	return &v
-}
-
+// used only by old smt (not by smt batch/create)
 func (s *SMT) hashSave(in [8]uint64, capacity, h [4]uint64) error {
 	if s.noSaveOnInsert {
 		return nil
 	}
-	v := prepareHashValueForSave(in, capacity)
+	v := utils.ConcatArrays8AndCapacityByPointers(&in, &capacity)
 
-	return s.Db.Insert(h, v)
+	return s.Db.Insert(h, *v)
 }
 
+func (s *SMT) hashSaveByPointers(in *[8]uint64, capacity, h *[4]uint64) error {
+	if s.noSaveOnInsert {
+		return nil
+	}
+	v := utils.ConcatArrays8AndCapacityByPointers(in, capacity)
+
+	return s.Db.Insert(*h, *v)
+}
+
+// used only by old smt (not by smt batch/create)
 func (s *SMT) hashcalcAndSave(in [8]uint64, capacity [4]uint64) ([4]uint64, error) {
 	h := utils.Hash(in, capacity)
 	return h, s.hashSave(in, capacity, h)
-}
-
-func hashCalcAndPrepareForSave(in [8]uint64, capacity [4]uint64) ([4]uint64, utils.NodeValue12) {
-	h := utils.Hash(in, capacity)
-	return h, prepareHashValueForSave(in, capacity)
-}
-
-func hashCalcAndPrepareForSaveByPointers(in *[8]uint64, capacity *[4]uint64) (*[4]uint64, *utils.NodeValue12) {
-	h := utils.HashByPointers(in, capacity)
-	return h, prepareHashValueForSaveByPointers(in, capacity)
 }
 
 func (s *RoSMT) getLastRoot() (utils.NodeKey, error) {

--- a/smt/pkg/smt/smt_batch.go
+++ b/smt/pkg/smt/smt_batch.go
@@ -248,10 +248,21 @@ func (s *SMT) InsertBatch(cfg InsertBatchConfig, nodeKeys []*utils.NodeKey, node
 	if smtBatchNodeRoot == nil {
 		rootNodeHash = &utils.NodeKey{0, 0, 0, 0}
 	} else {
-		if err := calculateAndSaveHashesDfs(s, smtBatchNodeRoot, make([]int, 256), 0); err != nil {
-			return nil, fmt.Errorf("calculating and saving hashes dfs: %w", err)
+		sdh := newSmtDfsHelper(s)
+
+		go func() {
+			defer sdh.destroy()
+
+			calculateAndSaveHashesDfs(sdh, smtBatchNodeRoot, make([]int, 256), 0)
+			rootNodeHash = (*utils.NodeKey)(smtBatchNodeRoot.hash)
+		}()
+
+		if !s.noSaveOnInsert {
+			if err = sdh.startConsumersLoop(s); err != nil {
+				return nil, fmt.Errorf("saving smt hashes dfs: %w", err)
+			}
 		}
-		rootNodeHash = (*utils.NodeKey)(smtBatchNodeRoot.hash)
+		sdh.wg.Wait()
 	}
 	if err := s.setLastRoot(*rootNodeHash); err != nil {
 		return nil, err
@@ -454,59 +465,44 @@ func updateNodeHashesForDelete(nodeHashesForDelete map[uint64]map[uint64]map[uin
 	}
 }
 
-func calculateAndSaveHashesDfs(s *SMT, smtBatchNode *smtBatchNode, path []int, level int) error {
+// no point to parallelize this function because db consumer is slower than this producer
+func calculateAndSaveHashesDfs(sdh *smtDfsHelper, smtBatchNode *smtBatchNode, path []int, level int) {
 	if smtBatchNode.isLeaf() {
-		hashObj, err := s.hashcalcAndSave(utils.ConcatArrays4(*smtBatchNode.nodeLeftHashOrRemainingKey, *smtBatchNode.nodeRightHashOrValueHash), utils.LeafCapacity)
-		if err != nil {
-			return fmt.Errorf("hashing leaf: %w", err)
-		}
-
+		hashObj, hashValue := hashCalcAndPrepareForSave(utils.ConcatArrays4(*smtBatchNode.nodeLeftHashOrRemainingKey, *smtBatchNode.nodeRightHashOrValueHash), utils.LeafCapacity)
 		smtBatchNode.hash = &hashObj
+		if !sdh.s.noSaveOnInsert {
+			sdh.dataChan <- newSmtDfsHelperDataStruct(&hashObj, &hashValue)
 
-		nodeKey := utils.JoinKey(path[:level], *smtBatchNode.nodeLeftHashOrRemainingKey)
-		if err := s.Db.InsertHashKey(hashObj, *nodeKey); err != nil {
-			return fmt.Errorf("inserting hash key: %w", err)
+			nodeKey := utils.JoinKey(path[:level], *smtBatchNode.nodeLeftHashOrRemainingKey)
+			sdh.dataChan <- newSmtDfsHelperDataStruct(&hashObj, nodeKey)
 		}
-
-		return nil
+		return
 	}
 
 	var totalHash utils.NodeValue8
 
 	if smtBatchNode.leftNode != nil {
 		path[level] = 0
-		if err := calculateAndSaveHashesDfs(s, smtBatchNode.leftNode, path, level+1); err != nil {
-			return err
-		}
-		if err := totalHash.SetHalfValue(*smtBatchNode.leftNode.hash, 0); err != nil {
-			return err
-		}
+		calculateAndSaveHashesDfs(sdh, smtBatchNode.leftNode, path, level+1)
+		totalHash.SetHalfValue(*smtBatchNode.leftNode.hash, 0) // no point to check for error because we used hardcoded 0 which ensures that no error will be returned
 	} else {
-		if err := totalHash.SetHalfValue(*smtBatchNode.nodeLeftHashOrRemainingKey, 0); err != nil {
-			return err
-		}
+		totalHash.SetHalfValue(*smtBatchNode.nodeLeftHashOrRemainingKey, 0) // no point to check for error because we used hardcoded 0 which ensures that no error will be returned
 	}
 
 	if smtBatchNode.rightNode != nil {
 		path[level] = 1
-		if err := calculateAndSaveHashesDfs(s, smtBatchNode.rightNode, path, level+1); err != nil {
-			return err
-		}
-		if err := totalHash.SetHalfValue(*smtBatchNode.rightNode.hash, 1); err != nil {
-			return err
-		}
+		calculateAndSaveHashesDfs(sdh, smtBatchNode.rightNode, path, level+1)
+		totalHash.SetHalfValue(*smtBatchNode.rightNode.hash, 1) // no point to check for error because we used hardcoded 1 which ensures that no error will be returned
 	} else {
-		if err := totalHash.SetHalfValue(*smtBatchNode.nodeRightHashOrValueHash, 1); err != nil {
-			return err
-		}
+		totalHash.SetHalfValue(*smtBatchNode.nodeRightHashOrValueHash, 1) // no point to check for error because we used hardcoded 1 which ensures that no error will be returned
 	}
 
-	hashObj, err := s.hashcalcAndSave(totalHash.ToUintArray(), utils.BranchCapacity)
-	if err != nil {
-		return err
+	hashObj, hashValue := hashCalcAndPrepareForSave(totalHash.ToUintArray(), utils.BranchCapacity)
+	if !sdh.s.noSaveOnInsert {
+		sdh.dataChan <- newSmtDfsHelperDataStruct(&hashObj, &hashValue)
 	}
+
 	smtBatchNode.hash = &hashObj
-	return nil
 }
 
 type smtBatchNode struct {
@@ -631,6 +627,65 @@ func (sbn *smtBatchNode) collapseLeafByRemovingTheSingleLeaf(insertingNodeKey []
 	sbn.rightNode = nil
 
 	return &sbn.parentNode
+}
+
+type smtDfsHelperDataStruct struct {
+	key   *[4]uint64
+	value interface{}
+}
+
+func newSmtDfsHelperDataStruct(key *[4]uint64, value interface{}) *smtDfsHelperDataStruct {
+	return &smtDfsHelperDataStruct{
+		key:   key,
+		value: value,
+	}
+}
+
+type smtDfsHelper struct {
+	s        *SMT
+	dataChan chan *smtDfsHelperDataStruct
+	wg       *sync.WaitGroup
+	once     *sync.Once
+}
+
+func newSmtDfsHelper(s *SMT) *smtDfsHelper {
+	sdh := &smtDfsHelper{
+		s:        s,
+		dataChan: make(chan *smtDfsHelperDataStruct, 1<<16),
+		wg:       &sync.WaitGroup{},
+		once:     &sync.Once{},
+	}
+
+	sdh.wg.Add(1)
+
+	return sdh
+}
+
+func (sdh *smtDfsHelper) destroy() {
+	sdh.once.Do(func() {
+		close(sdh.dataChan)
+		sdh.wg.Done()
+	})
+}
+
+func (sdh *smtDfsHelper) startConsumersLoop(s *SMT) error {
+	for {
+		dataStruct, ok := <-sdh.dataChan
+		if !ok {
+			return nil
+		}
+
+		switch castedDataStruct := dataStruct.value.(type) {
+		case *utils.NodeKey:
+			if err := s.Db.InsertHashKey(*dataStruct.key, *castedDataStruct); err != nil {
+				return fmt.Errorf("calculating and saving hashes dfs: %w", err)
+			}
+		case *utils.NodeValue12:
+			if err := s.Db.Insert(*dataStruct.key, *castedDataStruct); err != nil {
+				return fmt.Errorf("calculating and saving hashes dfs: %w", err)
+			}
+		}
+	}
 }
 
 func setNodeKeyMapValue[T int | *utils.NodeKey](nodeKeyMap map[uint64]map[uint64]map[uint64]map[uint64]T, nodeKey *utils.NodeKey, value T) {

--- a/smt/pkg/smt/smt_batch_compare_test.go
+++ b/smt/pkg/smt/smt_batch_compare_test.go
@@ -30,14 +30,8 @@ func TestCompareAllTreesInsertTimesAndFinalHashesUsingDiskDb(t *testing.T) {
 	compareAllTreesInsertTimesAndFinalHashes(t, smtIncremental, smtBulk, smtBatch)
 
 	smtIncrementalTx.Commit()
-	tt := time.Now()
-	t.Logf("1: %v\n", time.Since(tt))
 	smtBulkTx.Commit()
-	tt = time.Now()
-	t.Logf("2: %v\n", time.Since(tt))
 	smtBatchTx.Commit()
-	tt = time.Now()
-	t.Logf("3: %v\n", time.Since(tt))
 	t.Cleanup(func() {
 		smtIncrementalDb.Close()
 		smtBulkDb.Close()

--- a/smt/pkg/smt/smt_create.go
+++ b/smt/pkg/smt/smt_create.go
@@ -385,10 +385,7 @@ func (n *SmtNode) deleteTreeNoSave(keyPath []int, leafValueMap *sync.Map, kvMapO
 
 		newKey := utils.RemoveKeyBits(k, len(keyPath))
 		//hash and save leaf
-		newValH, newValHV, newLeafHash, newLeafHashV, err := createNewLeafNoSave(newKey, &accoutnValue)
-		if err != nil {
-			return [4]uint64{}, err
-		}
+		newValH, newValHV, newLeafHash, newLeafHashV := createNewLeafNoSave(newKey, &accoutnValue)
 		kvMapOfValuesToSave[newValH] = newValHV
 		kvMapOfValuesToSave[newLeafHash] = newLeafHashV
 		kvMapOfLeafValuesToSave[newLeafHash] = k
@@ -425,11 +422,7 @@ func (n *SmtNode) deleteTreeNoSave(keyPath []int, leafValueMap *sync.Map, kvMapO
 
 	totalHash.SetHalfValue(n.leftHash, 0)
 
-	newRoot, v, err := hashCalcAndPrepareForSave(totalHash.ToUintArray(), utils.BranchCapacity)
-	if err != nil {
-		return [4]uint64{}, err
-	}
-
+	newRoot, v := hashCalcAndPrepareForSave(totalHash.ToUintArray(), utils.BranchCapacity)
 	kvMapOfValuesToSave[newRoot] = v
 
 	return newRoot, nil
@@ -447,17 +440,9 @@ func (n *SmtNode) deleteTree(keyPath []int, s *SMT, leafValueMap *sync.Map) (new
 	return newRoot, nil
 }
 
-func createNewLeafNoSave(rkey utils.NodeKey, v *utils.NodeValue8) (newValH [4]uint64, newValHV utils.NodeValue12, newLeafHash [4]uint64, newLeafHashV utils.NodeValue12, err error) {
+func createNewLeafNoSave(rkey utils.NodeKey, v *utils.NodeValue8) (newValH [4]uint64, newValHV utils.NodeValue12, newLeafHash [4]uint64, newLeafHashV utils.NodeValue12) {
 	//hash and save leaf
-	newValH, newValHV, err = hashCalcAndPrepareForSave(v.ToUintArray(), utils.BranchCapacity)
-	if err != nil {
-		return [4]uint64{}, utils.NodeValue12{}, [4]uint64{}, utils.NodeValue12{}, err
-	}
-
-	newLeafHash, newLeafHashV, err = hashCalcAndPrepareForSave(utils.ConcatArrays4(rkey, newValH), utils.LeafCapacity)
-	if err != nil {
-		return [4]uint64{}, utils.NodeValue12{}, [4]uint64{}, utils.NodeValue12{}, err
-	}
-
-	return newValH, newValHV, newLeafHash, newLeafHashV, nil
+	newValH, newValHV = hashCalcAndPrepareForSave(v.ToUintArray(), utils.BranchCapacity)
+	newLeafHash, newLeafHashV = hashCalcAndPrepareForSave(utils.ConcatArrays4(rkey, newValH), utils.LeafCapacity)
+	return newValH, newValHV, newLeafHash, newLeafHashV
 }

--- a/smt/pkg/utils/utils.go
+++ b/smt/pkg/utils/utils.go
@@ -56,6 +56,12 @@ func Hash(in [8]uint64, capacity [4]uint64) [4]uint64 {
 	return result
 }
 
+func HashByPointers(in *[8]uint64, capacity *[4]uint64) *[4]uint64 {
+	var result [4]uint64 = [4]uint64{0, 0, 0, 0}
+	hashFunc(in, capacity, &result)
+	return &result
+}
+
 func (nk *NodeKey) IsZero() bool {
 	return nk[0] == 0 && nk[1] == 0 && nk[2] == 0 && nk[3] == 0
 }
@@ -112,6 +118,22 @@ func (nv *NodeValue8) ToUintArray() [8]uint64 {
 	// if nv is nil, result will be an array of 8 zeros
 
 	return result
+}
+
+func (nv *NodeValue8) ToUintArrayByPointer() *[8]uint64 {
+	var result [8]uint64
+
+	if nv != nil {
+		for i := 0; i < 8; i++ {
+			if nv[i] != nil {
+				result[i] = nv[i].Uint64()
+			}
+			// if nv[i] is nil, result[i] will remain as its zero value (0)
+		}
+	}
+	// if nv is nil, result will be an array of 8 zeros
+
+	return &result
 }
 
 func (nv *NodeValue12) ToBigInt() *big.Int {
@@ -409,6 +431,13 @@ func ConcatArrays4(a, b [4]uint64) [8]uint64 {
 		result[i+4] = v
 	}
 	return result
+}
+
+func ConcatArrays4ByPointers(a, b *[4]uint64) *[8]uint64 {
+	return &[8]uint64{
+		a[0], a[1], a[2], a[3],
+		b[0], b[1], b[2], b[3],
+	}
 }
 
 func ConcatArrays8AndCapacity(in [8]uint64, capacity [4]uint64) NodeValue12 {

--- a/smt/pkg/utils/utils.go
+++ b/smt/pkg/utils/utils.go
@@ -74,6 +74,10 @@ func (nk *NodeKey) ToBigInt() *big.Int {
 	return ArrayToScalar(nk[:])
 }
 
+func (nk *NodeKey) AsUint64Pointer() *[4]uint64 {
+	return (*[4]uint64)(nk)
+}
+
 func (nv *NodeValue8) IsZero() bool {
 	if nv == nil {
 		return true
@@ -440,18 +444,21 @@ func ConcatArrays4ByPointers(a, b *[4]uint64) *[8]uint64 {
 	}
 }
 
-func ConcatArrays8AndCapacity(in [8]uint64, capacity [4]uint64) NodeValue12 {
-	var sl []uint64
-	sl = append(sl, in[:]...)
-	sl = append(sl, capacity[:]...)
-
+func ConcatArrays8AndCapacityByPointers(in *[8]uint64, capacity *[4]uint64) *NodeValue12 {
 	v := NodeValue12{}
-	for i, val := range sl {
-		b := new(big.Int)
-		v[i] = b.SetUint64(val)
+	for i, val := range in {
+		v[i] = new(big.Int).SetUint64(val)
+	}
+	for i, val := range capacity {
+		v[i+8] = new(big.Int).SetUint64(val)
 	}
 
-	return v
+	return &v
+}
+
+func HashKeyAndValueByPointers(in *[8]uint64, capacity *[4]uint64) (*[4]uint64, *NodeValue12) {
+	h := HashByPointers(in, capacity)
+	return h, ConcatArrays8AndCapacityByPointers(in, capacity)
 }
 
 func RemoveKeyBits(k NodeKey, nBits int) NodeKey {


### PR DESCRIPTION
Increase SMT batch performance by ~17.7%. The performance increase does not apply when SMT does not write its values to a DB (DISK or MEMORY).

Tested on Cardona's and Bali's SMT for 1M blocks.