### PR TITLE
feat(sequencer): update handing of errors

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -488,8 +488,13 @@ var (
 	}
 	SequencerBatchVerificationTimeout = cli.StringFlag{
 		Name:  "zkevm.sequencer-batch-verification-timeout",
-		Usage: "This is a maximum time that a batch verification could take. Including retries. This could be interpreted as maximum that that the sequencer can run without executor. Setting it to 0s will mean infinite timeout. Defaults to 30min",
+		Usage: "This is a maximum time that a batch verification could take in terms of executors' errors. Including retries. This could be interpreted as `maximum that that the sequencer can run without executor`. Setting it to 0s will mean infinite timeout. Defaults to 30min",
 		Value: "30m",
+	}
+	SequencerBatchVerificationRetries = cli.StringFlag{
+		Name:  "zkevm.sequencer-batch-verification-retries",
+		Usage: "Number of attempts that a batch will re-run in case of an internal (not executors') error. This could be interpreted as `maximum attempts to send a batch for verification`. Setting it to -1 will mean unlimited attempts. Defaults to 3",
+		Value: "3",
 	}
 	SequencerTimeoutOnEmptyTxPool = cli.StringFlag{
 		Name:  "zkevm.sequencer-timeout-on-empty-tx-pool",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -36,6 +36,7 @@ type Zk struct {
 	SequencerBlockSealTime                 time.Duration
 	SequencerBatchSealTime                 time.Duration
 	SequencerBatchVerificationTimeout      time.Duration
+	SequencerBatchVerificationRetries      int
 	SequencerTimeoutOnEmptyTxPool          time.Duration
 	SequencerHaltOnBatchNumber             uint64
 	ExecutorUrls                           []string

--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -75,6 +75,7 @@ func (s *StageState) IntermediateHashesAt(db kv.Getter) (uint64, error) {
 type Unwinder interface {
 	// UnwindTo begins staged sync unwind to the specified block.
 	UnwindTo(unwindPoint uint64, badBlock libcommon.Hash)
+	IsUnwindSet() bool
 }
 
 // UnwindState contains the information about unwind.

--- a/eth/stagedsync/sync.go
+++ b/eth/stagedsync/sync.go
@@ -113,6 +113,10 @@ func (s *Sync) UnwindTo(unwindPoint uint64, badBlock libcommon.Hash) {
 	s.badBlock = badBlock
 }
 
+func (s *Sync) IsUnwindSet() bool {
+	return s.unwindPoint != nil
+}
+
 func (s *Sync) IsDone() bool {
 	return s.currentStage >= uint(len(s.stages)) && s.unwindPoint == nil
 }

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -196,6 +196,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.SequencerBlockSealTime,
 	&utils.SequencerBatchSealTime,
 	&utils.SequencerBatchVerificationTimeout,
+	&utils.SequencerBatchVerificationRetries,
 	&utils.SequencerTimeoutOnEmptyTxPool,
 	&utils.SequencerHaltOnBatchNumber,
 	&utils.ExecutorUrls,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -139,6 +139,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		SequencerBlockSealTime:                 sequencerBlockSealTime,
 		SequencerBatchSealTime:                 sequencerBatchSealTime,
 		SequencerBatchVerificationTimeout:      sequencerBatchVerificationTimeout,
+		SequencerBatchVerificationRetries:      ctx.Int(utils.SequencerBatchVerificationRetries.Name),
 		SequencerTimeoutOnEmptyTxPool:          sequencerTimeoutOnEmptyTxPool,
 		SequencerHaltOnBatchNumber:             ctx.Uint64(utils.SequencerHaltOnBatchNumber.Name),
 		ExecutorUrls:                           strings.Split(strings.ReplaceAll(ctx.String(utils.ExecutorUrls.Name), " ", ""), ","),

--- a/zk/legacy_executor_verifier/legacy_executor_verifier.go
+++ b/zk/legacy_executor_verifier/legacy_executor_verifier.go
@@ -35,13 +35,14 @@ type VerifierRequest struct {
 	Counters     map[string]int
 	creationTime time.Time
 	timeout      time.Duration
+	retries      int
 }
 
 func NewVerifierRequest(forkId, batchNumber uint64, blockNumbers []uint64, stateRoot common.Hash, counters map[string]int) *VerifierRequest {
-	return NewVerifierRequestWithTimeout(forkId, batchNumber, blockNumbers, stateRoot, counters, 0)
+	return NewVerifierRequestWithLimits(forkId, batchNumber, blockNumbers, stateRoot, counters, 0, -1)
 }
 
-func NewVerifierRequestWithTimeout(forkId, batchNumber uint64, blockNumbers []uint64, stateRoot common.Hash, counters map[string]int, timeout time.Duration) *VerifierRequest {
+func NewVerifierRequestWithLimits(forkId, batchNumber uint64, blockNumbers []uint64, stateRoot common.Hash, counters map[string]int, timeout time.Duration, retries int) *VerifierRequest {
 	return &VerifierRequest{
 		BatchNumber:  batchNumber,
 		BlockNumbers: blockNumbers,
@@ -50,6 +51,7 @@ func NewVerifierRequestWithTimeout(forkId, batchNumber uint64, blockNumbers []ui
 		Counters:     counters,
 		creationTime: time.Now(),
 		timeout:      timeout,
+		retries:      retries,
 	}
 }
 
@@ -59,6 +61,17 @@ func (vr *VerifierRequest) IsOverdue() bool {
 	}
 
 	return time.Since(vr.creationTime) > vr.timeout
+}
+
+func (vr *VerifierRequest) IncrementAndValidateRetries() bool {
+	if vr.retries == -1 {
+		return true
+	}
+
+	if vr.retries > 0 {
+		vr.retries--
+	}
+	return vr.retries > 0
 }
 
 func (vr *VerifierRequest) GetFirstBlockNumber() uint64 {
@@ -78,15 +91,25 @@ type VerifierResponse struct {
 }
 
 type VerifierBundle struct {
-	Request  *VerifierRequest
-	Response *VerifierResponse
+	Request                *VerifierRequest
+	Response               *VerifierResponse
+	readyForSendingRequest bool
 }
 
-func NewVerifierBundle(request *VerifierRequest, response *VerifierResponse) *VerifierBundle {
+func NewVerifierBundle(request *VerifierRequest, response *VerifierResponse, readyForSendingRequest bool) *VerifierBundle {
 	return &VerifierBundle{
-		Request:  request,
-		Response: response,
+		Request:                request,
+		Response:               response,
+		readyForSendingRequest: readyForSendingRequest,
 	}
+}
+
+func (vb *VerifierBundle) markAsreadyForSendingRequest() {
+	vb.readyForSendingRequest = true
+}
+
+func (vb *VerifierBundle) isInternalError() bool {
+	return !vb.readyForSendingRequest
 }
 
 type WitnessGenerator interface {
@@ -137,10 +160,11 @@ func (v *LegacyExecutorVerifier) StartAsyncVerification(
 	blockNumbers []uint64,
 	useRemoteExecutor bool,
 	requestTimeout time.Duration,
+	retries int,
 ) {
 	var promise *Promise[*VerifierBundle]
 
-	request := NewVerifierRequestWithTimeout(forkId, batchNumber, blockNumbers, stateRoot, counters, requestTimeout)
+	request := NewVerifierRequestWithLimits(forkId, batchNumber, blockNumbers, stateRoot, counters, requestTimeout, retries)
 	if useRemoteExecutor {
 		promise = v.VerifyAsync(request, blockNumbers)
 	} else {
@@ -197,7 +221,7 @@ func (v *LegacyExecutorVerifier) VerifyAsync(request *VerifierRequest, blockNumb
 	// eager promise will do the work as soon as called in a goroutine, then we can retrieve the result later
 	// ProcessResultsSequentiallyUnsafe relies on the fact that this function returns ALWAYS non-verifierBundle and error. The only exception is the case when verifications has been canceled. Only then the verifierBundle can be nil
 	return NewPromise[*VerifierBundle](func() (*VerifierBundle, error) {
-		verifierBundle := NewVerifierBundle(request, nil)
+		verifierBundle := NewVerifierBundle(request, nil, false)
 
 		e := v.GetNextOnlineAvailableExecutor()
 		if e == nil {
@@ -270,6 +294,8 @@ func (v *LegacyExecutorVerifier) VerifyAsync(request *VerifierRequest, blockNumb
 			return verifierBundle, err
 		}
 
+		verifierBundle.markAsreadyForSendingRequest()
+
 		ok, executorResponse, executorErr, generalErr := e.Verify(payload, request, previousBlock.Root())
 		if generalErr != nil {
 			return verifierBundle, generalErr
@@ -306,7 +332,7 @@ func (v *LegacyExecutorVerifier) VerifyWithoutExecutor(request *VerifierRequest,
 			ExecutorResponse: nil,
 			Error:            nil,
 		}
-		return NewVerifierBundle(request, response), nil
+		return NewVerifierBundle(request, response, true), nil
 	})
 	promise.Wait()
 
@@ -320,11 +346,14 @@ func (v *LegacyExecutorVerifier) HasPendingVerifications() bool {
 	return len(v.promises) > 0
 }
 
-func (v *LegacyExecutorVerifier) ProcessResultsSequentially() ([]*VerifierBundle, error) {
+// []*VerifierBundle: array of bundles that has been processed by the remove execute and that we have response for
+// *VerifierBundle: a bundle that indicates a unwind point. If this is not nil then this bundle is the very first bundle after the last in []*VerifierBundle
+func (v *LegacyExecutorVerifier) ProcessResultsSequentially() ([]*VerifierBundle, *VerifierBundle) {
 	v.mtxPromises.Lock()
 	defer v.mtxPromises.Unlock()
 
 	var verifierResponse []*VerifierBundle
+	var verifierBundleForUnwind *VerifierBundle
 
 	// not a stop signal, so we can start to process our promises now
 	for idx, promise := range v.promises {
@@ -344,15 +373,23 @@ func (v *LegacyExecutorVerifier) ProcessResultsSequentially() ([]*VerifierBundle
 
 			log.Error("error on our end while preparing the verification request, re-queueing the task", "err", err)
 
-			if verifierBundle.Request.IsOverdue() {
-				// signal an error, the caller can check on this and stop the process if needs be
-				return nil, fmt.Errorf("error: batch %d couldn't be processed in 30 minutes", verifierBundle.Request.BatchNumber)
+			if verifierBundle.isInternalError() {
+				canRetry := verifierBundle.Request.IncrementAndValidateRetries()
+				if !canRetry {
+					verifierBundleForUnwind = verifierBundle
+					break
+				}
+			} else {
+				if verifierBundle.Request.IsOverdue() {
+					verifierBundleForUnwind = verifierBundle
+					break
+				}
 			}
 
 			// re-queue the task - it should be safe to replace the index of the slice here as we only add to it
 			v.promises[idx] = promise.CloneAndRerun()
 
-			// break now as we know we can't proceed here until this promise is attempted again
+			// we have a problamtic bundle so we cannot processed next, because it should break the sequentiality
 			break
 		}
 
@@ -362,7 +399,7 @@ func (v *LegacyExecutorVerifier) ProcessResultsSequentially() ([]*VerifierBundle
 	// remove processed promises from the list
 	v.promises = v.promises[len(verifierResponse):]
 
-	return verifierResponse, nil
+	return verifierResponse, verifierBundleForUnwind
 }
 
 func (v *LegacyExecutorVerifier) Wait() {

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -368,7 +368,7 @@ func SpawnSequencingStage(
 		if err != nil {
 			return err
 		}
-		cfg.legacyVerifier.StartAsyncVerification(batchState.forkId, batchState.batchNumber, block.Root(), counters.UsedAsMap(), batchState.builtBlocks, useExecutorForVerification, batchContext.cfg.zk.SequencerBatchVerificationTimeout)
+		cfg.legacyVerifier.StartAsyncVerification(batchState.forkId, batchState.batchNumber, block.Root(), counters.UsedAsMap(), batchState.builtBlocks, useExecutorForVerification, batchContext.cfg.zk.SequencerBatchVerificationTimeout, batchContext.cfg.zk.SequencerBatchVerificationRetries)
 
 		// check for new responses from the verifier
 		needsUnwind, err := updateStreamAndCheckRollback(batchContext, batchState, streamWriter, u)

--- a/zk/stages/stage_sequence_execute_batch.go
+++ b/zk/stages/stage_sequence_execute_batch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/vm"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
+	verifier "github.com/ledgerwatch/erigon/zk/legacy_executor_verifier"
 	"github.com/ledgerwatch/log/v3"
 )
 
@@ -62,7 +63,7 @@ func updateStreamAndCheckRollback(
 	streamWriter *SequencerBatchStreamWriter,
 	u stagedsync.Unwinder,
 ) (bool, error) {
-	checkedVerifierBundles, err := streamWriter.CommitNewUpdates()
+	checkedVerifierBundles, verifierBundleForUnwind, err := streamWriter.CommitNewUpdates()
 	if err != nil {
 		return false, err
 	}
@@ -93,21 +94,35 @@ func updateStreamAndCheckRollback(
 			return false, err
 		}
 
-		unwindTo := verifierBundle.Request.GetLastBlockNumber() - 1
+		err = markForUnwind(batchContext, streamWriter, u, verifierBundle)
+		return err == nil, err
+	}
 
-		// for unwind we supply the block number X-1 of the block we want to remove, but supply the hash of the block
-		// causing the unwind.
-		unwindHeader := rawdb.ReadHeaderByNumber(batchContext.sdb.tx, verifierBundle.Request.GetLastBlockNumber())
-		if unwindHeader == nil {
-			return false, fmt.Errorf("could not find header for block %d", verifierBundle.Request.GetLastBlockNumber())
-		}
-
-		log.Warn(fmt.Sprintf("[%s] Block is invalid - rolling back", batchContext.s.LogPrefix()), "badBlock", verifierBundle.Request.GetLastBlockNumber(), "unwindTo", unwindTo, "root", unwindHeader.Root)
-
-		u.UnwindTo(unwindTo, unwindHeader.Hash())
-		streamWriter.legacyVerifier.CancelAllRequests()
-		return true, nil
+	if verifierBundleForUnwind != nil {
+		err = markForUnwind(batchContext, streamWriter, u, verifierBundleForUnwind)
+		return err == nil, err
 	}
 
 	return false, nil
+}
+
+func markForUnwind(
+	batchContext *BatchContext,
+	streamWriter *SequencerBatchStreamWriter,
+	u stagedsync.Unwinder,
+	verifierBundle *verifier.VerifierBundle,
+) error {
+	unwindTo := verifierBundle.Request.GetLastBlockNumber() - 1
+
+	// for unwind we supply the block number X-1 of the block we want to remove, but supply the hash of the block
+	// causing the unwind.
+	unwindHeader := rawdb.ReadHeaderByNumber(batchContext.sdb.tx, verifierBundle.Request.GetLastBlockNumber())
+	if unwindHeader == nil {
+		return fmt.Errorf("could not find header for block %d", verifierBundle.Request.GetLastBlockNumber())
+	}
+
+	log.Warn(fmt.Sprintf("[%s] Block is invalid - rolling back", batchContext.s.LogPrefix()), "badBlock", verifierBundle.Request.GetLastBlockNumber(), "unwindTo", unwindTo, "root", unwindHeader.Root)
+
+	u.UnwindTo(unwindTo, unwindHeader.Hash())
+	return nil
 }

--- a/zk/stages/stage_sequence_execute_data_stream.go
+++ b/zk/stages/stage_sequence_execute_data_stream.go
@@ -35,13 +35,10 @@ func newSequencerBatchStreamWriter(batchContext *BatchContext, batchState *Batch
 	}
 }
 
-func (sbc *SequencerBatchStreamWriter) CommitNewUpdates() ([]*verifier.VerifierBundle, error) {
-	verifierBundles, err := sbc.legacyVerifier.ProcessResultsSequentially()
-	if err != nil {
-		return nil, err
-	}
-
-	return sbc.writeBlockDetailsToDatastream(verifierBundles)
+func (sbc *SequencerBatchStreamWriter) CommitNewUpdates() ([]*verifier.VerifierBundle, *verifier.VerifierBundle, error) {
+	verifierBundles, verifierBundleForUnwind := sbc.legacyVerifier.ProcessResultsSequentially()
+	checkedVerifierBundles, err := sbc.writeBlockDetailsToDatastream(verifierBundles)
+	return checkedVerifierBundles, verifierBundleForUnwind, err
 }
 
 func (sbc *SequencerBatchStreamWriter) writeBlockDetailsToDatastream(verifiedBundles []*verifier.VerifierBundle) ([]*verifier.VerifierBundle, error) {

--- a/zk/stages/stages.go
+++ b/zk/stages/stages.go
@@ -104,7 +104,12 @@ func SequencerZkStages(
 			ID:          stages2.Execution,
 			Description: "Sequence transactions",
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *stages.StageState, u stages.Unwinder, tx kv.RwTx, quiet bool) error {
-				return SpawnSequencingStage(s, u, ctx, exec, history, quiet)
+				sequencerErr := SpawnSequencingStage(s, u, ctx, exec, history, quiet)
+				if sequencerErr != nil || u.IsUnwindSet() {
+					exec.legacyVerifier.CancelAllRequests()
+					// on the begining of next iteration the EXECUTION will be aligned to DS
+				}
+				return sequencerErr
 			},
 			Unwind: func(firstCycle bool, u *stages.UnwindState, s *stages.StageState, tx kv.RwTx) error {
 				return UnwindSequenceExecutionStage(u, s, tx, ctx, exec, firstCycle)


### PR DESCRIPTION
- Add a flag that can limit the number of verification requests' retries in case of internal error
- Checking if there is an error or unwind is set after finishing the sequencer loop. If so cancel all pending verification requests. The DS <-> Execution will be aligned on next iteration of the loop.