### PR TITLE
feat(sequencer): update handing of errors

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -493,8 +493,13 @@ var (
 	}
 	SequencerBatchVerificationTimeout = cli.StringFlag{
 		Name:  "zkevm.sequencer-batch-verification-timeout",
-		Usage: "This is a maximum time that a batch verification could take. Including retries. This could be interpreted as maximum that that the sequencer can run without executor. Setting it to 0s will mean infinite timeout. Defaults to 30min",
+		Usage: "This is a maximum time that a batch verification could take in terms of executors' errors. Including retries. This could be interpreted as `maximum that that the sequencer can run without executor`. Setting it to 0s will mean infinite timeout. Defaults to 30min",
 		Value: "30m",
+	}
+	SequencerBatchVerificationRetries = cli.StringFlag{
+		Name:  "zkevm.sequencer-batch-verification-retries",
+		Usage: "Number of attempts that a batch will re-run in case of an internal (not executors') error. This could be interpreted as `maximum attempts to send a batch for verification`. Setting it to -1 will mean unlimited attempts. Defaults to 3",
+		Value: "3",
 	}
 	SequencerTimeoutOnEmptyTxPool = cli.StringFlag{
 		Name:  "zkevm.sequencer-timeout-on-empty-tx-pool",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -37,6 +37,7 @@ type Zk struct {
 	SequencerBlockSealTime                 time.Duration
 	SequencerBatchSealTime                 time.Duration
 	SequencerBatchVerificationTimeout      time.Duration
+	SequencerBatchVerificationRetries      int
 	SequencerTimeoutOnEmptyTxPool          time.Duration
 	SequencerHaltOnBatchNumber             uint64
 	SequencerResequence                    bool

--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -75,6 +75,7 @@ func (s *StageState) IntermediateHashesAt(db kv.Getter) (uint64, error) {
 type Unwinder interface {
 	// UnwindTo begins staged sync unwind to the specified block.
 	UnwindTo(unwindPoint uint64, badBlock libcommon.Hash)
+	IsUnwindSet() bool
 }
 
 // UnwindState contains the information about unwind.

--- a/eth/stagedsync/sync.go
+++ b/eth/stagedsync/sync.go
@@ -113,6 +113,10 @@ func (s *Sync) UnwindTo(unwindPoint uint64, badBlock libcommon.Hash) {
 	s.badBlock = badBlock
 }
 
+func (s *Sync) IsUnwindSet() bool {
+	return s.unwindPoint != nil
+}
+
 func (s *Sync) IsDone() bool {
 	return s.currentStage >= uint(len(s.stages)) && s.unwindPoint == nil
 }

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -200,6 +200,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.SequencerBlockSealTime,
 	&utils.SequencerBatchSealTime,
 	&utils.SequencerBatchVerificationTimeout,
+	&utils.SequencerBatchVerificationRetries,
 	&utils.SequencerTimeoutOnEmptyTxPool,
 	&utils.SequencerHaltOnBatchNumber,
 	&utils.SequencerResequence,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -144,6 +144,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		SequencerBlockSealTime:                 sequencerBlockSealTime,
 		SequencerBatchSealTime:                 sequencerBatchSealTime,
 		SequencerBatchVerificationTimeout:      sequencerBatchVerificationTimeout,
+		SequencerBatchVerificationRetries:      ctx.Int(utils.SequencerBatchVerificationRetries.Name),
 		SequencerTimeoutOnEmptyTxPool:          sequencerTimeoutOnEmptyTxPool,
 		SequencerHaltOnBatchNumber:             ctx.Uint64(utils.SequencerHaltOnBatchNumber.Name),
 		SequencerResequence:                    ctx.Bool(utils.SequencerResequence.Name),

--- a/zk/stages/stage_sequence_execute_batch.go
+++ b/zk/stages/stage_sequence_execute_batch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/zk/l1_data"
+	verifier "github.com/ledgerwatch/erigon/zk/legacy_executor_verifier"
 	"github.com/ledgerwatch/log/v3"
 )
 
@@ -91,7 +92,7 @@ func updateStreamAndCheckRollback(
 	streamWriter *SequencerBatchStreamWriter,
 	u stagedsync.Unwinder,
 ) (bool, error) {
-	checkedVerifierBundles, err := streamWriter.CommitNewUpdates()
+	checkedVerifierBundles, verifierBundleForUnwind, err := streamWriter.CommitNewUpdates()
 	if err != nil {
 		return false, err
 	}
@@ -122,21 +123,35 @@ func updateStreamAndCheckRollback(
 			return false, err
 		}
 
-		unwindTo := verifierBundle.Request.GetLastBlockNumber() - 1
+		err = markForUnwind(batchContext, streamWriter, u, verifierBundle)
+		return err == nil, err
+	}
 
-		// for unwind we supply the block number X-1 of the block we want to remove, but supply the hash of the block
-		// causing the unwind.
-		unwindHeader := rawdb.ReadHeaderByNumber(batchContext.sdb.tx, verifierBundle.Request.GetLastBlockNumber())
-		if unwindHeader == nil {
-			return false, fmt.Errorf("could not find header for block %d", verifierBundle.Request.GetLastBlockNumber())
-		}
-
-		log.Warn(fmt.Sprintf("[%s] Block is invalid - rolling back", batchContext.s.LogPrefix()), "badBlock", verifierBundle.Request.GetLastBlockNumber(), "unwindTo", unwindTo, "root", unwindHeader.Root)
-
-		u.UnwindTo(unwindTo, unwindHeader.Hash())
-		streamWriter.legacyVerifier.CancelAllRequests()
-		return true, nil
+	if verifierBundleForUnwind != nil {
+		err = markForUnwind(batchContext, streamWriter, u, verifierBundleForUnwind)
+		return err == nil, err
 	}
 
 	return false, nil
+}
+
+func markForUnwind(
+	batchContext *BatchContext,
+	streamWriter *SequencerBatchStreamWriter,
+	u stagedsync.Unwinder,
+	verifierBundle *verifier.VerifierBundle,
+) error {
+	unwindTo := verifierBundle.Request.GetLastBlockNumber() - 1
+
+	// for unwind we supply the block number X-1 of the block we want to remove, but supply the hash of the block
+	// causing the unwind.
+	unwindHeader := rawdb.ReadHeaderByNumber(batchContext.sdb.tx, verifierBundle.Request.GetLastBlockNumber())
+	if unwindHeader == nil {
+		return fmt.Errorf("could not find header for block %d", verifierBundle.Request.GetLastBlockNumber())
+	}
+
+	log.Warn(fmt.Sprintf("[%s] Block is invalid - rolling back", batchContext.s.LogPrefix()), "badBlock", verifierBundle.Request.GetLastBlockNumber(), "unwindTo", unwindTo, "root", unwindHeader.Root)
+
+	u.UnwindTo(unwindTo, unwindHeader.Hash())
+	return nil
 }

--- a/zk/stages/stage_sequence_execute_data_stream.go
+++ b/zk/stages/stage_sequence_execute_data_stream.go
@@ -37,13 +37,10 @@ func newSequencerBatchStreamWriter(batchContext *BatchContext, batchState *Batch
 	}
 }
 
-func (sbc *SequencerBatchStreamWriter) CommitNewUpdates() ([]*verifier.VerifierBundle, error) {
-	verifierBundles, err := sbc.legacyVerifier.ProcessResultsSequentially(sbc.logPrefix)
-	if err != nil {
-		return nil, err
-	}
-
-	return sbc.writeBlockDetailsToDatastream(verifierBundles)
+func (sbc *SequencerBatchStreamWriter) CommitNewUpdates() ([]*verifier.VerifierBundle, *verifier.VerifierBundle, error) {
+	verifierBundles, verifierBundleForUnwind := sbc.legacyVerifier.ProcessResultsSequentially(sbc.logPrefix)
+	checkedVerifierBundles, err := sbc.writeBlockDetailsToDatastream(verifierBundles)
+	return checkedVerifierBundles, verifierBundleForUnwind, err
 }
 
 func (sbc *SequencerBatchStreamWriter) writeBlockDetailsToDatastream(verifiedBundles []*verifier.VerifierBundle) ([]*verifier.VerifierBundle, error) {

--- a/zk/stages/stages.go
+++ b/zk/stages/stages.go
@@ -104,7 +104,13 @@ func SequencerZkStages(
 			ID:          stages2.Execution,
 			Description: "Sequence transactions",
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *stages.StageState, u stages.Unwinder, tx kv.RwTx, quiet bool) error {
-				return SpawnSequencingStage(s, u, ctx, exec, history, quiet)
+				sequencerErr := SpawnSequencingStage(s, u, ctx, exec, history, quiet)
+				if sequencerErr != nil || u.IsUnwindSet() {
+					exec.legacyVerifier.CancelAllRequests()
+					// on the begining of next iteration the EXECUTION will be aligned to DS
+					shouldCheckForExecutionAndDataStreamAlighment = true
+				}
+				return sequencerErr
 			},
 			Unwind: func(firstCycle bool, u *stages.UnwindState, s *stages.StageState, tx kv.RwTx) error {
 				return UnwindSequenceExecutionStage(u, s, tx, ctx, exec, firstCycle)


### PR DESCRIPTION
Add a flag that can limit the number of verification requests' retries in case of internal error
Checking if there is an error or unwind is set after finishing the sequencer loop. If so cancel all pending verification requests and enable DS <-> Execution alignment on next iteration of the stage loop