### PR TITLE
Add l1 contract address retrieval

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -466,6 +466,11 @@ var (
 		Usage: "Check the contract address on the L1",
 		Value: true,
 	}
+	L1ContractAddressRetrieveFlag = cli.BoolFlag{
+		Name:  "zkevm.l1-contract-address-retrieve",
+		Usage: "Retrieve the contracts addresses from the L1",
+		Value: true,
+	}
 	RebuildTreeAfterFlag = cli.Uint64Flag{
 		Name:  "zkevm.rebuild-tree-after",
 		Usage: "Rebuild the state tree after this many blocks behind",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -848,17 +848,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 		log.Info("Rollup ID", "rollupId", cfg.L1RollupId)
 
-		// check contract addresses in config against L1
-		if cfg.Zk.L1ContractAddressCheck {
-			success, err := l1ContractAddressCheck(ctx, cfg.Zk, backend.l1Syncer)
-			if !success || err != nil {
-				//log.Warn("Contract address check failed", "success", success, "err", err)
-				panic("Contract address check failed")
-			}
-			log.Info("Contract address check passed")
-		} else {
-			log.Info("Contract address check skipped")
-		}
+		// Check if L1 contracts addresses should be retrieved from the L1 chain
+		l1ContractAddressProcess(ctx, cfg.Zk, backend.l1Syncer)
 
 		l1InfoTreeSyncer := syncer.NewL1Syncer(
 			ctx,
@@ -1554,6 +1545,57 @@ func checkPortIsFree(addr string) (free bool) {
 	return false
 }
 
+func l1ContractAddressProcess(ctx context.Context, cfg *ethconfig.Zk, l1BlockSyncer *syncer.L1Syncer) {
+	if cfg.L1ContractAddressRetrieve {
+		l1ContractAddress(ctx, cfg, l1BlockSyncer)
+		return
+	}
+	l1ContractAddressValidate(ctx, cfg, l1BlockSyncer)
+}
+
+func l1ContractAddress(ctx context.Context, cfg *ethconfig.Zk, l1BlockSyncer *syncer.L1Syncer) {
+	if err := l1ContractAdressFromZKevm(ctx, cfg, l1BlockSyncer); err != nil {
+		panic("Failed to retrieve contract addresses from L1")
+	}
+	log.Info("Contract addresses retrieved from L1")
+}
+
+func l1ContractAdressFromZKevm(ctx context.Context, cfg *ethconfig.Zk, l1BlockSyncer *syncer.L1Syncer) error {
+	l1AddrRollup, err := l1BlockSyncer.CallRollupManager(ctx, &cfg.AddressZkevm)
+	if err != nil {
+		return err
+	}
+	cfg.AddressRollup = l1AddrRollup
+
+	l1AddrGerManager, err := l1BlockSyncer.CallGlobalExitRootManager(ctx, &cfg.AddressZkevm)
+	if err != nil {
+		return err
+	}
+	cfg.AddressGerManager = l1AddrGerManager
+
+	l1AddrSequencer, err := l1BlockSyncer.CallTrustedSequencer(ctx, &cfg.AddressZkevm)
+	if err != nil {
+		return err
+	}
+	cfg.AddressSequencer = l1AddrSequencer
+
+	return nil
+}
+
+func l1ContractAddressValidate(ctx context.Context, cfg *ethconfig.Zk, l1BlockSyncer *syncer.L1Syncer) {
+	if !cfg.L1ContractAddressCheck {
+		log.Info("Contract address check skipped")
+		return
+	}
+
+	success, err := l1ContractAddressCheck(ctx, cfg, l1BlockSyncer)
+	if !success || err != nil {
+		panic("Contract address check failed")
+	}
+
+	log.Info("Contract address check passed")
+}
+
 func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSyncer *syncer.L1Syncer) (bool, error) {
 	l1AddrRollup, err := l1BlockSyncer.CallRollupManager(ctx, &cfg.AddressZkevm)
 	if err != nil {
@@ -1564,6 +1606,7 @@ func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSynce
 		log.Warn("L1 contract address check failed (AddressRollup)", "expected", cfg.AddressRollup, "actual", l1AddrRollup)
 		return false, nil
 	}
+	log.Warn("🚨 zkevm.address-rollup configuration parameter is deprecated and it will be removed in upcoming releases")
 
 	if cfg.AddressAdmin != (libcommon.Address{}) {
 		log.Warn("🚨 zkevm.address-admin configuration parameter is deprecated and it will be removed in upcoming releases")
@@ -1577,6 +1620,7 @@ func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSynce
 		log.Warn("L1 contract address check failed (AddressGerManager)", "expected", cfg.AddressGerManager, "actual", l1AddrGerManager)
 		return false, nil
 	}
+	log.Warn("🚨 zkevm.address-ger-manager configuration parameter is deprecated and it will be removed in upcoming releases")
 
 	l1AddrSequencer, err := l1BlockSyncer.CallTrustedSequencer(ctx, &cfg.AddressZkevm)
 	if err != nil {
@@ -1586,5 +1630,7 @@ func l1ContractAddressCheck(ctx context.Context, cfg *ethconfig.Zk, l1BlockSynce
 		log.Warn("L1 contract address check failed (AddressSequencer)", "expected", cfg.AddressSequencer, "actual", l1AddrSequencer)
 		return false, nil
 	}
+	log.Warn("🚨 zkevm.address-sequencer configuration parameter is deprecated and it will be removed in upcoming releases")
+
 	return true, nil
 }

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -22,6 +22,7 @@ type Zk struct {
 	AddressZkevm                           common.Address
 	AddressGerManager                      common.Address
 	L1ContractAddressCheck                 bool
+	L1ContractAddressRetrieve              bool
 	L1RollupId                             uint64
 	L1BlockRange                           uint64
 	L1QueryDelay                           uint64

--- a/hermezconfig-dev.yaml.example
+++ b/hermezconfig-dev.yaml.example
@@ -23,6 +23,7 @@ zkevm.executor-strict: true
 zkevm.executor-urls: 51.210.116.237:50071
 
 zkevm.l1-contract-address-check: false
+zkevm.l1-contract-address-retrieve: false
 
 externalcl: true
 http.api: [eth, debug, net, trace, web3, erigon, txpool, zkevm]

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -191,6 +191,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.L1FirstBlockFlag,
 	&utils.L1FinalizedBlockRequirementFlag,
 	&utils.L1ContractAddressCheckFlag,
+	&utils.L1ContractAddressRetrieveFlag,
 	&utils.RpcRateLimitsFlag,
 	&utils.RpcGetBatchWitnessConcurrencyLimitFlag,
 	&utils.DatastreamVersionFlag,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -136,6 +136,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		L1FirstBlock:                           ctx.Uint64(utils.L1FirstBlockFlag.Name),
 		L1FinalizedBlockRequirement:            ctx.Uint64(utils.L1FinalizedBlockRequirementFlag.Name),
 		L1ContractAddressCheck:                 ctx.Bool(utils.L1ContractAddressCheckFlag.Name),
+		L1ContractAddressRetrieve:              ctx.Bool(utils.L1ContractAddressRetrieveFlag.Name),
 		RpcGetBatchWitnessConcurrencyLimit:     ctx.Int(utils.RpcGetBatchWitnessConcurrencyLimitFlag.Name),
 		DatastreamVersion:                      ctx.Int(utils.DatastreamVersionFlag.Name),
 		RebuildTreeAfter:                       ctx.Uint64(utils.RebuildTreeAfterFlag.Name),
@@ -215,10 +216,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		}
 	}
 
-	checkFlag(utils.AddressSequencerFlag.Name, cfg.AddressSequencer)
-	checkFlag(utils.AddressRollupFlag.Name, cfg.AddressRollup)
 	checkFlag(utils.AddressZkevmFlag.Name, cfg.AddressZkevm)
-	checkFlag(utils.AddressGerManagerFlag.Name, cfg.AddressGerManager)
 
 	checkFlag(utils.L1ChainIdFlag.Name, cfg.L1ChainId)
 	checkFlag(utils.L1RpcUrlFlag.Name, cfg.L1RpcUrl)
@@ -230,4 +228,5 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	checkFlag(utils.L1QueryDelayFlag.Name, cfg.L1QueryDelay)
 	checkFlag(utils.TxPoolRejectSmartContractDeployments.Name, cfg.TxPoolRejectSmartContractDeployments)
 	checkFlag(utils.L1ContractAddressCheckFlag.Name, cfg.L1ContractAddressCheck)
+	checkFlag(utils.L1ContractAddressRetrieveFlag.Name, cfg.L1ContractAddressCheck)
 }


### PR DESCRIPTION
Fixes #1259

- added ``zkevm.l1-contract-address-retrieve`` flag. If true ``sequencer``, ``rollup`` and ``ger-manager`` contract addresses will be retrieved from the L1 using value of ``zkevm.address-zkevm`` flag
- If it's set to false ``zkevm.address-sequencer``, ``zkevm.address-rollup`` and ``zkevm.address-ger-manager`` flags should be set.
  - These flags will be validated based on the value of ``zkevm.l1-contract-address-check`` flag