### PR TITLE
1298 acl access control list augmentation

### DIFF
--- a/cmd/acl/README.md
+++ b/cmd/acl/README.md
@@ -32,7 +32,7 @@ Examples on how to setup your data-dir
 This command takes the following form: 
 
 ```shell
-    acl mode --datadir=<data-dir> --mode=<mode>
+    acl mode --datadir=<data-dir> --mode=<mode> --log_count=<number_integer>[optional]
 ```
 
 ## supported ACL Types
@@ -100,5 +100,5 @@ The `remove` command will remove the given policy from an account in given acces
     acl add --address=0x0921598333Cf3cE5FE2031C056C79aec59EE10b6 --policy=sendTx --type=allowlist --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool
     acl remove --address=0x0921598333Cf3cE5FE2031C056C79aec59EE10b6 --policy=sendTx --type=allowlist --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool
 
-    acl mode --mode=disabled --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool
+    acl mode --mode=disabled --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool --log_count=20
 ```

--- a/cmd/acl/README.md
+++ b/cmd/acl/README.md
@@ -3,28 +3,42 @@
 In the root of `Erigon` project, use this command to build the commands:
 
 ```shell
-make acl
+    make acl
 ```
 
 It can then be run using the following command
 
 ```shell
-./buid/bin/acl sub-command options...
+    ./buid/bin/acl sub-command options...
 ```
 
 Snapshots supports the following sub commands:
 
-## mode - access list mode
+## data-dir
+
+Examples on how to setup your data-dir
+
+```shell
+    # on sequencer:
+    /Path/Choosen/OnHermezConfig/txpool
+    # example
+    /Users/{$USER}/code/erigon-data/chain/txpool
+    # on default path:
+    /Users/{$USER}/Library/Erigon
+```
+
+## mode - set mode of access list 
 
 This command takes the following form: 
 
 ```shell
-    acl mode <data-dir> <mode>
+    acl mode --datadir=<data-dir> --mode=<mode>
 ```
 
 ## supported ACL Types
 - `allowlist` - allow list type
 - `blocklist` - block list type
+- `disabled` - doesn't block or allow, everyone is able to do transactions and deploy contracts.
 
 ## supported policies
 - `sendTx` - enables or disables ability of an account to send transactions (deploy contracts transactions not included).
@@ -42,7 +56,7 @@ This command can be used to update an access list in the `acl` data base.
 This command takes the following form: 
 
 ```shell
-    acl update <data-dir> <type> <csv>
+    acl update --datadir=<data-dir> --type=<type> --csv=<path_to_csv>
 ```
 The `update` command will read the `.csv` file provided which should be in format `address,"policy1,policy2"`, and update the defined `acl` in the `db`. Note that the `.csv` file is considered as the final state of policies for given `acl` type for defined addresses, meaning, if an address in the `.csv` file has `sendTx` policy, but in `db` it had `deploy`, after this command, it will have `sendTx` in the `db`, there is no appending. Also, it is worth mentioning that using a `.csv` file user can delete addresses from an `acl` table by leaving policies string as empty `""`. This will tell the command that the user wants to remove an address completely from an `acl`.
 
@@ -53,7 +67,7 @@ This command can be used to add a policy to an account in the specified `acl`.
 This command takes the following form: 
 
 ```shell
-    acl add <data-dir> <type> <address> <policy>
+    acl add --datadir=<data-dir> --type=<type> --address=<address> --policy=<policy>
 ```
 
 The `add` command will add the given policy to an account in given access list table if account is not already added to access list table, or if given account does not have that policy.
@@ -65,8 +79,26 @@ This command can be used to remove a policy from an account in the specified `ac
 This command takes the following form: 
 
 ```shell
-    acl remove <data-dir> <type> <address> <policy>
+    acl remove --datadir=<data-dir> --type=<type> --adress=<address> --policy=<policy>
 ```
 The `remove` command will remove the given policy from an account in given access list table if given account has that policy assigned.
 
+## list - log the information in current acl data-dir
 
+```shell
+    acl list --datadir=<data-dir>
+```
+
+## operating example:
+
+```shell
+    acl list  --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool
+
+    acl add --address=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --policy=deploy --type=blocklist --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool
+    acl add --address=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --policy=sendTx --type=blocklist --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool
+
+    acl add --address=0x0921598333Cf3cE5FE2031C056C79aec59EE10b6 --policy=sendTx --type=allowlist --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool
+    acl remove --address=0x0921598333Cf3cE5FE2031C056C79aec59EE10b6 --policy=sendTx --type=allowlist --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool
+
+    acl mode --mode=disabled --datadir=/Users/username_pc_mac/path_to_data/erigon-data/devnet/txpool
+```

--- a/cmd/acl/list/list.go
+++ b/cmd/acl/list/list.go
@@ -1,0 +1,36 @@
+package list
+
+import (
+	"fmt"
+
+	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/zk/txpool"
+	"github.com/ledgerwatch/log/v3"
+	"github.com/urfave/cli/v2"
+)
+
+var Command = cli.Command{
+	Action: run,
+	Name:   "list",
+	Usage:  "List the content at the ACL",
+	Flags: []cli.Flag{
+		&utils.DataDirFlag,
+	},
+}
+
+func run(cliCtx *cli.Context) error {
+
+	dataDir := cliCtx.String(utils.DataDirFlag.Name)
+	fmt.Println("Listing ", "dataDir:", dataDir)
+	log.Info("at ACL listing command")
+
+	aclDB, err := txpool.OpenACLDB(cliCtx.Context, dataDir)
+	if err != nil {
+		log.Error("Failed to open ACL database", "err", err)
+		return err
+	}
+
+	txpool.ListContentAtACL(cliCtx.Context, aclDB)
+
+	return nil
+}

--- a/cmd/acl/list/list.go
+++ b/cmd/acl/list/list.go
@@ -34,7 +34,7 @@ func run(cliCtx *cli.Context) error {
 		return nil
 	}
 	for i, pt := range pts {
-		log.Info("Policy transaction - ", "index:", i, "pt:", pt)
+		log.Info("Policy transaction - ", "index:", i, "pt:", pt.ToString())
 	}
 
 	return nil

--- a/cmd/acl/list/list.go
+++ b/cmd/acl/list/list.go
@@ -1,11 +1,9 @@
 package list
 
 import (
-	"fmt"
-
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/zk/txpool"
-	"github.com/ledgerwatch/log/v3"
+	"github.com/ledgerwatch/erigon/zkevm/log"
 	"github.com/urfave/cli/v2"
 )
 
@@ -19,10 +17,8 @@ var Command = cli.Command{
 }
 
 func run(cliCtx *cli.Context) error {
-
 	dataDir := cliCtx.String(utils.DataDirFlag.Name)
-	fmt.Println("Listing ", "dataDir:", dataDir)
-	log.Info("at ACL listing command")
+	log.Info("Listing ", "dataDir:", dataDir)
 
 	aclDB, err := txpool.OpenACLDB(cliCtx.Context, dataDir)
 	if err != nil {
@@ -30,7 +26,16 @@ func run(cliCtx *cli.Context) error {
 		return err
 	}
 
-	txpool.ListContentAtACL(cliCtx.Context, aclDB)
+	content, _ := txpool.ListContentAtACL(cliCtx.Context, aclDB)
+	log.Info(content)
+	pts, _ := txpool.LastPolicyTransactions(cliCtx.Context, aclDB)
+	if len(pts) == 0 {
+		log.Info("No policy transactions found")
+		return nil
+	}
+	for i, pt := range pts {
+		log.Info("Policy transaction - ", "index:", i, "pt:", pt)
+	}
 
 	return nil
 }

--- a/cmd/acl/main.go
+++ b/cmd/acl/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/ledgerwatch/erigon/cmd/acl/list"
 	"github.com/ledgerwatch/erigon/cmd/acl/mode"
 	"github.com/ledgerwatch/erigon/cmd/acl/update"
 	"github.com/ledgerwatch/erigon/params"
@@ -25,6 +26,7 @@ func main() {
 
 	app.Commands = []*cli.Command{
 		&mode.Command,
+		&list.Command,
 		&update.UpdateCommand,
 		&update.RemoveCommand,
 		&update.AddCommand,

--- a/cmd/acl/main.go
+++ b/cmd/acl/main.go
@@ -11,14 +11,11 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/acl/mode"
 	"github.com/ledgerwatch/erigon/cmd/acl/update"
 	"github.com/ledgerwatch/erigon/params"
-	"github.com/ledgerwatch/erigon/turbo/logging"
-	"github.com/ledgerwatch/log/v3"
+	"github.com/ledgerwatch/erigon/zkevm/log"
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
-	logging.LogVerbosityFlag.Value = log.LvlError.String()
-	logging.LogConsoleVerbosityFlag.Value = log.LvlError.String()
 
 	app := cli.NewApp()
 	app.Name = "acl"

--- a/cmd/acl/main.go
+++ b/cmd/acl/main.go
@@ -11,11 +11,15 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/acl/mode"
 	"github.com/ledgerwatch/erigon/cmd/acl/update"
 	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/turbo/logging"
 	"github.com/ledgerwatch/erigon/zkevm/log"
+	loglvl "github.com/ledgerwatch/log/v3"
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
+	logging.LogVerbosityFlag.Value = loglvl.LvlError.String()
+	logging.LogConsoleVerbosityFlag.Value = loglvl.LvlError.String()
 
 	app := cli.NewApp()
 	app.Name = "acl"

--- a/cmd/acl/mode/mode.go
+++ b/cmd/acl/mode/mode.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	mode string // Mode of the ACL
+	mode           string // Mode of the ACL
+	logCountOutput int    // Output for log count
 )
 
 var Command = cli.Command{
@@ -23,6 +24,11 @@ var Command = cli.Command{
 			Name:        "mode",
 			Usage:       "Mode of the ACL (allowlist, blocklist or disabled)",
 			Destination: &mode,
+		},
+		&cli.IntFlag{
+			Name:        "log_count",
+			Usage:       "Number of transactions at startup to log",
+			Destination: &logCountOutput,
 		},
 	},
 }
@@ -38,7 +44,7 @@ func run(cliCtx *cli.Context) error {
 
 	dataDir := cliCtx.String(utils.DataDirFlag.Name)
 
-	log.Info("Setting mode", "mode", mode, "dataDir", dataDir)
+	log.Info("Setting mode ", "mode - ", mode, "dataDir - ", dataDir, "log_count_output - ", logCountOutput)
 
 	aclDB, err := txpool.OpenACLDB(cliCtx.Context, dataDir)
 	if err != nil {
@@ -51,7 +57,13 @@ func run(cliCtx *cli.Context) error {
 		return err
 	}
 
-	log.Info("ACL Mode set", "mode", mode)
+	if cliCtx.IsSet("log_count") {
+		// Assuming you need to store log_count_output in the config table
+		if err := txpool.SetLogCount(cliCtx.Context, aclDB, logCountOutput); err != nil {
+			log.Error("Failed to set log_count_output", "err", err)
+			return err
+		}
+	}
 
 	return nil
 }

--- a/cmd/acl/mode/mode.go
+++ b/cmd/acl/mode/mode.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/zk/txpool"
-	"github.com/ledgerwatch/log/v3"
+	"github.com/ledgerwatch/erigon/zkevm/log"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/acl/mode/mode.go
+++ b/cmd/acl/mode/mode.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	mode           string // Mode of the ACL
-	logCountOutput int    // Output for log count
+	logCountOutput string // Output for log count
 )
 
 var Command = cli.Command{
@@ -25,7 +25,7 @@ var Command = cli.Command{
 			Usage:       "Mode of the ACL (allowlist, blocklist or disabled)",
 			Destination: &mode,
 		},
-		&cli.IntFlag{
+		&cli.StringFlag{
 			Name:        "log_count",
 			Usage:       "Number of transactions at startup to log",
 			Destination: &logCountOutput,

--- a/cmd/acl/update/update.go
+++ b/cmd/acl/update/update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/zk/txpool"
-	"github.com/ledgerwatch/log/v3"
+	"github.com/ledgerwatch/erigon/zkevm/log"
 	"github.com/urfave/cli/v2"
 )
 

--- a/zk/txpool/acl.go
+++ b/zk/txpool/acl.go
@@ -96,6 +96,7 @@ var (
 	errUnsupportedACLType = errors.New("unsupported acl type")
 	errUnknownACLTable    = errors.New("unknown acl table")
 	errUnknownPolicy      = errors.New("unknown policy")
+	errWrongOperation     = errors.New("wrong operation")
 )
 
 const ACLDB kv.Label = 255

--- a/zk/txpool/acl.go
+++ b/zk/txpool/acl.go
@@ -22,9 +22,10 @@ const (
 type ACLTable string
 
 const (
-	Config    = "Config"
-	Allowlist = "Allowlist"
-	BlockList = "BlockList"
+	Config             = "Config"
+	Allowlist          = "Allowlist"
+	BlockList          = "BlockList"
+	PolicyTransactions = "PolicyTransactions"
 )
 
 func (t ACLTable) String() string {
@@ -39,6 +40,8 @@ func ResolveACLTable(table string) (ACLTable, error) {
 		return Allowlist, nil
 	case "blocklist":
 		return BlockList, nil
+	case "policytransactions":
+		return PolicyTransactions, nil
 	default:
 		return "", errUnknownACLTable
 	}
@@ -88,6 +91,7 @@ var (
 		Config,
 		Allowlist,
 		BlockList,
+		PolicyTransactions,
 	}
 
 	ACLTablesCfg = kv.TableCfg{}

--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -261,10 +261,10 @@ func ListContentAtACL(ctx context.Context, db kv.RwDB) error {
 	var buffer bytes.Buffer
 
 	tables := db.AllTables()
-
-	buffer.WriteString("Tables\nTable - { Flags, AutoDupSortKeysConversion, IsDeprecated, DBI, DupFromLen, DupToLen }")
+	buffer.WriteString("ListContentAtACL\n")
+	buffer.WriteString("Tables\nTable - { Flags, AutoDupSortKeysConversion, IsDeprecated, DBI, DupFromLen, DupToLen }\n")
 	for key, config := range tables {
-		buffer.WriteString(fmt.Sprint(key, config))
+		buffer.WriteString(fmt.Sprint(key, config, "\n"))
 	}
 
 	err := db.View(ctx, func(tx kv.Tx) error {

--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -628,6 +628,15 @@ func SetMode(ctx context.Context, aclDB kv.RwDB, mode string) error {
 	})
 }
 
+// SetLogCount sets the mode of the ACL
+func SetLogCount(ctx context.Context, aclDB kv.RwDB, logCount int) error {
+	return aclDB.Update(ctx, func(tx kv.RwTx) error {
+		logCountBytes := make([]byte, 8)
+		binary.BigEndian.PutUint64(logCountBytes, uint64(logCount))
+		return tx.Put(Config, []byte(logCountPolicyTransactions), logCountBytes)
+	})
+}
+
 // GetMode gets the mode of the ACL
 func GetMode(ctx context.Context, aclDB kv.RwDB) (ACLMode, error) {
 	var mode ACLMode

--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -288,8 +288,8 @@ func UpdatePolicies(ctx context.Context, aclDB kv.RwDB, aclType string, addrs []
 }
 
 type PolicyTransaction struct {
-	aclType   ACLTypeBinary
 	addr      common.Address //  20 bytes in size
+	aclType   ACLTypeBinary
 	policy    Policy
 	operation Operation
 	timeTx    time.Time
@@ -304,8 +304,6 @@ func timestampToBytes(t time.Time) []byte {
 }
 
 func InsertPolicyTransaction(ctx context.Context, aclDB kv.RwDB, pt PolicyTransaction) error {
-	table := "historyTransaction"
-
 	t := pt.timeTx
 	// Convert time.Time to bytes
 	unixBytes := timestampToBytes(t)
@@ -314,7 +312,7 @@ func InsertPolicyTransaction(ctx context.Context, aclDB kv.RwDB, pt PolicyTransa
 	value := append([]byte{pt.aclType.ToByte(), pt.operation.ToByte(), pt.policy.ToByte()}, addressTimestamp...)
 
 	return aclDB.Update(ctx, func(tx kv.RwTx) error {
-		return tx.Put(table, addressTimestamp, value)
+		return tx.Put(PolicyTransactions, addressTimestamp, value)
 	})
 }
 

--- a/zk/txpool/policy_test.go
+++ b/zk/txpool/policy_test.go
@@ -296,18 +296,39 @@ func TestUpdatePolicies(t *testing.T) {
 		t.Parallel()
 
 		// Create test addresses and policies
-		addr1 := common.HexToAddress("0x1234567890abcdef")
-		addr2 := common.HexToAddress("0xabcdef1234567890")
+		addr1 := common.HexToAddress("0x1234567890abcdea")
+		addr2 := common.HexToAddress("0xabcdef1234567891")
+		policiesOld := [][]Policy{
+			{SendTx, Deploy},
+			{SendTx},
+		}
+
+		err := UpdatePolicies(ctx, db, "blocklist", []common.Address{addr1, addr2}, policiesOld)
+		require.NoError(t, err)
+
+		// Check if the policies are added correctly
+		hasPolicy, err := DoesAccountHavePolicy(ctx, db, addr1, SendTx)
+		require.NoError(t, err)
+		require.True(t, hasPolicy)
+
+		hasPolicy, err = DoesAccountHavePolicy(ctx, db, addr1, Deploy)
+		require.NoError(t, err)
+		require.True(t, hasPolicy)
+
+		hasPolicy, err = DoesAccountHavePolicy(ctx, db, addr2, SendTx)
+		require.NoError(t, err)
+		require.True(t, hasPolicy)
+
 		policies := [][]Policy{
 			{},
 			{SendTx},
 		}
 
-		err := UpdatePolicies(ctx, db, "blocklist", []common.Address{addr1, addr2}, policies)
+		err = UpdatePolicies(ctx, db, "blocklist", []common.Address{addr1, addr2}, policies)
 		require.NoError(t, err)
 
 		// Check if the policies are removed correctly
-		hasPolicy, err := DoesAccountHavePolicy(ctx, db, addr1, SendTx)
+		hasPolicy, err = DoesAccountHavePolicy(ctx, db, addr1, SendTx)
 		require.NoError(t, err)
 		require.False(t, hasPolicy)
 
@@ -324,18 +345,42 @@ func TestUpdatePolicies(t *testing.T) {
 		t.Parallel()
 
 		// Create test addresses and policies
-		addr1 := common.HexToAddress("0x1234567890abcdef")
-		addr2 := common.HexToAddress("0xabcdef1234567890")
+		addr1 := common.HexToAddress("0x1234567890abcded")
+		addr2 := common.HexToAddress("0xabcdef1234567893")
+
+		// first add these policies
+		policiesOld := [][]Policy{
+			{SendTx, Deploy},
+			{SendTx},
+		}
+
+		err := UpdatePolicies(ctx, db, "blocklist", []common.Address{addr1, addr2}, policiesOld)
+		require.NoError(t, err)
+
+		// Check if the policies are added correctly
+		hasPolicy, err := DoesAccountHavePolicy(ctx, db, addr1, SendTx)
+		require.NoError(t, err)
+		require.True(t, hasPolicy)
+
+		hasPolicy, err = DoesAccountHavePolicy(ctx, db, addr1, Deploy)
+		require.NoError(t, err)
+		require.True(t, hasPolicy)
+
+		hasPolicy, err = DoesAccountHavePolicy(ctx, db, addr2, SendTx)
+		require.NoError(t, err)
+		require.True(t, hasPolicy)
+
+		// then remove policies
 		policies := [][]Policy{
 			{},
 			{},
 		}
 
-		err := UpdatePolicies(ctx, db, "blocklist", []common.Address{addr1, addr2}, policies)
+		err = UpdatePolicies(ctx, db, "blocklist", []common.Address{addr1, addr2}, policies)
 		require.NoError(t, err)
 
 		// Check if the policies are removed correctly
-		hasPolicy, err := DoesAccountHavePolicy(ctx, db, addr1, SendTx)
+		hasPolicy, err = DoesAccountHavePolicy(ctx, db, addr1, SendTx)
 		require.NoError(t, err)
 		require.False(t, hasPolicy)
 

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -523,9 +523,6 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remote.StateChang
 		p.allowYieldingTransactions()
 	}
 
-	// Call to log to check ACL changes
-	ListContentAtACL(ctx, p.aclDB)
-
 	//log.Info("[txpool] new block", "number", p.lastSeenBlock.Load(), "pendngBaseFee", pendingBaseFee, "in", time.Since(t))
 	return nil
 }

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -523,6 +523,9 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remote.StateChang
 		p.allowYieldingTransactions()
 	}
 
+	// Call to log to check ACL changes
+	ListContentAtACL(ctx, p.aclDB)
+
 	//log.Info("[txpool] new block", "number", p.lastSeenBlock.Load(), "pendngBaseFee", pendingBaseFee, "in", time.Since(t))
 	return nil
 }

--- a/zk/txpool/txpooluitl/all_components.go
+++ b/zk/txpool/txpooluitl/all_components.go
@@ -117,6 +117,8 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, ethCfg *ethconfig.
 		return nil, nil, nil, nil, nil, err
 	}
 
+	txpool.ListContentAtACL(ctx, aclDB)
+
 	chainConfig, _, err := SaveChainConfigIfNeed(ctx, chainDB, txPoolDB, true)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err

--- a/zk/txpool/txpooluitl/all_components.go
+++ b/zk/txpool/txpooluitl/all_components.go
@@ -117,7 +117,9 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, ethCfg *ethconfig.
 		return nil, nil, nil, nil, nil, err
 	}
 
-	txpool.ListContentAtACL(ctx, aclDB)
+	// Log Content at StartUp
+	str, _ := txpool.ListContentAtACL(ctx, aclDB)
+	log.Info(str)
 
 	chainConfig, _, err := SaveChainConfigIfNeed(ctx, chainDB, txPoolDB, true)
 	if err != nil {


### PR DESCRIPTION
Adding new features to ACL to make easier to use.

- list of ACL data, to debug.
- README updated with new info.
- added new functions to create a history of transactions in acl.
- at normal acl operations added feature to add transactions to this history table.
- option at acl mode CLI to add new config variable value to the config table.
- added at startup a log of last X acl transactions changes ( 10 being the default ).