### PR TITLE
tweak(acl): log recent acl change transactions (default 10)

### DIFF
--- a/cmd/acl/README.md
+++ b/cmd/acl/README.md
@@ -32,7 +32,7 @@ Examples on how to setup your data-dir
 This command takes the following form: 
 
 ```shell
-    acl mode --datadir=<data-dir> --mode=<mode> --log_count=<number_integer>[optional]
+    acl mode --datadir=<data-dir> --mode=<mode> 
 ```
 
 ## supported ACL Types
@@ -86,7 +86,7 @@ The `remove` command will remove the given policy from an account in given acces
 ## list - log the information in current acl data-dir
 
 ```shell
-    acl list --datadir=<data-dir>
+    acl list --datadir=<data-dir> --log_count=<number_integer>[optional]
 ```
 
 ## operating example:

--- a/cmd/acl/list/list.go
+++ b/cmd/acl/list/list.go
@@ -28,7 +28,7 @@ func run(cliCtx *cli.Context) error {
 
 	content, _ := txpool.ListContentAtACL(cliCtx.Context, aclDB)
 	log.Info(content)
-	pts, _ := txpool.LastPolicyTransactions(cliCtx.Context, aclDB)
+	pts, _ := txpool.LastPolicyTransactions(cliCtx.Context, aclDB, 10)
 	if len(pts) == 0 {
 		log.Info("No policy transactions found")
 		return nil

--- a/cmd/acl/list/list.go
+++ b/cmd/acl/list/list.go
@@ -7,12 +7,19 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var logCountOutput int // Output for log count
+
 var Command = cli.Command{
 	Action: run,
 	Name:   "list",
 	Usage:  "List the content at the ACL",
 	Flags: []cli.Flag{
 		&utils.DataDirFlag,
+		&cli.IntFlag{
+			Name:        "log_count",
+			Usage:       "Number of transactions at startup to log",
+			Destination: &logCountOutput,
+		},
 	},
 }
 
@@ -28,7 +35,7 @@ func run(cliCtx *cli.Context) error {
 
 	content, _ := txpool.ListContentAtACL(cliCtx.Context, aclDB)
 	log.Info(content)
-	pts, _ := txpool.LastPolicyTransactions(cliCtx.Context, aclDB, 10)
+	pts, _ := txpool.LastPolicyTransactions(cliCtx.Context, aclDB, logCountOutput)
 	if len(pts) == 0 {
 		log.Info("No policy transactions found")
 		return nil

--- a/cmd/acl/mode/mode.go
+++ b/cmd/acl/mode/mode.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	mode           string // Mode of the ACL
-	logCountOutput string // Output for log count
+	mode string // Mode of the ACL
 )
 
 var Command = cli.Command{
@@ -24,11 +23,6 @@ var Command = cli.Command{
 			Name:        "mode",
 			Usage:       "Mode of the ACL (allowlist, blocklist or disabled)",
 			Destination: &mode,
-		},
-		&cli.StringFlag{
-			Name:        "log_count",
-			Usage:       "Number of transactions at startup to log",
-			Destination: &logCountOutput,
 		},
 	},
 }
@@ -44,7 +38,7 @@ func run(cliCtx *cli.Context) error {
 
 	dataDir := cliCtx.String(utils.DataDirFlag.Name)
 
-	log.Info("Setting mode ", "mode - ", mode, "dataDir - ", dataDir, "log_count_output - ", logCountOutput)
+	log.Info("Setting mode ", "mode - ", mode, "dataDir - ", dataDir)
 
 	aclDB, err := txpool.OpenACLDB(cliCtx.Context, dataDir)
 	if err != nil {
@@ -55,14 +49,6 @@ func run(cliCtx *cli.Context) error {
 	if err := txpool.SetMode(cliCtx.Context, aclDB, mode); err != nil {
 		log.Error("Failed to set acl mode", "err", err)
 		return err
-	}
-
-	if cliCtx.IsSet("log_count") {
-		// Assuming you need to store log_count_output in the config table
-		if err := txpool.SetLogCount(cliCtx.Context, aclDB, logCountOutput); err != nil {
-			log.Error("Failed to set log_count_output", "err", err)
-			return err
-		}
 	}
 
 	return nil

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -733,6 +733,11 @@ var (
 		Usage: "The multiplier to reduce the SMT depth by when calculating virtual counters",
 		Value: 0.6,
 	}
+	ACLPrintHistory = cli.IntFlag{
+		Name:  "acl.print-history",
+		Usage: "Number of entries to print from the ACL history on node startup",
+		Value: 10,
+	}
 	DebugTimers = cli.BoolFlag{
 		Name:  "debug.timers",
 		Usage: "Enable debug timers",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -86,6 +86,8 @@ type Zk struct {
 	ExecutorPayloadOutput       string
 
 	TxPoolRejectSmartContractDeployments bool
+
+	ACLPrintHistory int
 }
 
 var DefaultZkConfig = &Zk{}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -281,4 +281,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.DisableVirtualCounters,
 	&utils.DAUrl,
 	&utils.VirtualCountersSmtReduction,
+
+	&utils.ACLPrintHistory,
 }

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -184,6 +184,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		DataStreamWriteTimeout:                 ctx.Duration(utils.DataStreamWriteTimeout.Name),
 		DataStreamInactivityTimeout:            ctx.Duration(utils.DataStreamInactivityTimeout.Name),
 		VirtualCountersSmtReduction:            ctx.Float64(utils.VirtualCountersSmtReduction.Name),
+		ACLPrintHistory:                        ctx.Int(utils.ACLPrintHistory.Name),
 	}
 
 	utils2.EnableTimer(cfg.DebugTimers)

--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -607,19 +606,6 @@ func SetMode(ctx context.Context, aclDB kv.RwDB, mode string) error {
 
 	return aclDB.Update(ctx, func(tx kv.RwTx) error {
 		return tx.Put(Config, []byte(modeKey), []byte(m))
-	})
-}
-
-// SetLogCount sets the mode of the ACL
-func SetLogCount(ctx context.Context, aclDB kv.RwDB, logCount string) error {
-
-	_, err := strconv.Atoi(logCount)
-	if err != nil {
-		return fmt.Errorf("invalid log count, nan: %s", logCount)
-	}
-
-	return aclDB.Update(ctx, func(tx kv.RwTx) error {
-		return tx.Put(Config, []byte(logCountPolicyTransactions), []byte(logCount))
 	})
 }
 

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -360,6 +360,7 @@ func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, 
 	for _, sender := range cfg.TracedSenders {
 		tracedSenders[common.BytesToAddress([]byte(sender))] = struct{}{}
 	}
+
 	return &TxPool{
 		lock:                    &sync.Mutex{},
 		byHash:                  map[string]*metaTx{},

--- a/zk/txpool/txpooluitl/all_components.go
+++ b/zk/txpool/txpooluitl/all_components.go
@@ -117,9 +117,15 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, ethCfg *ethconfig.
 		return nil, nil, nil, nil, nil, err
 	}
 
-	// Log Content at StartUp
-	str, _ := txpool.ListContentAtACL(ctx, aclDB)
-	log.Info(str)
+	if ethCfg.Zk.ACLPrintHistory > 0 {
+		pts, _ := txpool.LastPolicyTransactions(context.Background(), aclDB, ethCfg.Zk.ACLPrintHistory)
+		if len(pts) == 0 {
+			log.Info("[ACL] No policy transactions found")
+		}
+		for i, pt := range pts {
+			log.Info("[ACL] Policy transaction - ", "index:", i, "pt:", pt.ToString())
+		}
+	}
 
 	chainConfig, _, err := SaveChainConfigIfNeed(ctx, chainDB, txPoolDB, true)
 	if err != nil {


### PR DESCRIPTION
- output last 10 transactions by default from ACL
- configurable via flag `acl.print-history`