### PR TITLE
Remove duplicated fields and fix websocket port

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -123,8 +123,8 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	rootCmd.PersistentFlags().BoolVar(&cfg.HttpCompression, "http.compression", true, "Disable http compression")
 	rootCmd.PersistentFlags().BoolVar(&cfg.WebsocketEnabled, "ws", false, "Enable Websockets - Same port as HTTP[S]")
 	rootCmd.PersistentFlags().BoolVar(&cfg.WebsocketCompression, "ws.compression", false, "Enable Websocket compression (RFC 7692)")
-	rootCmd.PersistentFlags().StringVar(&cfg.WebSocketListenAddress, "ws.addr", nodecfg.DefaultHTTPHost, "Websocket server listening interface")
-	rootCmd.PersistentFlags().IntVar(&cfg.WebSocketPort, "ws.port", nodecfg.DefaultHTTPPort, "Websocket server listening port")
+	rootCmd.PersistentFlags().StringVar(&cfg.WebsocketListenAddress, "ws.addr", nodecfg.DefaultHTTPHost, "Websocket server listening interface")
+	rootCmd.PersistentFlags().IntVar(&cfg.WebsocketPort, "ws.port", nodecfg.DefaultHTTPPort, "Websocket server listening port")
 	rootCmd.PersistentFlags().StringSliceVar(&cfg.WebsocketCORSDomain, "ws.corsdomain", []string{}, "Comma separated list of domains from which to accept cross origin requests (browser enforced)")
 
 	rootCmd.PersistentFlags().BoolVar(&cfg.HttpsServerEnabled, "https.enabled", false, "enable http server")
@@ -731,7 +731,7 @@ func startRegularRpcServer(ctx context.Context, cfg *httpcfg.HttpCfg, rpcAPI []r
 		}
 
 		var wsApiFlags []string
-		for _, flag := range cfg.WebSocketApi {
+		for _, flag := range cfg.WebsocketApi {
 			if flag != "engine" {
 				wsApiFlags = append(wsApiFlags, flag)
 			}
@@ -763,7 +763,7 @@ func startRegularRpcServer(ctx context.Context, cfg *httpcfg.HttpCfg, rpcAPI []r
 			return fmt.Errorf("could not start register RPC apis: %w", err)
 		}
 
-		wsEndpoint := fmt.Sprintf("tcp://%s:%d", cfg.WebSocketListenAddress, cfg.WebSocketPort)
+		wsEndpoint := fmt.Sprintf("tcp://%s:%d", cfg.WebsocketListenAddress, cfg.WebsocketPort)
 
 		wsHttpHandler := wsSrv.WebsocketHandler(cfg.WebsocketCORSDomain, nil, cfg.WebsocketCompression, logger)
 		wsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -48,10 +48,9 @@ type HttpCfg struct {
 	WebsocketEnabled                  bool
 	WebsocketCompression              bool
 	WebsocketSubscribeLogsChannelSize int
-	WebSocketListenAddress            string
-	WebSocketPort                     int
+	WebsocketListenAddress            string
 	WebsocketCORSDomain               []string
-	WebSocketApi                      []string
+	WebsocketApi                      []string
 	RpcAllowListFilePath              string
 	RpcBatchConcurrency               uint
 	RpcStreamingDisable               bool

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -489,6 +489,9 @@ func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *nodecfg.Config, logger log.Logg
 		WebsocketPort:                     ctx.Int(utils.WSPortFlag.Name),
 		WebsocketEnabled:                  ctx.IsSet(utils.WSEnabledFlag.Name),
 		WebsocketSubscribeLogsChannelSize: ctx.Int(utils.WSSubscribeLogsChannelSize.Name),
+		WebsocketListenAddress:            ctx.String(utils.WSListenAddrFlag.Name),
+		WebsocketCORSDomain:               strings.Split(ctx.String(utils.WSAllowedOriginsFlag.Name), ","),
+		WebsocketApi:                      wsApis,
 		RpcBatchConcurrency:               ctx.Uint(utils.RpcBatchConcurrencyFlag.Name),
 		RpcStreamingDisable:               ctx.Bool(utils.RpcStreamingDisableFlag.Name),
 		DBReadConcurrency:                 ctx.Int(utils.DBReadConcurrencyFlag.Name),
@@ -501,10 +504,6 @@ func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *nodecfg.Config, logger log.Logg
 		ReturnDataLimit:                   ctx.Int(utils.RpcReturnDataLimit.Name),
 		AllowUnprotectedTxs:               ctx.Bool(utils.AllowUnprotectedTxs.Name),
 		MaxGetProofRewindBlockCount:       ctx.Int(utils.RpcMaxGetProofRewindBlockCount.Name),
-
-		WebSocketListenAddress: ctx.String(utils.WSListenAddrFlag.Name),
-		WebsocketCORSDomain:    strings.Split(ctx.String(utils.WSAllowedOriginsFlag.Name), ","),
-		WebSocketApi:           wsApis,
 
 		TxPoolApiAddr: ctx.String(utils.TxpoolApiAddrFlag.Name),
 


### PR DESCRIPTION
Due to merge conflicts, two flags `WebSocketPort` (uppercase `S`) and `WebsocketPort` (lowercase `s`) were both used in the config, resulting in the flag value not being propagated correctly.
This commit will remove the inconsistency and use `WebsocketXXXX` for all websocket-related flags.