### PR TITLE
Fix zk counter for all HFs

### DIFF
--- a/core/vm/zk_counters_limits.go
+++ b/core/vm/zk_counters_limits.go
@@ -10,9 +10,9 @@ const stepDeduction = 200
 const baseSafetyPercentage float64 = 0.05
 
 var (
-	defaultTotalSteps  = 1 << 23
-	forkId10TotalSteps = 1 << 24
-	forkId11TotalSteps = 1 << 25
+	preForkId10TotalSteps = 1 << 23
+	forkId10TotalSteps    = 1 << 24
+	forkId11TotalSteps    = 1 << 25
 
 	unlimitedCounters = counterLimits{
 		totalSteps: math.MaxInt32,
@@ -102,13 +102,13 @@ func getCounterLimits(forkId uint16) *Counters {
 func getTotalSteps(forkId uint16) int {
 	var totalSteps int
 
-	switch forkId {
-	case uint16(zk_consts.ForkID10):
+	if forkId < uint16(zk_consts.ForkID10) {
+		return preForkId10TotalSteps
+	} else if forkId == uint16(zk_consts.ForkID10) {
 		totalSteps = forkId10TotalSteps
-	case uint16(zk_consts.ForkID11):
+	} else if forkId >= uint16(zk_consts.ForkID11) {
+		// Use the new total steps for ForkID11 and above, unless a new limit is added in the future
 		totalSteps = forkId11TotalSteps
-	default:
-		totalSteps = defaultTotalSteps
 	}
 
 	// we need to remove some steps as these will always be used during batch execution

--- a/core/vm/zk_counters_limits_test.go
+++ b/core/vm/zk_counters_limits_test.go
@@ -1,0 +1,67 @@
+package vm
+
+import (
+	"testing"
+
+	zk_consts "github.com/ledgerwatch/erigon-lib/chain"
+)
+
+func TestGetTotalSteps(t *testing.T) {
+	tests := []struct {
+		name     string
+		forkID   uint16
+		expected int
+	}{
+		{
+			name:     "Pre ForkID10",
+			forkID:   uint16(zk_consts.ForkID9Elderberry2),
+			expected: preForkId10TotalSteps, // 1 << 23
+		},
+		{
+			name:     "ForkID10",
+			forkID:   uint16(zk_consts.ForkID10),
+			expected: forkId10TotalSteps - stepDeduction,
+		},
+		{
+			name:     "ForkID11",
+			forkID:   uint16(zk_consts.ForkID11),
+			expected: forkId11TotalSteps - stepDeduction,
+		},
+		{
+			name:     "ForkID12",
+			forkID:   uint16(zk_consts.ForkID12Banana),
+			expected: forkId11TotalSteps - stepDeduction,
+		},
+		{
+			name:     "ForkID13",
+			forkID:   uint16(zk_consts.ForkId13Durian),
+			expected: forkId11TotalSteps - stepDeduction,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getTotalSteps(tt.forkID)
+			if got != tt.expected {
+				t.Errorf("getTotalSteps(%d) = %d, want %d", tt.forkID, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCounterLimitsProgression(t *testing.T) {
+	// Test that forkid progression is correct from for 9 to 100
+	startForkID := uint16(zk_consts.ForkID9Elderberry2)
+	endForkID := uint16(100)
+
+	var prevLimit int
+	for forkID := startForkID; forkID <= endForkID; forkID++ {
+		currentLimit := getTotalSteps(forkID)
+
+		if prevLimit > currentLimit {
+			t.Errorf("ForkID %d has fewer steps (%d) than previous forkID %d (%d)!", forkID, currentLimit, forkID-1, prevLimit)
+		}
+
+		prevLimit = currentLimit
+	}
+}


### PR DESCRIPTION
Total steps for forkId 12+ was incorrectly set to pre-forkId9 value (`defaultTotalSteps  = 1 << 23`). It should've been set to `1 << 25`.