### PR TITLE
test: add unit tests for txpool/policy

### DIFF
--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -355,6 +355,9 @@ func bytesToTimestamp(b []byte) time.Time {
 func LastPolicyTransactions(ctx context.Context, aclDB kv.RwDB, count int) ([]PolicyTransaction, error) {
 	var pts []PolicyTransaction
 	err := aclDB.View(ctx, func(tx kv.Tx) error {
+		if count == 0 {
+			return nil
+		}
 		c, err := tx.Cursor(PolicyTransactions)
 		if err != nil {
 			return err

--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -371,7 +371,7 @@ func LastPolicyTransactions(ctx context.Context, aclDB kv.RwDB, count int) ([]Po
 		}
 		pts = append(pts, pt)
 
-		for i := 0; i < count; i++ {
+		for i := 1; i < count; i++ {
 			_, value, err = c.Prev()
 			if err != nil {
 				return err

--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -45,6 +45,8 @@ func OperationFromByte(b byte) Operation {
 		return Remove
 	case byte(Update):
 		return Update
+	case byte(ModeChange):
+		return ModeChange
 	default:
 		return Add // Default or error handling can be added here
 	}

--- a/zk/txpool/policy_test.go
+++ b/zk/txpool/policy_test.go
@@ -69,6 +69,31 @@ func newTestTxPoolDB(tb testing.TB, dir string) kv.RwDB {
 	return txPoolDB
 }
 
+func policyTransactionSliceEqual(a, b []PolicyTransaction) bool {
+	// Check if lengths are different
+	if len(a) != len(b) {
+		return false
+	}
+
+	// Check each element, excluding timeTx
+	for i := range a {
+		if a[i].aclType != b[i].aclType {
+			return false
+		}
+		if ACLTypeBinary(a[i].operation) != ACLTypeBinary(b[i].operation) {
+			return false
+		}
+		if a[i].addr != b[i].addr {
+			return false
+		}
+		if a[i].policy != b[i].policy {
+			return false
+		}
+	}
+
+	return true
+}
+
 func TestCheckDBsCreation(t *testing.T) {
 	t.Parallel()
 
@@ -407,6 +432,51 @@ func TestUpdatePolicies(t *testing.T) {
 		err := UpdatePolicies(ctx, db, "unknown_acl_type", []common.Address{addr1, addr2}, policies)
 		require.ErrorIs(t, err, errUnsupportedACLType)
 	})
+}
+
+func TestLastPolicyTransactions(t *testing.T) {
+	db := newTestACLDB(t, "")
+	ctx := context.Background()
+
+	SetMode(ctx, db, BlocklistMode)
+
+	// Create a test address and policy
+	addrOne := common.HexToAddress("0x1234567890abcdef")
+	policyOne := SendTx
+
+	// addrTwo := common.HexToAddress("0xabcdef1234567890")
+	// policyTwo := SendTx
+
+	// Add the policy to the ACL
+	require.NoError(t, AddPolicy(ctx, db, "blocklist", addrOne, policyOne))
+	// require.NoError(t, AddPolicy(ctx, db, "blocklist", addrTwo, policyTwo))
+
+	// Create expected policyTransaction output and append to []PolicyTransaction
+	policyTransactionOne := PolicyTransaction{addr: common.HexToAddress("0x1234567890abcdef"), aclType: ResolveACLTypeToBinary("blocklist"), policy: Policy(SendTx.ToByte()), operation: Operation(Add.ToByte())}
+	// policyTransactionTwo := PolicyTransaction{addr: common.HexToAddress("0xabcdef1234567890"), aclType: ResolveACLTypeToBinary("blocklist"), policy: Policy(SendTx.ToByte()), operation: Operation(Add.ToByte())}
+
+	var policyTransactionSlice []PolicyTransaction
+	policyTransactionSlice = append(policyTransactionSlice, policyTransactionOne)
+	// policyTransactionSlice = append(policyTransactionSlice, policyTransactionTwo)
+
+	// Table driven test
+	var tests = []struct {
+		count int
+		want  []PolicyTransaction
+	}{
+		{1, policyTransactionSlice},
+	}
+	for _, tt := range tests {
+		t.Run("LastPolicyTransactions", func(t *testing.T) {
+			ans, _ := LastPolicyTransactions(ctx, db, tt.count)
+			// if err != nil {
+			// 	t.Errorf("LastPolicyTransactions did not execute successfully: %v", err)
+			// }
+			if !policyTransactionSliceEqual(ans, tt.want) {
+				t.Errorf("got %v, want %v", ans, tt.want)
+			}
+		})
+	}
 }
 
 func TestIsActionAllowed(t *testing.T) {

--- a/zk/txpool/policy_test.go
+++ b/zk/txpool/policy_test.go
@@ -457,6 +457,9 @@ func TestLastPolicyTransactions(t *testing.T) {
 
 	// LastPolicyTransactions seems to append in reverse order than this test function. So the order of elements is also reversed
 	// Single element in PolicyTransaction slice
+	var policyTransactionSliceNone []PolicyTransaction
+
+	// Single element in PolicyTransaction slice
 	var policyTransactionSliceSingle []PolicyTransaction
 	policyTransactionSliceSingle = append(policyTransactionSliceSingle, policyTransactionTwo)
 
@@ -470,6 +473,7 @@ func TestLastPolicyTransactions(t *testing.T) {
 		count int
 		want  []PolicyTransaction
 	}{
+		{0, policyTransactionSliceNone},
 		{1, policyTransactionSliceSingle},
 		{2, policyTransactionSliceDouble},
 	}


### PR DESCRIPTION
This PR brings two chagnes:
- adds unit test for the [LastPolicyTransactions](https://github.com/0xPolygonHermez/cdk-erigon/blob/zkevm/zk/txpool/policy.go#L355) function for extended test coverage.
- fix an issue where LastPolicyTransactions would return an error in case where there is only a single element in the PolicyTransaction slice.
![Screenshot from 2024-10-28 17-27-53](https://github.com/user-attachments/assets/967ec282-1574-4f78-a4ae-9738d8479be1)
