### PR TITLE
fix: change return value of ListContentAtACL and write test for it

### DIFF
--- a/zk/txpool/policy.go
+++ b/zk/txpool/policy.go
@@ -556,12 +556,15 @@ func RemovePolicy(ctx context.Context, aclDB kv.RwDB, aclType string, addr commo
 	return err
 }
 
-func ListContentAtACL(ctx context.Context, db kv.RwDB) (string, error) {
-
+func ListContentAtACL(ctx context.Context, db kv.RwDB) ([]string, error) {
+	var combinedBuffers []string
 	var buffer bytes.Buffer
+	var bufferConfig bytes.Buffer
+	var bufferBlockList bytes.Buffer
+	var bufferAllowlist bytes.Buffer
 
 	tables := db.AllTables()
-	buffer.WriteString("ListContentAtACL\n")
+	buffer.WriteString(" \n")
 	buffer.WriteString("Tables\nTable - { Flags, AutoDupSortKeysConversion, IsDeprecated, DBI, DupFromLen, DupToLen }\n")
 	for key, config := range tables {
 		buffer.WriteString(fmt.Sprint(key, config, "\n"))
@@ -572,6 +575,7 @@ func ListContentAtACL(ctx context.Context, db kv.RwDB) (string, error) {
 		buffer.WriteString("\nConfig\n")
 		err := tx.ForEach(Config, nil, func(k, v []byte) error {
 			buffer.WriteString(fmt.Sprintf("Key: %s, Value: %s\n", string(k), string(v)))
+			bufferConfig.WriteString(fmt.Sprintf("Key: %s, Value: %s\n", string(k), string(v)))
 			return nil
 		})
 
@@ -593,10 +597,14 @@ func ListContentAtACL(ctx context.Context, db kv.RwDB) (string, error) {
 				"\nBlocklist\n%s",
 				BlockListContent.String(),
 			))
+			bufferBlockList.WriteString(fmt.Sprintf(
+				"\nBlocklist\n%s",
+				BlockListContent.String(),
+			))
 		} else {
 			buffer.WriteString("\nBlocklist is empty")
+			bufferBlockList.WriteString("\nBlocklist is empty")
 		}
-
 		// Allowlist table
 		var AllowlistContent strings.Builder
 		err = tx.ForEach(Allowlist, nil, func(k, v []byte) error {
@@ -615,14 +623,24 @@ func ListContentAtACL(ctx context.Context, db kv.RwDB) (string, error) {
 				"\nAllowlist\n%s",
 				AllowlistContent.String(),
 			))
+			bufferAllowlist.WriteString(fmt.Sprintf(
+				"\nAllowlist\n%s",
+				AllowlistContent.String(),
+			))
 		} else {
 			buffer.WriteString("\nAllowlist is empty")
+			bufferAllowlist.WriteString("\nAllowlist is empty")
 		}
 
 		return err
 	})
 
-	return buffer.String(), err
+	combinedBuffers = append(combinedBuffers, buffer.String())
+	combinedBuffers = append(combinedBuffers, bufferConfig.String())
+	combinedBuffers = append(combinedBuffers, bufferBlockList.String())
+	combinedBuffers = append(combinedBuffers, bufferAllowlist.String())
+
+	return combinedBuffers, err
 }
 
 // SetMode sets the mode of the ACL

--- a/zk/txpool/policy_test.go
+++ b/zk/txpool/policy_test.go
@@ -508,34 +508,30 @@ func TestListContentAtACL(t *testing.T) {
 	require.NoError(t, err)
 
 	var tests = []struct {
-		table         string
 		wantAllowlist string
 		wantBlockList string
 	}{
-		{"tableOne", "\nAllowlist\nKey: 0000000000000000000000001234567890abcdef, Value: {\n\tdeploy: false\n\tsendTx: true\n}\n", "\nBlocklist\nKey: 0000000000000000000000001234567890abcdef, Value: {\n\tsendTx: true\n\tdeploy: false\n}\n"},
+		{"\nAllowlist\nKey: 0000000000000000000000001234567890abcdef, Value: {\n\tdeploy: false\n\tsendTx: true\n}\n", "\nBlocklist\nKey: 0000000000000000000000001234567890abcdef, Value: {\n\tsendTx: true\n\tdeploy: false\n}\n"},
 	}
 	// ListContentAtACL will return []string in the following order:
-	// buffer.String()
-	// bufferConfig.String()
-	// bufferBlockList.String()
-	// bufferAllowlist.String()
+	// [buffer.String(), bufferConfig.String(), bufferBlockList.String(), bufferAllowlist.String()]
 	ans, err := ListContentAtACL(ctx, db)
 	for _, tt := range tests {
 		t.Run("ListContentAtACL", func(t *testing.T) {
 			switch {
 			case err != nil:
 				t.Errorf("ListContentAtACL did not execute successfully: %v", err)
-			case !strings.Contains(tt.wantAllowlist, "\nAllowlist\nKey: 0000000000000000000000001234567890abcdef"):
+			case !strings.Contains(ans[3], "\nAllowlist\nKey: 0000000000000000000000001234567890abcdef"):
 				t.Errorf("got %v, want %v", ans, tt.wantAllowlist)
-			case !strings.Contains(tt.wantAllowlist, "sendTx: true"):
+			case !strings.Contains(ans[3], "sendTx: true"):
 				t.Errorf("got %v, want %v", ans, tt.wantAllowlist)
-			case !strings.Contains(tt.wantAllowlist, "deploy: false"):
+			case !strings.Contains(ans[3], "deploy: false"):
 				t.Errorf("got %v, want %v", ans, tt.wantAllowlist)
-			case !strings.Contains(tt.wantBlockList, "\nBlocklist\nKey: 0000000000000000000000001234567890abcdef"):
+			case !strings.Contains(ans[2], "\nBlocklist\nKey: 0000000000000000000000001234567890abcdef"):
 				t.Errorf("got %v, want %v", ans, tt.wantBlockList)
-			case !strings.Contains(tt.wantBlockList, "sendTx: true"):
+			case !strings.Contains(ans[2], "sendTx: true"):
 				t.Errorf("got %v, want %v", ans, tt.wantBlockList)
-			case !strings.Contains(tt.wantBlockList, "deploy: false"):
+			case !strings.Contains(ans[2], "deploy: false"):
 				t.Errorf("got %v, want %v", ans, tt.wantBlockList)
 			}
 		})

--- a/zk/txpool/policy_test.go
+++ b/zk/txpool/policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -485,4 +486,58 @@ func TestIsActionAllowed(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, allowed) // In disabled mode, all actions are allowed
 	})
+}
+
+func TestListContentAtACL(t *testing.T) {
+	db := newTestACLDB(t, "")
+	ctx := context.Background()
+
+	// Populate different tables in ACL
+	// Create a test address and policy for allowlist table
+	addrAllowlist := common.HexToAddress("0x1234567890abcdef")
+	policyAllowlist := SendTx
+
+	err := AddPolicy(ctx, db, "allowlist", addrAllowlist, policyAllowlist)
+	require.NoError(t, err)
+
+	// Create a test address and policy for blocklist table
+	addrBlocklist := common.HexToAddress("0x1234567890abcdef")
+	policyBlocklist := SendTx
+
+	err = AddPolicy(ctx, db, "blocklist", addrBlocklist, policyBlocklist)
+	require.NoError(t, err)
+
+	var tests = []struct {
+		table         string
+		wantAllowlist string
+		wantBlockList string
+	}{
+		{"tableOne", "\nAllowlist\nKey: 0000000000000000000000001234567890abcdef, Value: {\n\tdeploy: false\n\tsendTx: true\n}\n", "\nBlocklist\nKey: 0000000000000000000000001234567890abcdef, Value: {\n\tsendTx: true\n\tdeploy: false\n}\n"},
+	}
+	// ListContentAtACL will return []string in the following order:
+	// buffer.String()
+	// bufferConfig.String()
+	// bufferBlockList.String()
+	// bufferAllowlist.String()
+	ans, err := ListContentAtACL(ctx, db)
+	for _, tt := range tests {
+		t.Run("ListContentAtACL", func(t *testing.T) {
+			switch {
+			case err != nil:
+				t.Errorf("ListContentAtACL did not execute successfully: %v", err)
+			case !strings.Contains(tt.wantAllowlist, "\nAllowlist\nKey: 0000000000000000000000001234567890abcdef"):
+				t.Errorf("got %v, want %v", ans, tt.wantAllowlist)
+			case !strings.Contains(tt.wantAllowlist, "sendTx: true"):
+				t.Errorf("got %v, want %v", ans, tt.wantAllowlist)
+			case !strings.Contains(tt.wantAllowlist, "deploy: false"):
+				t.Errorf("got %v, want %v", ans, tt.wantAllowlist)
+			case !strings.Contains(tt.wantBlockList, "\nBlocklist\nKey: 0000000000000000000000001234567890abcdef"):
+				t.Errorf("got %v, want %v", ans, tt.wantBlockList)
+			case !strings.Contains(tt.wantBlockList, "sendTx: true"):
+				t.Errorf("got %v, want %v", ans, tt.wantBlockList)
+			case !strings.Contains(tt.wantBlockList, "deploy: false"):
+				t.Errorf("got %v, want %v", ans, tt.wantBlockList)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR introduces a few important changes to the [ListContentAtACL](https://github.com/0xPolygonHermez/cdk-erigon/blob/zkevm/zk/txpool/policy.go#L559) function:
- Previously, the return value of `ListContentAtACL` was dynamic, and there were `756` unique combinations for the output (5, 2, 2). The nature of the db query could not be changed, but to make this much more predictable and testable, the previous return value has been split into 4 different strings - all combined to return a `[]string`. The slice of strings contains the original output, in addition to three other outputs, separated by the table names:
    - 	combinedBuffers = append(combinedBuffers, buffer.String())
	combinedBuffers = append(combinedBuffers, bufferConfig.String())
	combinedBuffers = append(combinedBuffers, bufferBlockList.String())
	combinedBuffers = append(combinedBuffers, bufferAllowlist.String())
- The above change allows the function to be testable by not looking at all the possible combinations, but by looking at the individual table outputs, and checking whether the mocked values exist using `strings.Contains`