### PR TITLE
Regular info tree updates (#1399)

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -678,6 +678,16 @@ var (
 		Usage: "A comma separated list of batch numbers that are known bad on the L1. These will automatically be marked as bad during L1 recovery",
 		Value: "",
 	}
+	InfoTreeUpdateInterval = cli.DurationFlag{
+		Name:  "zkevm.info-tree-update-interval",
+		Usage: "The interval at which the sequencer checks the L1 for new GER information",
+		Value: 1 * time.Minute,
+	}
+	ACLPrintHistory = cli.IntFlag{
+		Name:  "acl.print-history",
+		Usage: "Number of entries to print from the ACL history on node start up",
+		Value: 10,
+	}
 	DebugTimers = cli.BoolFlag{
 		Name:  "debug.timers",
 		Usage: "Enable debug timers",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -125,6 +125,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/utils"
 	"github.com/ledgerwatch/erigon/zk/witness"
 	"github.com/ledgerwatch/erigon/zkevm/etherman"
+	"github.com/ledgerwatch/erigon/zk/l1infotree"
 )
 
 // Config contains the configuration options of the ETH protocol.
@@ -871,6 +872,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			cfg.L1HighestBlockType,
 		)
 
+		l1InfoTreeUpdater := l1infotree.NewUpdater(cfg.Zk, l1InfoTreeSyncer)
+
 		if isSequencer {
 			// if we are sequencing transactions, we do the sequencing loop...
 			witnessGenerator := witness.NewGenerator(
@@ -941,11 +944,11 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 				backend.dataStream,
 				backend.l1Syncer,
 				seqVerSyncer,
-				l1InfoTreeSyncer,
 				l1BlockSyncer,
 				backend.txPool2,
 				backend.txPool2DB,
 				verifier,
+				l1InfoTreeUpdater,
 			)
 
 			backend.syncUnwindOrder = zkStages.ZkSequencerUnwindOrder
@@ -979,9 +982,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 				backend.forkValidator,
 				backend.engine,
 				backend.l1Syncer,
-				l1InfoTreeSyncer,
 				streamClient,
 				backend.dataStream,
+				l1InfoTreeUpdater,
 			)
 
 			backend.syncUnwindOrder = zkStages.ZkUnwindOrder

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -82,6 +82,8 @@ type Zk struct {
 
 	TxPoolRejectSmartContractDeployments bool
 
+	ACLPrintHistory        int
+	InfoTreeUpdateInterval time.Duration
 	BadBatches []uint64
 }
 

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -234,5 +234,9 @@ var DefaultFlags = []cli.Flag{
 	&utils.DisableVirtualCounters,
 	&utils.DAUrl,
 	&utils.VirtualCountersSmtReduction,
+	
+
+	&utils.ACLPrintHistory,
+	&utils.InfoTreeUpdateInterval,
 	&utils.BadBatches,
 }

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -192,6 +192,9 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		DataStreamWriteTimeout:                 ctx.Duration(utils.DataStreamWriteTimeout.Name),
 		DataStreamInactivityTimeout:            ctx.Duration(utils.DataStreamInactivityTimeout.Name),
 		VirtualCountersSmtReduction:            ctx.Float64(utils.VirtualCountersSmtReduction.Name),
+		
+		ACLPrintHistory:                        ctx.Int(utils.ACLPrintHistory.Name),
+		InfoTreeUpdateInterval:                 ctx.Duration(utils.InfoTreeUpdateInterval.Name),
 		BadBatches:                             badBatches,
 	}
 

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -19,6 +19,7 @@ import (
 	zkStages "github.com/ledgerwatch/erigon/zk/stages"
 	"github.com/ledgerwatch/erigon/zk/syncer"
 	"github.com/ledgerwatch/erigon/zk/txpool"
+	"github.com/ledgerwatch/erigon/zk/l1infotree"
 )
 
 // NewDefaultZkStages creates stages for zk syncer (RPC mode)
@@ -33,9 +34,9 @@ func NewDefaultZkStages(ctx context.Context,
 	forkValidator *engineapi.ForkValidator,
 	engine consensus.Engine,
 	l1Syncer *syncer.L1Syncer,
-	l1InfoTreeSyncer *syncer.L1Syncer,
 	datastreamClient zkStages.DatastreamClient,
 	datastreamServer *datastreamer.StreamServer,
+	infoTreeUpdater *l1infotree.Updater,
 ) []*stagedsync.Stage {
 	dirs := cfg.Dirs
 	blockReader := snapshotsync.NewBlockReaderWithSnapshots(snapshots, cfg.TransactionsV3)
@@ -47,7 +48,7 @@ func NewDefaultZkStages(ctx context.Context,
 
 	return zkStages.DefaultZkStages(ctx,
 		zkStages.StageL1SyncerCfg(db, l1Syncer, cfg.Zk),
-		zkStages.StageL1InfoTreeCfg(db, cfg.Zk, l1InfoTreeSyncer),
+		zkStages.StageL1InfoTreeCfg(db, cfg.Zk, infoTreeUpdater),
 		zkStages.StageBatchesCfg(db, datastreamClient, cfg.Zk),
 		zkStages.StageDataStreamCatchupCfg(datastreamServer, db, cfg.Genesis.Config.ChainID.Uint64(), cfg.DatastreamVersion, cfg.HasExecutors()),
 		stagedsync.StageCumulativeIndexCfg(db),
@@ -97,11 +98,11 @@ func NewSequencerZkStages(ctx context.Context,
 	datastreamServer *datastreamer.StreamServer,
 	sequencerStageSyncer *syncer.L1Syncer,
 	l1Syncer *syncer.L1Syncer,
-	l1InfoTreeSyncer *syncer.L1Syncer,
 	l1BlockSyncer *syncer.L1Syncer,
 	txPool *txpool.TxPool,
 	txPoolDb kv.RwDB,
 	verifier *legacy_executor_verifier.LegacyExecutorVerifier,
+	infoTreeUpdater *l1infotree.Updater,
 ) []*stagedsync.Stage {
 	dirs := cfg.Dirs
 	blockReader := snapshotsync.NewBlockReaderWithSnapshots(snapshots, cfg.TransactionsV3)
@@ -114,7 +115,7 @@ func NewSequencerZkStages(ctx context.Context,
 		stagedsync.StageCumulativeIndexCfg(db),
 		zkStages.StageL1SyncerCfg(db, l1Syncer, cfg.Zk),
 		zkStages.StageL1SequencerSyncCfg(db, cfg.Zk, sequencerStageSyncer),
-		zkStages.StageL1InfoTreeCfg(db, cfg.Zk, l1InfoTreeSyncer),
+		zkStages.StageL1InfoTreeCfg(db, cfg.Zk, infoTreeUpdater),
 		zkStages.StageSequencerL1BlockSyncCfg(db, cfg.Zk, l1BlockSyncer),
 		zkStages.StageDataStreamCatchupCfg(datastreamServer, db, cfg.Genesis.Config.ChainID.Uint64(), cfg.DatastreamVersion, cfg.HasExecutors()),
 		zkStages.StageSequenceBlocksCfg(
@@ -140,6 +141,7 @@ func NewSequencerZkStages(ctx context.Context,
 			txPoolDb,
 			verifier,
 			uint16(cfg.YieldSize),
+			infoTreeUpdater,
 		),
 		stagedsync.StageHashStateCfg(db, dirs, cfg.HistoryV3, agg),
 		zkStages.StageZkInterHashesCfg(db, true, true, false, dirs.Tmp, blockReader, controlServer.Hd, cfg.HistoryV3, agg, cfg.Zk),

--- a/zk/l1infotree/updater.go
+++ b/zk/l1infotree/updater.go
@@ -1,0 +1,291 @@
+package l1infotree
+
+import (
+	"github.com/ledgerwatch/erigon/eth/ethconfig"
+	"github.com/ledgerwatch/erigon/zk/hermez_db"
+	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
+	zkTypes "github.com/ledgerwatch/erigon/zk/types"
+	"github.com/ledgerwatch/erigon/core/types"
+	"time"
+	"github.com/ledgerwatch/erigon/zk/contracts"
+	"github.com/ledgerwatch/log/v3"
+	"fmt"
+	"sort"
+	"github.com/iden3/go-iden3-crypto/keccak256"
+	"errors"
+	"github.com/gateway-fm/cdk-erigon-lib/kv"
+	"github.com/gateway-fm/cdk-erigon-lib/common"
+)
+
+type Syncer interface {
+	IsSyncStarted() bool
+	Run(lastCheckedBlock uint64)
+	GetLogsChan() chan []types.Log
+	GetProgressMessageChan() chan string
+	IsDownloading() bool
+	GetHeader(blockNumber uint64) (*types.Header, error)
+	L1QueryHeaders(logs []types.Log) (map[uint64]*types.Header, error)
+	Stop()
+}
+
+type Updater struct {
+	cfg          *ethconfig.Zk
+	syncer       Syncer
+	progress     uint64
+	latestUpdate *zkTypes.L1InfoTreeUpdate
+}
+
+func NewUpdater(cfg *ethconfig.Zk, syncer Syncer) *Updater {
+	return &Updater{
+		cfg:    cfg,
+		syncer: syncer,
+	}
+}
+
+func (u *Updater) GetProgress() uint64 {
+	return u.progress
+}
+
+func (u *Updater) GetLatestUpdate() *zkTypes.L1InfoTreeUpdate {
+	return u.latestUpdate
+}
+
+func (u *Updater) WarmUp(tx kv.RwTx) (err error) {
+	defer func() {
+		if err != nil {
+			u.syncer.Stop()
+		}
+	}()
+
+	hermezDb := hermez_db.NewHermezDb(tx)
+
+	progress, err := stages.GetStageProgress(tx, stages.L1InfoTree)
+	if err != nil {
+		return err
+	}
+	if progress == 0 {
+		progress = u.cfg.L1FirstBlock - 1
+	}
+
+	u.progress = progress
+
+	latestUpdate, _, err := hermezDb.GetLatestL1InfoTreeUpdate()
+	if err != nil {
+		return err
+	}
+
+	u.latestUpdate = latestUpdate
+
+	if !u.syncer.IsSyncStarted() {
+		u.syncer.Run(u.progress)
+	}
+
+	return nil
+}
+
+func (u *Updater) CheckForInfoTreeUpdates(logPrefix string, tx kv.RwTx) (allLogs []types.Log, err error) {
+	defer func() {
+		if err != nil {
+			u.syncer.Stop()
+		}
+	}()
+
+	hermezDb := hermez_db.NewHermezDb(tx)
+	logChan := u.syncer.GetLogsChan()
+	progressChan := u.syncer.GetProgressMessageChan()
+
+	// first get all the logs we need to process
+LOOP:
+	for {
+		select {
+		case logs := <-logChan:
+			allLogs = append(allLogs, logs...)
+		case msg := <-progressChan:
+			log.Info(fmt.Sprintf("[%s] %s", logPrefix, msg))
+		default:
+			if !u.syncer.IsDownloading() {
+				break LOOP
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// sort the logs by block number - it is important that we process them in order to get the index correct
+	sort.Slice(allLogs, func(i, j int) bool {
+		l1 := allLogs[i]
+		l2 := allLogs[j]
+		// first sort by block number and if equal then by tx index
+		if l1.BlockNumber != l2.BlockNumber {
+			return l1.BlockNumber < l2.BlockNumber
+		}
+		if l1.TxIndex != l2.TxIndex {
+			return l1.TxIndex < l2.TxIndex
+		}
+		return l1.Index < l2.Index
+	})
+
+	// chunk the logs into batches, so we don't overload the RPC endpoints too much at once
+	chunks := chunkLogs(allLogs, 50)
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	processed := 0
+
+	tree, err := initialiseL1InfoTree(hermezDb)
+	if err != nil {
+		return nil, err
+	}
+
+	// process the logs in chunks
+	for _, chunk := range chunks {
+		select {
+		case <-ticker.C:
+			log.Info(fmt.Sprintf("[%s] Processed %d/%d logs, %d%% complete", logPrefix, processed, len(allLogs), processed*100/len(allLogs)))
+		default:
+		}
+
+		headersMap, err := u.syncer.L1QueryHeaders(chunk)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, l := range chunk {
+			switch l.Topics[0] {
+			case contracts.UpdateL1InfoTreeTopic:
+				header := headersMap[l.BlockNumber]
+				if header == nil {
+					header, err = u.syncer.GetHeader(l.BlockNumber)
+					if err != nil {
+						return nil, err
+					}
+				}
+
+				tmpUpdate, err := createL1InfoTreeUpdate(l, header)
+				if err != nil {
+					return nil, err
+				}
+
+				leafHash := HashLeafData(tmpUpdate.GER, tmpUpdate.ParentHash, tmpUpdate.Timestamp)
+				if tree.LeafExists(leafHash) {
+					log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", leafHash)
+					continue
+				}
+
+				if u.latestUpdate != nil {
+					tmpUpdate.Index = u.latestUpdate.Index + 1
+				} // if latestUpdate is nil then Index = 0 which is the default value so no need to set it
+				u.latestUpdate = tmpUpdate
+
+				newRoot, err := tree.AddLeaf(uint32(u.latestUpdate.Index), leafHash)
+				if err != nil {
+					return nil, err
+				}
+				log.Debug("New L1 Index",
+					"index", u.latestUpdate.Index,
+					"root", newRoot.String(),
+					"mainnet", u.latestUpdate.MainnetExitRoot.String(),
+					"rollup", u.latestUpdate.RollupExitRoot.String(),
+					"ger", u.latestUpdate.GER.String(),
+					"parent", u.latestUpdate.ParentHash.String(),
+				)
+
+				if err = handleL1InfoTreeUpdate(hermezDb, u.latestUpdate); err != nil {
+					return nil, err
+				}
+				if err = hermezDb.WriteL1InfoTreeLeaf(u.latestUpdate.Index, leafHash); err != nil {
+					return nil, err
+				}
+				if err = hermezDb.WriteL1InfoTreeRoot(common.BytesToHash(newRoot[:]), u.latestUpdate.Index); err != nil {
+					return nil, err
+				}
+
+				processed++
+			default:
+				log.Warn("received unexpected topic from l1 info tree stage", "topic", l.Topics[0])
+			}
+		}
+	}
+
+	// save the progress - we add one here so that we don't cause overlap on the next run.  We don't want to duplicate an info tree update in the db
+	if len(allLogs) > 0 {
+		u.progress = allLogs[len(allLogs)-1].BlockNumber + 1
+	}
+	if err = stages.SaveStageProgress(tx, stages.L1InfoTree, u.progress); err != nil {
+		return nil, err
+	}
+
+	return allLogs, nil
+}
+
+func chunkLogs(slice []types.Log, chunkSize int) [][]types.Log {
+	var chunks [][]types.Log
+	for i := 0; i < len(slice); i += chunkSize {
+		end := i + chunkSize
+
+		// If end is greater than the length of the slice, reassign it to the length of the slice
+		if end > len(slice) {
+			end = len(slice)
+		}
+
+		chunks = append(chunks, slice[i:end])
+	}
+	return chunks
+}
+
+func initialiseL1InfoTree(hermezDb *hermez_db.HermezDb) (*L1InfoTree, error) {
+	leaves, err := hermezDb.GetAllL1InfoTreeLeaves()
+	if err != nil {
+		return nil, err
+	}
+
+	allLeaves := make([][32]byte, len(leaves))
+	for i, l := range leaves {
+		allLeaves[i] = l
+	}
+
+	tree, err := NewL1InfoTree(32, allLeaves)
+	if err != nil {
+		return nil, err
+	}
+
+	return tree, nil
+}
+
+func createL1InfoTreeUpdate(l types.Log, header *types.Header) (*zkTypes.L1InfoTreeUpdate, error) {
+	if len(l.Topics) != 3 {
+		return nil, errors.New("received log for info tree that did not have 3 topics")
+	}
+
+	if l.BlockNumber != header.Number.Uint64() {
+		return nil, errors.New("received log for info tree that did not match the block number")
+	}
+
+	mainnetExitRoot := l.Topics[1]
+	rollupExitRoot := l.Topics[2]
+	combined := append(mainnetExitRoot.Bytes(), rollupExitRoot.Bytes()...)
+	ger := keccak256.Hash(combined)
+	update := &zkTypes.L1InfoTreeUpdate{
+		GER:             common.BytesToHash(ger),
+		MainnetExitRoot: mainnetExitRoot,
+		RollupExitRoot:  rollupExitRoot,
+		BlockNumber:     l.BlockNumber,
+		Timestamp:       header.Time,
+		ParentHash:      header.ParentHash,
+	}
+
+	return update, nil
+}
+
+func handleL1InfoTreeUpdate(
+	hermezDb *hermez_db.HermezDb,
+	update *zkTypes.L1InfoTreeUpdate,
+) error {
+	var err error
+	if err = hermezDb.WriteL1InfoTreeUpdate(update); err != nil {
+		return err
+	}
+	if err = hermezDb.WriteL1InfoTreeUpdateToGer(update); err != nil {
+		return err
+	}
+	return nil
+}

--- a/zk/stages/stage_l1_info_tree.go
+++ b/zk/stages/stage_l1_info_tree.go
@@ -3,32 +3,24 @@ package stages
 import (
 	"context"
 	"fmt"
-	"sort"
-	"time"
-
-	"github.com/gateway-fm/cdk-erigon-lib/common"
-	"github.com/gateway-fm/cdk-erigon-lib/kv"
-	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
-	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
-	"github.com/ledgerwatch/erigon/zk/contracts"
-	"github.com/ledgerwatch/erigon/zk/hermez_db"
 	"github.com/ledgerwatch/erigon/zk/l1infotree"
 	"github.com/ledgerwatch/log/v3"
+	"github.com/gateway-fm/cdk-erigon-lib/kv"
 )
 
 type L1InfoTreeCfg struct {
-	db     kv.RwDB
-	zkCfg  *ethconfig.Zk
-	syncer IL1Syncer
+	db      kv.RwDB
+	zkCfg   *ethconfig.Zk
+	updater *l1infotree.Updater
 }
 
-func StageL1InfoTreeCfg(db kv.RwDB, zkCfg *ethconfig.Zk, sync IL1Syncer) L1InfoTreeCfg {
+func StageL1InfoTreeCfg(db kv.RwDB, zkCfg *ethconfig.Zk, updater *l1infotree.Updater) L1InfoTreeCfg {
 	return L1InfoTreeCfg{
-		db:     db,
-		zkCfg:  zkCfg,
-		syncer: sync,
+		db:      db,
+		zkCfg:   zkCfg,
+		updater: updater,
 	}
 }
 
@@ -53,150 +45,21 @@ func SpawnL1InfoTreeStage(
 		defer tx.Rollback()
 	}
 
-	hermezDb := hermez_db.NewHermezDb(tx)
-
-	progress, err := stages.GetStageProgress(tx, stages.L1InfoTree)
-	if err != nil {
+	if err := cfg.updater.WarmUp(tx); err != nil {
 		return err
 	}
-	if progress == 0 {
-		progress = cfg.zkCfg.L1FirstBlock - 1
-	}
 
-	latestUpdate, _, err := hermezDb.GetLatestL1InfoTreeUpdate()
+	allLogs, err := cfg.updater.CheckForInfoTreeUpdates(logPrefix, tx)
 	if err != nil {
 		return err
 	}
 
-	if !cfg.syncer.IsSyncStarted() {
-		cfg.syncer.Run(progress)
+	var latestIndex uint64
+	latestUpdate := cfg.updater.GetLatestUpdate()
+	if latestUpdate != nil {
+		latestIndex = latestUpdate.Index
 	}
-
-	logChan := cfg.syncer.GetLogsChan()
-	progressChan := cfg.syncer.GetProgressMessageChan()
-
-	// first get all the logs we need to process
-	var allLogs []types.Log
-LOOP:
-	for {
-		select {
-		case logs := <-logChan:
-			allLogs = append(allLogs, logs...)
-		case msg := <-progressChan:
-			log.Info(fmt.Sprintf("[%s] %s", logPrefix, msg))
-		default:
-			if !cfg.syncer.IsDownloading() {
-				break LOOP
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
-
-	// sort the logs by block number - it is important that we process them in order to get the index correct
-	sort.Slice(allLogs, func(i, j int) bool {
-		l1 := allLogs[i]
-		l2 := allLogs[j]
-		// first sort by block number and if equal then by tx index
-		if l1.BlockNumber != l2.BlockNumber {
-			return l1.BlockNumber < l2.BlockNumber
-		}
-		if l1.TxIndex != l2.TxIndex {
-			return l1.TxIndex < l2.TxIndex
-		}
-		return l1.Index < l2.Index
-	})
-
-	// chunk the logs into batches, so we don't overload the RPC endpoints too much at once
-	chunks := chunkLogs(allLogs, 50)
-
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
-	processed := 0
-
-	tree, err := initialiseL1InfoTree(hermezDb)
-	if err != nil {
-		return err
-	}
-
-	// process the logs in chunks
-	for _, chunk := range chunks {
-		select {
-		case <-ticker.C:
-			log.Info(fmt.Sprintf("[%s] Processed %d/%d logs, %d%% complete", logPrefix, processed, len(allLogs), processed*100/len(allLogs)))
-		default:
-		}
-
-		headersMap, err := cfg.syncer.L1QueryHeaders(chunk)
-		if err != nil {
-			return err
-		}
-
-		for _, l := range chunk {
-			switch l.Topics[0] {
-			case contracts.UpdateL1InfoTreeTopic:
-				header := headersMap[l.BlockNumber]
-				if header == nil {
-					header, err = cfg.syncer.GetHeader(l.BlockNumber)
-					if err != nil {
-						return err
-					}
-				}
-
-				tmpUpdate, err := CreateL1InfoTreeUpdate(l, header)
-				if err != nil {
-					return err
-				}
-
-				leafHash := l1infotree.HashLeafData(tmpUpdate.GER, tmpUpdate.ParentHash, tmpUpdate.Timestamp)
-				if tree.LeafExists(leafHash) {
-					log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", leafHash)
-					continue
-				}
-
-				if latestUpdate != nil {
-					tmpUpdate.Index = latestUpdate.Index + 1
-				} // if latestUpdate is nil then Index = 0 which is the default value so no need to set it
-				latestUpdate = tmpUpdate
-
-				newRoot, err := tree.AddLeaf(uint32(latestUpdate.Index), leafHash)
-				if err != nil {
-					return err
-				}
-				log.Debug("New L1 Index",
-					"index", latestUpdate.Index,
-					"root", newRoot.String(),
-					"mainnet", latestUpdate.MainnetExitRoot.String(),
-					"rollup", latestUpdate.RollupExitRoot.String(),
-					"ger", latestUpdate.GER.String(),
-					"parent", latestUpdate.ParentHash.String(),
-				)
-
-				if err = HandleL1InfoTreeUpdate(hermezDb, latestUpdate); err != nil {
-					return err
-				}
-				if err = hermezDb.WriteL1InfoTreeLeaf(latestUpdate.Index, leafHash); err != nil {
-					return err
-				}
-				if err = hermezDb.WriteL1InfoTreeRoot(common.BytesToHash(newRoot[:]), latestUpdate.Index); err != nil {
-					return err
-				}
-
-				processed++
-			default:
-				log.Warn("received unexpected topic from l1 info tree stage", "topic", l.Topics[0])
-			}
-		}
-	}
-
-	// save the progress - we add one here so that we don't cause overlap on the next run.  We don't want to duplicate an info tree update in the db
-	if len(allLogs) > 0 {
-		progress = allLogs[len(allLogs)-1].BlockNumber + 1
-	}
-	if err := stages.SaveStageProgress(tx, stages.L1InfoTree, progress); err != nil {
-		return err
-	}
-
-	log.Info(fmt.Sprintf("[%s] Info tree updates", logPrefix), "count", len(allLogs))
+	log.Info(fmt.Sprintf("[%s] Info tree updates", logPrefix), "count", len(allLogs), "latestIndex", latestIndex)
 
 	if freshTx {
 		if err := tx.Commit(); err != nil {
@@ -205,40 +68,6 @@ LOOP:
 	}
 
 	return nil
-}
-
-func chunkLogs(slice []types.Log, chunkSize int) [][]types.Log {
-	var chunks [][]types.Log
-	for i := 0; i < len(slice); i += chunkSize {
-		end := i + chunkSize
-
-		// If end is greater than the length of the slice, reassign it to the length of the slice
-		if end > len(slice) {
-			end = len(slice)
-		}
-
-		chunks = append(chunks, slice[i:end])
-	}
-	return chunks
-}
-
-func initialiseL1InfoTree(hermezDb *hermez_db.HermezDb) (*l1infotree.L1InfoTree, error) {
-	leaves, err := hermezDb.GetAllL1InfoTreeLeaves()
-	if err != nil {
-		return nil, err
-	}
-
-	allLeaves := make([][32]byte, len(leaves))
-	for i, l := range leaves {
-		allLeaves[i] = l
-	}
-
-	tree, err := l1infotree.NewL1InfoTree(32, allLeaves)
-	if err != nil {
-		return nil, err
-	}
-
-	return tree, nil
 }
 
 func UnwindL1InfoTreeStage(u *stagedsync.UnwindState, tx kv.RwTx, cfg L1InfoTreeCfg, ctx context.Context) error {

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -37,6 +37,7 @@ import (
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/erigon/zk/utils"
 	"github.com/ledgerwatch/log/v3"
+	"github.com/ledgerwatch/erigon/zk/l1infotree"
 )
 
 const (
@@ -81,6 +82,8 @@ type SequenceBlockCfg struct {
 
 	legacyVerifier *verifier.LegacyExecutorVerifier
 	yieldSize      uint16
+
+	infoTreeUpdater *l1infotree.Updater
 }
 
 func StageSequenceBlocksCfg(
@@ -108,6 +111,7 @@ func StageSequenceBlocksCfg(
 	txPoolDb kv.RwDB,
 	legacyVerifier *verifier.LegacyExecutorVerifier,
 	yieldSize uint16,
+	infoTreeUpdater *l1infotree.Updater,
 ) SequenceBlockCfg {
 
 	return SequenceBlockCfg{
@@ -134,6 +138,7 @@ func StageSequenceBlocksCfg(
 		txPoolDb:         txPoolDb,
 		legacyVerifier:   legacyVerifier,
 		yieldSize:        yieldSize,
+		infoTreeUpdater:  infoTreeUpdater,
 	}
 }
 
@@ -284,12 +289,13 @@ func prepareL1AndInfoTreeRelatedStuff(sdb *stageDb, batchState *BatchState, prop
 	return
 }
 
-func prepareTickers(cfg *SequenceBlockCfg) (*time.Ticker, *time.Ticker, *time.Ticker) {
+func prepareTickers(cfg *SequenceBlockCfg) (*time.Ticker, *time.Ticker, *time.Ticker, *time.Ticker) {
 	batchTicker := time.NewTicker(cfg.zk.SequencerBatchSealTime)
 	logTicker := time.NewTicker(10 * time.Second)
 	blockTicker := time.NewTicker(cfg.zk.SequencerBlockSealTime)
+	infoTreeTicker := time.NewTicker(cfg.zk.InfoTreeUpdateInterval)
 
-	return batchTicker, logTicker, blockTicker
+	return batchTicker, logTicker, blockTicker, infoTreeTicker
 }
 
 // will be called at the start of every new block created within a batch to figure out if there is a new GER


### PR DESCRIPTION
* starting work on info tree updates during execution

* info tree updater in sequencer loop

* logging latest index for info tree updates # Conflicts:
#	cmd/utils/flags.go
#	eth/ethconfig/config_zkevm.go
#	turbo/cli/default_flags.go
#	turbo/cli/flags_zkevm.go
#	turbo/stages/zk_stages.go
#	zk/stages/stage_l1_info_tree.go
#	zk/stages/stage_l1_sequencer_sync.go
#	zk/stages/stage_sequence_execute_utils.go