### PR TITLE
Fix body of the query

### DIFF
--- a/zkevm/jsonrpc/client/client.go
+++ b/zkevm/jsonrpc/client/client.go
@@ -37,9 +37,13 @@ func (e *HTTPError) Error() string {
 func JSONRPCCall(url, method string, parameters ...interface{}) (types.Response, error) {
 	const jsonRPCVersion = "2.0"
 
-	params, err := json.Marshal(parameters)
-	if err != nil {
-		return types.Response{}, err
+	params := []byte{}
+	if len(parameters) != 0 {
+		var err error
+		params, err = json.Marshal(parameters)
+		if err != nil {
+			return types.Response{}, err
+		}
 	}
 
 	req := types.Request{
@@ -96,9 +100,13 @@ func JSONRPCBatchCall(url string, methods []string, parameterGroups ...[]interfa
 	batchRequest := make([]types.Request, 0, len(methods))
 
 	for i, method := range methods {
-		params, err := json.Marshal(parameterGroups[i])
-		if err != nil {
-			return nil, err
+		params := []byte{}
+		if len(parameterGroups[i]) != 0 {
+			var err error
+			params, err = json.Marshal(parameterGroups[i])
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		req := types.Request{


### PR DESCRIPTION
Closes #1409 
This PR fixes the body of the call when there is no parameter.
json.marshall was returning []byte(nil) which is different to []byte{} and this was causing the errors