### PR TITLE
fix: healthcheck EthAPI interface

### DIFF
--- a/cmd/rpcdaemon/health/check_block.go
+++ b/cmd/rpcdaemon/health/check_block.go
@@ -11,7 +11,8 @@ func checkBlockNumber(blockNumber rpc.BlockNumber, api EthAPI) error {
 	if api == nil {
 		return fmt.Errorf("no connection to the Erigon server or `eth` namespace isn't enabled")
 	}
-	data, err := api.GetBlockByNumber(context.TODO(), blockNumber, false)
+	fullTx := false
+	data, err := api.GetBlockByNumber(context.TODO(), blockNumber, &fullTx)
 	if err != nil {
 		return err
 	}

--- a/cmd/rpcdaemon/health/check_time.go
+++ b/cmd/rpcdaemon/health/check_time.go
@@ -8,16 +8,15 @@ import (
 	"github.com/ledgerwatch/erigon/rpc"
 )
 
-var (
-	errTimestampTooOld = errors.New("timestamp too old")
-)
+var errTimestampTooOld = errors.New("timestamp too old")
 
 func checkTime(
 	r *http.Request,
 	seconds int,
 	ethAPI EthAPI,
 ) error {
-	i, err := ethAPI.GetBlockByNumber(r.Context(), rpc.LatestBlockNumber, false)
+	fullTx := false
+	i, err := ethAPI.GetBlockByNumber(r.Context(), rpc.LatestBlockNumber, &fullTx)
 	if err != nil {
 		return err
 	}

--- a/cmd/rpcdaemon/health/health_test.go
+++ b/cmd/rpcdaemon/health/health_test.go
@@ -32,7 +32,7 @@ type ethApiStub struct {
 	syncingError  error
 }
 
-func (e *ethApiStub) GetBlockByNumber(_ context.Context, _ rpc.BlockNumber, _ bool) (map[string]interface{}, error) {
+func (e *ethApiStub) GetBlockByNumber(_ context.Context, _ rpc.BlockNumber, _ *bool) (map[string]interface{}, error) {
 	return e.blockResult, e.blockError
 }
 

--- a/cmd/rpcdaemon/health/interfaces.go
+++ b/cmd/rpcdaemon/health/interfaces.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 
 	"github.com/ledgerwatch/erigon/rpc"
@@ -12,6 +13,6 @@ type NetAPI interface {
 }
 
 type EthAPI interface {
-	GetBlockByNumber(_ context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error)
+	GetBlockByNumber(_ context.Context, number rpc.BlockNumber, fullTx *bool) (map[string]interface{}, error)
 	Syncing(ctx context.Context) (interface{}, error)
 }


### PR DESCRIPTION
FIxes: #1405

- Make GetBlockByNumber of ``EthAPI`` interface  in ``cmd/rpcdaemon/health/interfaces.go``same as in ``turbo/jsonrpc/eth_api.go``