### PR TITLE
Allow execution to short circuit to the last downloaded batch

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -410,6 +410,11 @@ var (
 		Usage: "The time to wait for data to arrive from the stream before reporting an error (0s doesn't check)",
 		Value: "3s",
 	}
+	L2ShortCircuitToVerifiedBatchFlag = cli.BoolFlag{
+		Name:  "zkevm.l2-short-circuit-to-verified-batch",
+		Usage: "Short circuit block execution up to the batch after the latest verified batch (default: true). When disabled, the sequencer will execute all downloaded batches",
+		Value: true,
+	}
 	L1SyncStartBlock = cli.Uint64Flag{
 		Name:  "zkevm.l1-sync-start-block",
 		Usage: "Designed for recovery of the network from the L1 batch data, slower mode of operation than the datastream.  If set the datastream will not be used",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -12,6 +12,7 @@ type Zk struct {
 	L2RpcUrl                               string
 	L2DataStreamerUrl                      string
 	L2DataStreamerTimeout                  time.Duration
+	L2ShortCircuitToVerifiedBatch          bool
 	L1SyncStartBlock                       uint64
 	L1SyncStopBatch                        uint64
 	L1ChainId                              uint64

--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -264,7 +264,7 @@ func getExecRange(cfg ExecuteBlockCfg, tx kv.RwTx, stageProgress, toBlock uint64
 		return to, total, nil
 	}
 
-	shouldShortCircuit, noProgressTo, err := utils.ShouldShortCircuitExecution(tx, logPrefix)
+	shouldShortCircuit, noProgressTo, err := utils.ShouldShortCircuitExecution(tx, logPrefix, cfg.zk.L2ShortCircuitToVerifiedBatch)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -175,6 +175,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.L2RpcUrlFlag,
 	&utils.L2DataStreamerUrlFlag,
 	&utils.L2DataStreamerTimeout,
+	&utils.L2ShortCircuitToVerifiedBatchFlag,
 	&utils.L1SyncStartBlock,
 	&utils.L1SyncStopBatch,
 	&utils.L1ChainIdFlag,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -8,13 +8,14 @@ import (
 
 	"time"
 
+	"strconv"
+
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/zk/sequencer"
 	utils2 "github.com/ledgerwatch/erigon/zk/utils"
 	"github.com/urfave/cli/v2"
-	"strconv"
 )
 
 var DeprecatedFlags = map[string]string{
@@ -69,6 +70,8 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	if err != nil {
 		panic(fmt.Sprintf("could not parse l2 datastreamer timeout value %s", l2DataStreamTimeoutVal))
 	}
+
+	l2ShortCircuitToVerifiedBatchVal := ctx.Bool(utils.L2ShortCircuitToVerifiedBatchFlag.Name)
 
 	sequencerBlockSealTimeVal := ctx.String(utils.SequencerBlockSealTime.Name)
 	sequencerBlockSealTime, err := time.ParseDuration(sequencerBlockSealTimeVal)
@@ -133,6 +136,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		L2RpcUrl:                               ctx.String(utils.L2RpcUrlFlag.Name),
 		L2DataStreamerUrl:                      ctx.String(utils.L2DataStreamerUrlFlag.Name),
 		L2DataStreamerTimeout:                  l2DataStreamTimeout,
+		L2ShortCircuitToVerifiedBatch:          l2ShortCircuitToVerifiedBatchVal,
 		L1SyncStartBlock:                       ctx.Uint64(utils.L1SyncStartBlock.Name),
 		L1SyncStopBatch:                        ctx.Uint64(utils.L1SyncStopBatch.Name),
 		L1ChainId:                              ctx.Uint64(utils.L1ChainIdFlag.Name),


### PR DESCRIPTION
For rollups using pessimistic proof, there won't be "verified batch". We need a configurable flag for the RPC node to catch up quickly to the sequencer even when verified batch is always 0. More context: https://github.com/0xPolygonHermez/cdk-erigon/issues/1423#issuecomment-2464259201