### PR TITLE
feat: new zkevm api to retrieve rollup address and rollup manager address

### DIFF
--- a/docs/endpoints/endpoints.md
+++ b/docs/endpoints/endpoints.md
@@ -202,6 +202,8 @@ If the endpoint is not in the list below, it means this specific endpoint is not
 - zkevm_getProverInput
 - zkevm_getVersionHistory
 - zkevm_getWitness
+- zkevm_getRollupAddress
+- zkevm_getRollupManagerAddress
 - zkevm_isBlockConsolidated
 - zkevm_isBlockVirtualized
 - zkevm_verifiedBatchNumber

--- a/docs/endpoints/endpoints.md
+++ b/docs/endpoints/endpoints.md
@@ -200,10 +200,10 @@ If the endpoint is not in the list below, it means this specific endpoint is not
 - zkevm_getL2BlockInfoTree
 - zkevm_getLatestGlobalExitRoot
 - zkevm_getProverInput
-- zkevm_getVersionHistory
-- zkevm_getWitness
 - zkevm_getRollupAddress
 - zkevm_getRollupManagerAddress
+- zkevm_getVersionHistory
+- zkevm_getWitness
 - zkevm_isBlockConsolidated
 - zkevm_isBlockVirtualized
 - zkevm_verifiedBatchNumber

--- a/turbo/jsonrpc/zkevm_api.go
+++ b/turbo/jsonrpc/zkevm_api.go
@@ -78,6 +78,8 @@ type ZkEvmAPI interface {
 	GetForkById(ctx context.Context, forkId hexutil.Uint64) (res json.RawMessage, err error)
 	GetForkIdByBatchNumber(ctx context.Context, batchNumber rpc.BlockNumber) (hexutil.Uint64, error)
 	GetForks(ctx context.Context) (res json.RawMessage, err error)
+	GetRollupAddress(ctx context.Context) (res json.RawMessage, err error)
+	GetRollupManagerAddress(ctx context.Context) (res json.RawMessage, err error)
 }
 
 const getBatchWitness = "getBatchWitness"
@@ -1845,4 +1847,26 @@ func (api *ZkEvmAPIImpl) GetForks(ctx context.Context) (res json.RawMessage, err
 	}
 
 	return forksJson, err
+}
+
+func (api *ZkEvmAPIImpl) GetRollupAddress(ctx context.Context) (res json.RawMessage, err error) {
+	rollupAddress := api.config.AddressZkevm
+
+	rollupAddressJson, err := json.Marshal(rollupAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return rollupAddressJson, err
+}
+
+func (api *ZkEvmAPIImpl) GetRollupManagerAddress(ctx context.Context) (res json.RawMessage, err error) {
+	rollupManagerAddress := api.config.AddressRollup
+
+	rollupManagerAddressJson, err := json.Marshal(rollupManagerAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return rollupManagerAddressJson, err
 }

--- a/turbo/jsonrpc/zkevm_api_test.go
+++ b/turbo/jsonrpc/zkevm_api_test.go
@@ -1475,7 +1475,7 @@ func TestGetRollupManagerAddress(t *testing.T) {
 	cfgZk := ethconfig.DefaultZkConfig
 	assert.NotNil(cfgZk)
 
-	// Check rollup address of default ZkConfig
+	// Check rollup manager address of default ZkConfig
 	assert.Equal(cfgZk.AddressRollup, common.HexToAddress("0x0"))
 
 	// Modify ZkConfig

--- a/turbo/jsonrpc/zkevm_api_test.go
+++ b/turbo/jsonrpc/zkevm_api_test.go
@@ -1448,3 +1448,41 @@ func TestGetForks(t *testing.T) {
 	assert.Equal(forks[2].Version, "")
 	assert.Equal(forks[2].BlockNumber, hexutil.Uint64(3000))
 }
+
+func TestGetRollupAddress(t *testing.T) {
+	assert := assert.New(t)
+
+	// Init new ZkConfig
+	cfgZk := ethconfig.DefaultZkConfig
+	assert.NotNil(cfgZk)
+
+	// Check rollup address of default ZkConfig
+	assert.Equal(cfgZk.AddressZkevm, common.HexToAddress("0x0"))
+
+	// Modify ZkConfig
+	cfgZk.AddressZkevm = common.HexToAddress("0x1")
+	assert.Equal(cfgZk.AddressZkevm, common.HexToAddress("0x1"))
+	cfgZk.AddressZkevm = common.HexToAddress("0x9f77a1fB020Bf0980b75828e3fbdAB13A1D7824A")
+	assert.Equal(cfgZk.AddressZkevm, common.HexToAddress("0x9f77a1fB020Bf0980b75828e3fbdAB13A1D7824A"))
+	cfgZk.AddressZkevm = common.HexToAddress("0x5F5221e63CC430C00E65cb9D85066f710650faa9")
+	assert.Equal(cfgZk.AddressZkevm, common.HexToAddress("0x5F5221e63CC430C00E65cb9D85066f710650faa9"))
+}
+
+func TestGetRollupManagerAddress(t *testing.T) {
+	assert := assert.New(t)
+
+	// Init new ZkConfig
+	cfgZk := ethconfig.DefaultZkConfig
+	assert.NotNil(cfgZk)
+
+	// Check rollup address of default ZkConfig
+	assert.Equal(cfgZk.AddressRollup, common.HexToAddress("0x0"))
+
+	// Modify ZkConfig
+	cfgZk.AddressRollup = common.HexToAddress("0x1")
+	assert.Equal(cfgZk.AddressRollup, common.HexToAddress("0x1"))
+	cfgZk.AddressRollup = common.HexToAddress("0x9f77a1fB020Bf0980b75828e3fbdAB13A1D7824A")
+	assert.Equal(cfgZk.AddressRollup, common.HexToAddress("0x9f77a1fB020Bf0980b75828e3fbdAB13A1D7824A"))
+	cfgZk.AddressRollup = common.HexToAddress("0x5F5221e63CC430C00E65cb9D85066f710650faa9")
+	assert.Equal(cfgZk.AddressRollup, common.HexToAddress("0x5F5221e63CC430C00E65cb9D85066f710650faa9"))
+}


### PR DESCRIPTION
This PR introduces two new zkEVM APIs:
- zkevm_getRollupAddress
- zkevm_getRollupManagerAddress

This will allow end users to use the above methods to query the Rollup Address and Rollup Manager Address of the network using the RPC only.

![image](https://github.com/user-attachments/assets/1632ed00-702e-4d7f-a778-a28488c02aee)
