### PR TITLE
tweak(zkevm_api): accinput batch 0/1

### DIFF
--- a/turbo/jsonrpc/zkevm_api.go
+++ b/turbo/jsonrpc/zkevm_api.go
@@ -735,6 +735,11 @@ func (api *ZkEvmAPIImpl) getAccInputHash(ctx context.Context, db SequenceReader,
 		return nil, fmt.Errorf("failed to get sequence range data for batch %d: %w", batchNum, err)
 	}
 
+	// if we are asking for genesis return 0x0..0
+	if batchNum == 0 && prevSequence.BatchNo == 0 {
+		return &common.Hash{}, nil
+	}
+
 	if prevSequence == nil || batchSequence == nil {
 		var missing string
 		if prevSequence == nil && batchSequence == nil {
@@ -745,16 +750,6 @@ func (api *ZkEvmAPIImpl) getAccInputHash(ctx context.Context, db SequenceReader,
 			missing = "current batch sequence"
 		}
 		return nil, fmt.Errorf("failed to get %s for batch %d", missing, batchNum)
-	}
-
-	// if we are asking for the injected batch or genesis return 0x0..0
-	if (batchNum == 0 || batchNum == 1) && prevSequence.BatchNo == 0 {
-		return &common.Hash{}, nil
-	}
-
-	// if prev is 0, set to 1 (injected batch)
-	if prevSequence.BatchNo == 0 {
-		prevSequence.BatchNo = 1
 	}
 
 	// get batch range for sequence
@@ -793,11 +788,8 @@ func (api *ZkEvmAPIImpl) getAccInputHash(ctx context.Context, db SequenceReader,
 		return nil, fmt.Errorf("batch %d is out of range of sequence calldata", batchNum)
 	}
 
-	accInputHash = &prevSequenceAccinputHash
-	if prevSequenceBatch == 0 {
-		return
-	}
 	// calculate acc input hash
+	accInputHash = &prevSequenceAccinputHash
 	for i := 0; i < int(batchNum-prevSequenceBatch); i++ {
 		accInputHash = accInputHashCalcFn(prevSequenceAccinputHash, i)
 		prevSequenceAccinputHash = *accInputHash

--- a/turbo/jsonrpc/zkevm_api_test.go
+++ b/turbo/jsonrpc/zkevm_api_test.go
@@ -480,7 +480,7 @@ func TestGetBatchByNumber(t *testing.T) {
 	assert.Equal(gers[len(gers)-1], batch.GlobalExitRoot)
 	assert.Equal(mainnetExitRoots[len(mainnetExitRoots)-1], batch.MainnetExitRoot)
 	assert.Equal(rollupExitRoots[len(rollupExitRoots)-1], batch.RollupExitRoot)
-	assert.Equal(common.HexToHash(common.Hash{}.String()), batch.AccInputHash)
+	assert.Equal(common.HexToHash("0x97d1524156ccb46723e5c3c87951da9a390499ba288161d879df1dbc03d49afc"), batch.AccInputHash)
 	assert.Equal(common.HexToHash("0x22ddb9a356815c3fac1026b6dec5df3124afbadb485c9ba5a3e3398a04b7ba97"), *batch.SendSequencesTxHash)
 	assert.Equal(rpctypes.ArgUint64(1714427009), batch.Timestamp)
 	assert.Equal(true, batch.Closed)


### PR DESCRIPTION
Seems like the issues previously were due to an assumption of the accInputHash of batch 1 (injected) at etrog+ being 0x0, however this is not true. The oldAccInputHash of the injected batch is 0x0, otherwise it is fed into the calculation of accInputHash for the given fork as normal.