### PR TITLE
fix: replace L1 rpc url in error for getting l1 gas price

### DIFF
--- a/turbo/jsonrpc/eth_system_zk.go
+++ b/turbo/jsonrpc/eth_system_zk.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/zkevm/encoding"
 	"github.com/ledgerwatch/erigon/zkevm/jsonrpc/client"
 	"github.com/ledgerwatch/log/v3"
@@ -124,6 +126,10 @@ func (api *APIImpl) l1GasPrice() (*big.Int, error) {
 	}
 
 	if res.Error != nil {
+		if strings.Contains(res.Error.Message, api.L1RpcUrl) {
+			replacement := fmt.Sprintf("<%s>", utils.L1RpcUrlFlag.Name)
+			res.Error.Message = strings.ReplaceAll(res.Error.Message, api.L1RpcUrl, replacement)
+		}
 		return nil, fmt.Errorf("RPC error response: %s", res.Error.Message)
 	}
 


### PR DESCRIPTION
Fixes: #1529

- Replace the L1 RPC url with the flag name when error for fetching L1 gas price appears and contains the L1 RPC url