### PR TITLE
Fix 'full-witness-contract-interaction.json' test

### DIFF
--- a/smt/pkg/smt/smt_state_writer_test.go
+++ b/smt/pkg/smt/smt_state_writer_test.go
@@ -40,10 +40,10 @@ func TestSMTApplyTraces(t *testing.T) {
 		// 	name: "SC deployment full witness",
 		// 	file: "./testdata/zerotraces/full-witness-contract-deployment.json",
 		// },
-		// {
-		// 	name: "SC interaction full witness",
-		// 	file: "./testdata/zerotraces/full-witness-contract-interaction.json",
-		// },
+		{
+			name: "SC interaction full witness",
+			file: "./testdata/zerotraces/full-witness-contract-interaction.json",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Set balance and nonce separately, as one might be missing which leads to invalid state.
Set bytecode only when Write is not empty.