### PR TITLE
fix: add case for sequenceBatchesValidiumBanana

### DIFF
--- a/zk/syncer/utils.go
+++ b/zk/syncer/utils.go
@@ -55,7 +55,7 @@ func GetAccInputDataCalcFunction(l1InfoRoot common.Hash, decodedSequenceInterfac
 		totalSequenceBatches = len(decodedSequence.Batches)
 	case *SequenceBatchesCalldataValidiumBanana:
 		accInputHashCalcFn = func(prevAccInputHash common.Hash, index int) *common.Hash {
-			return utils.CalculateBananaValidiumAccInputHash(prevAccInputHash, decodedSequence.Batches[index].TransactionHash, l1InfoRoot, decodedSequence.MaxSequenceTimestamp, decodedSequence.L2Coinbase, decodedSequence.Batches[index].ForcedBlockHashL1)
+			return utils.CalculateBananaValidiumAccInputHash(prevAccInputHash, decodedSequence.Batches[index].TransactionsHash, l1InfoRoot, decodedSequence.MaxSequenceTimestamp, decodedSequence.L2Coinbase, decodedSequence.Batches[index].ForcedBlockHashL1)
 		}
 		totalSequenceBatches = len(decodedSequence.Batches)
 	default:
@@ -119,6 +119,10 @@ func DecodeSequenceBatchesCalldata(data []byte) (calldata interface{}, err error
 		} else {
 			return decodeBananaSequenceBatchesValidiumCallData(unpackedCalldata), nil
 		}
+	case contracts.SequenceBatchesValidiumBanana:
+		if method.Name == sequenceBatchesValidiumMethodName {
+			return decodeBananaSequenceBatchesValidiumCallData(unpackedCalldata), nil
+		}
 	default:
 		return nil, fmt.Errorf("no decoder found for method signature: %s", methodSig)
 	}
@@ -166,7 +170,7 @@ func decodeBananaSequenceBatchesCallData(unpackedCalldata map[string]interface{}
 }
 
 type SequencedBatchValidiumBanana struct {
-	TransactionHash      common.Hash
+	TransactionsHash     common.Hash
 	ForcedGlobalExitRoot common.Hash
 	ForcedTimestamp      uint64
 	ForcedBlockHashL1    common.Hash
@@ -180,7 +184,7 @@ type SequenceBatchesCalldataValidiumBanana struct {
 
 func decodeBananaSequenceBatchesValidiumCallData(unpackedCalldata map[string]interface{}) *SequenceBatchesCalldataValidiumBanana {
 	unpackedbatches := unpackedCalldata["batches"].([]struct {
-		TransactionHash      [32]uint8 `json:"transactionHash"`
+		TransactionsHash     [32]uint8 `json:"transactionsHash"`
 		ForcedGlobalExitRoot [32]uint8 `json:"forcedGlobalExitRoot"`
 		ForcedTimestamp      uint64    `json:"forcedTimestamp"`
 		ForcedBlockHashL1    [32]uint8 `json:"forcedBlockHashL1"`
@@ -194,7 +198,7 @@ func decodeBananaSequenceBatchesValidiumCallData(unpackedCalldata map[string]int
 
 	for i, batch := range unpackedbatches {
 		calldata.Batches[i] = SequencedBatchValidiumBanana{
-			TransactionHash:      common.BytesToHash(batch.TransactionHash[:]),
+			TransactionsHash:     common.BytesToHash(batch.TransactionsHash[:]),
 			ForcedGlobalExitRoot: common.BytesToHash(batch.ForcedGlobalExitRoot[:]),
 			ForcedTimestamp:      batch.ForcedTimestamp,
 			ForcedBlockHashL1:    common.BytesToHash(batch.ForcedBlockHashL1[:]),


### PR DESCRIPTION
This PR adds support for `sequenceBatchesValidiumBanana`. Without this, some combinations of CDK deployment will fail to generate the `accInputHash` for batches relying on it. This PR should also fix #1517, and it's been tested with a locally built CDK Erigon image on the current `main` branch of Kurtosis CDK.

## Testing
Locally tested on Kurtosis CDK.

The below image shows the `accInputHash` values being calculated for different batches.
![image (30)](https://github.com/user-attachments/assets/32ff8851-917d-4685-932f-31141ae48ab7)

Although the error `[cdk-erigon-rpc-001] [EROR] [12-18|05:48:49.948] failed to get acc input hash for batch 76: failed to get current batch sequence for batch 76` will persist, this shouldn't be an issue, because CDK Erigon will retry and attempt to recalculate the `accInputHash` over time. This can be observed in the below image:
![image (31)](https://github.com/user-attachments/assets/b5dc7b92-e6e9-4c6b-b460-29aaf806e76a)
