### PR TITLE
fix: wrong mutex used on getLowestPrice in gas tracker

### DIFF
--- a/turbo/jsonrpc/eth_system_gas_tracking.go
+++ b/turbo/jsonrpc/eth_system_gas_tracking.go
@@ -88,8 +88,8 @@ func (t *RecurringL1GasPriceTracker) getLatestPrice() *big.Int {
 }
 
 func (t *RecurringL1GasPriceTracker) getLowestPrice() *big.Int {
-	t.latestMtx.Lock()
-	defer t.latestMtx.Unlock()
+	t.lowestMtx.Lock()
+	defer t.lowestMtx.Unlock()
 
 	return t.lowestPrice
 }


### PR DESCRIPTION
Fixed the wrong mutex in getLowestPrices for gas tracker.