### PR TITLE
update(readme): update readme for require ubuntu version 22 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cdk-erigon is a fork of Erigon, currently in Alpha, optimized for syncing with t
 
 ## Hardware requirements
 
-* A Linux-based OS (e.g., Ubuntu Server 22.04 LTS).
+* A Linux-based OS (e.g., Ubuntu Server 22.04 LTS), with g++ 12+ being necessary, meaning Ubuntu 22.04 LTS or a more recent version is required.
 * At least 32GB RAM with a 4-core CPU.
 * Both Apple Silicon and AMD64 are supported.
 


### PR DESCRIPTION
g++ 12 or higher is required to build CDK-Erigon so ubuntu 22.04 or a higher version is required. Ubuntu 20.04 will not be able to build CDK-Erigon.