### PR TITLE
Fix/test sequencing stage timeouts

### DIFF
--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -144,9 +144,9 @@ func TestSpawnSequencingStage(t *testing.T) {
 
 	zkCfg := &ethconfig.Zk{
 		SequencerResequence:    false,
-		SequencerBatchSealTime: 10 * time.Second,
-		SequencerBlockSealTime: 10 * time.Second,
-		InfoTreeUpdateInterval: 10 * time.Second,
+		SequencerBatchSealTime: 3 * time.Millisecond, // normally it is greater that block seal time, allows one more block to be added to the batch
+		SequencerBlockSealTime: 2 * time.Millisecond,
+		InfoTreeUpdateInterval: 2 * time.Millisecond,
 	}
 
 	legacyVerifier := verifier.NewLegacyExecutorVerifier(*zkCfg, nil, db1, nil, nil)
@@ -173,27 +173,29 @@ func TestSpawnSequencingStage(t *testing.T) {
 	tx = memdb.BeginRw(t, db1)
 	hDB = hermez_db.NewHermezDb(tx)
 
+	expectedBlockNum := latestL1BlockNumber.Uint64() + 1
 	// WriteBlockL1InfoTreeIndex
-	l1InfoTreeIndex, err := hDB.GetBlockL1InfoTreeIndex(101)
+	l1InfoTreeIndex, err := hDB.GetBlockL1InfoTreeIndex(expectedBlockNum)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), l1InfoTreeIndex)
 
 	// WriteBlockL1InfoTreeIndexProgress
 	blockNumber, l1InfoTreeIndex, err := hDB.GetLatestBlockL1InfoTreeIndexProgress()
 	require.NoError(t, err)
-	assert.Equal(t, uint64(101), blockNumber)
+	assert.Equal(t, expectedBlockNum, blockNumber)
 	assert.Equal(t, uint64(1), l1InfoTreeIndex)
 
 	// WriteBlockInfoRoot
-	root, err := hDB.GetBlockInfoRoot(101)
+	root, err := hDB.GetBlockInfoRoot(expectedBlockNum)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(101), blockNumber)
 	assert.NotEmpty(t, root.String())
 
 	// IncrementStateVersionByBlockNumberIfNeeded
 	blockNumber, stateVersion, err := rawdb.GetLatestStateVersion(tx)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(101), blockNumber)
+	// batch/block sealing timeouts are small, so it could happen that an extra block is not added to the batch.
+	// No requirement prevents adding and extra block to the batch or not adding it. For more specific cases, create a separate test.
+	assert.True(t, expectedBlockNum <= blockNumber && blockNumber <= expectedBlockNum+1, "value is not in range")
 	assert.Equal(t, uint64(1), stateVersion)
 	tx.Rollback()
 }


### PR DESCRIPTION
Equal timeouts for batch and block sealing produces undefined behavior - one extra block could be included or not.
Reduced the timeouts to avoid a single test waiting for 10 seconds.
Made timeouts different. But since timeouts are small, an extra block could be added or not - allow this.