### PR TITLE
feat(bad-tx): trim bad tx hashes from db via config

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -855,7 +855,7 @@ var (
 	}
 	BadTxPurge = cli.BoolFlag{
 		Name:  "zkevm.bad-tx-purge",
-		Usage: "Purge the bad transactions form the database on startup. Default false.",
+		Usage: "Purge the bad transactions from the database on startup. Default false.",
 		Value: false,
 	}
 	SyncLimitVerifiedEnabled = cli.BoolFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -848,6 +848,16 @@ var (
 		Usage: "The maximum number of times a transaction that consumes too many counters to fit into a batch will be attempted before it is rejected outright by eth_sendRawTransaction",
 		Value: 2,
 	}
+	BadTxStoreValue = cli.Uint64Flag{
+		Name:  "zkevm.bad-tx-store-value",
+		Usage: "The maximum number of bad transactions to store in the database. Default 200.",
+		Value: 200,
+	}
+	BadTxPurge = cli.BoolFlag{
+		Name:  "zkevm.bad-tx-purge",
+		Usage: "Purge the bad transactions form the database on startup. Default false.",
+		Value: false,
+	}
 	SyncLimitVerifiedEnabled = cli.BoolFlag{
 		Name:  "zkevm.sync-limit-verified-enabled",
 		Usage: "Enable sync to verified batch height.",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -152,6 +152,7 @@ type Config = ethconfig.Config
 type PreStartTasks struct {
 	WarmUpDataStream  bool
 	PurgeWitnessCache bool
+	PurgeBadTxs       bool
 }
 
 // Ethereum implements the Ethereum full node service.
@@ -1011,6 +1012,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		}
 
 		backend.preStartTasks.PurgeWitnessCache = config.WitnessCachePurge
+		backend.preStartTasks.PurgeBadTxs = config.BadTxPurge
 
 		// entering ZK territory!
 		cfg := backend.config
@@ -1452,6 +1454,22 @@ func (s *Ethereum) PreStart() error {
 		hermezDb := hermez_db.NewHermezDb(tx)
 		if err := hermezDb.PurgeWitnessCaches(); err != nil {
 			return fmt.Errorf("failed to purge witness caches: %w", err)
+		}
+		if err = tx.Commit(); err != nil {
+			return fmt.Errorf("tx.Commit: %w", err)
+		}
+	}
+
+	if s.preStartTasks.PurgeBadTxs {
+		log.Warn("[PreStart] purge bad transactions cache enabled, purging...", "zkevm.bad-tx-purge", s.config.BadTxPurge)
+		tx, err := s.chainDB.BeginRw(context.Background())
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+		hermezDb := hermez_db.NewHermezDb(tx)
+		if err = hermezDb.PurgeBadTxHashes(); err != nil {
+			return fmt.Errorf("failed to purge bad transactions: %w", err)
 		}
 		if err = tx.Commit(); err != nil {
 			return fmt.Errorf("tx.Commit: %w", err)

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -113,6 +113,8 @@ type Zk struct {
 	RejectLowGasPriceTolerance     float64
 	LogLevel                       log.Lvl
 	BadTxAllowance                 uint64
+	BadTxStoreValue                uint64
+	BadTxPurge                     bool
 }
 
 var DefaultZkConfig = &Zk{}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -309,4 +309,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.RejectLowGasPriceTransactions,
 	&utils.RejectLowGasPriceTolerance,
 	&utils.BadTxAllowance,
+	&utils.BadTxStoreValue,
+	&utils.BadTxPurge,
 }

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -275,6 +275,8 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		PanicOnReorg:                           ctx.Bool(utils.PanicOnReorg.Name),
 		ShadowSequencer:                        ctx.Bool(utils.ShadowSequencer.Name),
 		BadTxAllowance:                         ctx.Uint64(utils.BadTxAllowance.Name),
+		BadTxStoreValue:                        ctx.Uint64(utils.BadTxStoreValue.Name),
+		BadTxPurge:                             ctx.Bool(utils.BadTxPurge.Name),
 	}
 
 	utils2.EnableTimer(cfg.DebugTimers)

--- a/zk/hermez_db/utils.go
+++ b/zk/hermez_db/utils.go
@@ -3,6 +3,7 @@ package hermez_db
 import (
 	"encoding/binary"
 	"fmt"
+	"time"
 
 	"github.com/ledgerwatch/erigon-lib/common"
 )
@@ -79,4 +80,15 @@ func SplitGerKey(data []byte) (uint64, *common.Hash, error) {
 	l1BlockHash := common.BytesToHash(data[8:])
 
 	return blockNo, &l1BlockHash, nil
+}
+
+func TimeToBytes(t time.Time) []byte {
+	buf := make([]byte, 16)
+	binary.BigEndian.PutUint64(buf[:8], uint64(t.Unix()))
+	binary.BigEndian.PutUint64(buf[8:], uint64(t.UnixNano()))
+	return buf
+}
+
+func BytesToTime(data []byte) time.Time {
+	return time.Unix(int64(binary.BigEndian.Uint64(data[:8])), int64(binary.BigEndian.Uint64(data[8:])))
 }

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -554,6 +554,9 @@ func sequencingBatchStep(
 							if err != nil {
 								return err
 							}
+							if err = sdb.hermezDb.TruncateBadTxHashCounterBelow(cfg.zk.BadTxStoreValue); err != nil {
+								return err
+							}
 							log.Info(fmt.Sprintf("[%s] single transaction %s cannot fit into batch - overflow", logPrefix, txHash), "context", ocs, "times_seen", counter)
 						} else {
 							batchState.newOverflowTransaction()

--- a/zk/tests/unwinds/unwind.sh
+++ b/zk/tests/unwinds/unwind.sh
@@ -117,6 +117,7 @@ different_files=(
     "SyncStage.txt"
     "BadHeaderNumber.txt"
     "CallToIndex.txt"
+    "bad_tx_hashes_lookup.txt"
 )
 
 is_in_array() {
@@ -176,7 +177,7 @@ for file in "$dataPath/phase2-dump1"/*; do
         echo "Phase 2 No difference found in $filename"
     else
         # file where it should be different
-        if [ "$filename" = "BadHeaderNumber.txt" ]; then  
+        if [ "$filename" = "BadHeaderNumber.txt" ] || [ "$filename" = "bad_tx_hashes_lookup.txt" ]; then
             echo "Phase 2 - Expected differences in $filename"
         else
             echo "Phase 2 - Error unexpected differences in $filename"


### PR DESCRIPTION
Trim a given amount of bad tx's from the DB via config. Bad tx hash's from overflowed batch state.

**Flags Added**
zkevm.bad-tx-store-value: The amount of bad tx's we should store
zkevm.bad-tx-purge: If set true, then purge the table on startup