### PR TITLE
Stage interhashes optimisations

### DIFF
--- a/erigon-lib/etl/buffers.go
+++ b/erigon-lib/etl/buffers.go
@@ -212,7 +212,6 @@ func (b *appendSortableBuffer) Put(k, v []byte) {
 		b.size += len(k)
 	}
 	b.size += len(v)
-	fmt.Printf("put: %d, %x, %x . %x\n", b.size, k, stored, v)
 	b.entries[string(k)] = append(stored, v...)
 }
 
@@ -256,7 +255,6 @@ func (b *appendSortableBuffer) Write(w io.Writer) error {
 	var numBuf [binary.MaxVarintLen64]byte
 	entries := b.sortedBuf
 	for _, entry := range entries {
-		fmt.Printf("write: %x, %x\n", entry.key, entry.value)
 		lk := int64(len(entry.key))
 		if entry.key == nil {
 			lk = -1

--- a/smt/pkg/db/mem-db.go
+++ b/smt/pkg/db/mem-db.go
@@ -284,3 +284,32 @@ func (m *MemDb) GetDb() map[string][]string {
 
 	return m.Db
 }
+
+/*
+As there are no collectors in the memdb we can just fall back to the regular insert
+calls to add them to the maps
+*/
+func (m *MemDb) CollectAccountValue(key utils.NodeKey, value utils.NodeValue8) {
+	m.InsertAccountValue(key, value)
+}
+
+func (m *MemDb) CollectKeySource(key utils.NodeKey, value []byte) {
+	m.InsertKeySource(key, value)
+}
+
+func (m *MemDb) CollectSmt(key utils.NodeKey, value utils.NodeValue12) {
+	m.Insert(key, value)
+}
+
+func (m *MemDb) CollectHashKey(key utils.NodeKey, value utils.NodeKey) {
+	m.InsertHashKey(key, value)
+}
+
+func (m *MemDb) CloseSmtCollectors() {
+	// no-op
+}
+
+func (m *MemDb) LoadSmtCollectors() error {
+	// no-op
+	return nil
+}

--- a/smt/pkg/smt/smt.go
+++ b/smt/pkg/smt/smt.go
@@ -19,10 +19,14 @@ import (
 
 type DB interface {
 	Insert(key utils.NodeKey, value utils.NodeValue12) error
+	CollectSmt(key utils.NodeKey, value utils.NodeValue12)
 	InsertAccountValue(key utils.NodeKey, value utils.NodeValue8) error
+	CollectAccountValue(key utils.NodeKey, value utils.NodeValue8)
 	InsertKeySource(key utils.NodeKey, value []byte) error
+	CollectKeySource(key utils.NodeKey, value []byte)
 	DeleteKeySource(key utils.NodeKey) error
 	InsertHashKey(key utils.NodeKey, value utils.NodeKey) error
+	CollectHashKey(key utils.NodeKey, value utils.NodeKey)
 	AddCode(code []byte) error
 	DeleteHashKey(key utils.NodeKey) error
 	Delete(string) error
@@ -32,6 +36,8 @@ type DB interface {
 	CommitBatch() error
 	OpenBatch(quitCh <-chan struct{})
 	RollbackBatch()
+	CloseSmtCollectors()
+	LoadSmtCollectors() error
 	RoDB
 }
 

--- a/smt/pkg/smt/smt_create.go
+++ b/smt/pkg/smt/smt_create.go
@@ -57,6 +57,8 @@ func (s *SMT) GenerateFromKVBulk(ctx context.Context, logPrefix string, nodeKeys
 		deletesWorker.DoWork()
 	}()
 
+	defer s.Db.CloseSmtCollectors()
+
 	var buildSmtLoopErr error
 	var rootNode *SmtNode
 	tempTreeBuildStart := time.Now()
@@ -111,6 +113,10 @@ func (s *SMT) GenerateFromKVBulk(ctx context.Context, logPrefix string, nodeKeys
 
 	finalRoot, err := rootNode.deleteTree(pathToDeleteFrom, s, &leafValueMap)
 	if err != nil {
+		return [4]uint64{}, err
+	}
+
+	if err := s.Db.LoadSmtCollectors(); err != nil {
 		return [4]uint64{}, err
 	}
 

--- a/smt/pkg/utils/job_queue.go
+++ b/smt/pkg/utils/job_queue.go
@@ -8,6 +8,8 @@ import (
 type DB interface {
 	InsertHashKey(key NodeKey, value NodeKey) error
 	Insert(key NodeKey, value NodeValue12) error
+	CollectSmt(key NodeKey, value NodeValue12)
+	CollectHashKey(key NodeKey, value NodeKey)
 }
 
 type JobResult interface {
@@ -36,14 +38,10 @@ func (r *CalcAndPrepareJobResult) GetError() error {
 
 func (r *CalcAndPrepareJobResult) Save() error {
 	for key, value := range r.LeafsKvMap {
-		if err := r.db.InsertHashKey(key, value); err != nil {
-			return err
-		}
+		r.db.CollectHashKey(key, value)
 	}
 	for key, value := range r.KvMap {
-		if err := r.db.Insert(key, value); err != nil {
-			return err
-		}
+		r.db.CollectSmt(key, value)
 	}
 	return nil
 }

--- a/smt/pkg/utils/util_test.go
+++ b/smt/pkg/utils/util_test.go
@@ -192,26 +192,6 @@ func TestArrayToScalar(t *testing.T) {
 	}
 }
 
-func TestArrayToScalarBig(t *testing.T) {
-	array := []*big.Int{
-		new(big.Int),
-		new(big.Int),
-		new(big.Int),
-	}
-
-	array[0].SetString("1122334455667788", 16)
-	array[1].SetString("99aabbccddeeff00", 16)
-	array[2].SetString("1122334455667788", 16)
-
-	expected, _ := new(big.Int).SetString("112233445566778899aabbccddeeff001122334455667788", 16)
-
-	result := ArrayToScalarBig(array)
-
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("ArrayToScalarBig(%v) = %v, want %v", array, result, expected)
-	}
-}
-
 func TestRemoveKeyBits(t *testing.T) {
 	testCases := map[string]struct {
 		k      NodeKey


### PR DESCRIPTION
* first pass switching SMT algo to use ETL

moving ETL code behind the smt DB interfaces

WIP - adding timing logging

first pass of inters stage improvements

profiling added to inters stage

remove log timing from inters sub processes

more efficient node key to hex conversion

moving some small functions away from big int usage

* switch etl to sortable buffer for inters