### PR TITLE
enhance(l1-info-sync): sync l1 info table from l2 rpc id an rpc node

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -872,6 +872,16 @@ var (
 		Name:  "zkevm.genesis-config-path",
 		Usage: "File path for the zk config containing allocs, chainspec, and other zk specific configurations.",
 	}
+	L2InfoTreeUpdatesBatchSize = cli.Uint64Flag{
+		Name:  "zkevm.l2-info-tree-updates-batch-size",
+		Usage: "Size of the batch of L2 info tree updates to retrieve at a time. L2 info tree updates must be enabled to use this.",
+		Value: 500,
+	}
+	L2InfoTreeUpdatesEnabled = cli.BoolFlag{
+		Name:  "zkevm.l2-info-tree-updates-enabled",
+		Usage: "When enabled a RPC node can use the L2 to build the InfoTree.",
+		Value: false,
+	}
 	ACLPrintHistory = cli.IntFlag{
 		Name:  "acl.print-history",
 		Usage: "Number of entries to print from the ACL history on node start up",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1123,7 +1123,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			cfg.L1HighestBlockType,
 		)
 
-		l1InfoTreeUpdater := l1infotree.NewUpdater(cfg.Zk, l1InfoTreeSyncer)
+		l1InfoTreeUpdater := l1infotree.NewUpdater(cfg.Zk, l1InfoTreeSyncer, l1infotree.NewL2InfoTreeSyncer(ctx, cfg.Zk))
 
 		var dataStreamServer server.DataStreamServer
 		if backend.streamServer != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1123,7 +1123,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			cfg.L1HighestBlockType,
 		)
 
-		l1InfoTreeUpdater := l1infotree.NewUpdater(cfg.Zk, l1InfoTreeSyncer, l1infotree.NewL2InfoTreeSyncer(ctx, cfg.Zk))
+		l1InfoTreeUpdater := l1infotree.NewUpdater(cfg.Zk, l1InfoTreeSyncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, cfg.Zk))
 
 		var dataStreamServer server.DataStreamServer
 		if backend.streamServer != nil {

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -115,6 +115,8 @@ type Zk struct {
 	BadTxAllowance                 uint64
 	BadTxStoreValue                uint64
 	BadTxPurge                     bool
+	L2InfoTreeUpdatesBatchSize     uint64
+	L2InfoTreeUpdatesEnabled       bool
 }
 
 var DefaultZkConfig = &Zk{}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -251,6 +251,8 @@ var DefaultFlags = []cli.Flag{
 	&utils.PanicOnReorg,
 	&utils.ShadowSequencer,
 	&utils.ZKGenesisConfigPathFlag,
+	&utils.L2InfoTreeUpdatesBatchSize,
+	&utils.L2InfoTreeUpdatesEnabled,
 
 	&utils.SilkwormExecutionFlag,
 	&utils.SilkwormRpcDaemonFlag,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -277,6 +277,8 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		BadTxAllowance:                         ctx.Uint64(utils.BadTxAllowance.Name),
 		BadTxStoreValue:                        ctx.Uint64(utils.BadTxStoreValue.Name),
 		BadTxPurge:                             ctx.Bool(utils.BadTxPurge.Name),
+		L2InfoTreeUpdatesBatchSize:             ctx.Uint64(utils.L2InfoTreeUpdatesBatchSize.Name),
+		L2InfoTreeUpdatesEnabled:               ctx.Bool(utils.L2InfoTreeUpdatesEnabled.Name),
 	}
 
 	utils2.EnableTimer(cfg.DebugTimers)

--- a/turbo/jsonrpc/zkevm_api_test.go
+++ b/turbo/jsonrpc/zkevm_api_test.go
@@ -882,7 +882,7 @@ func TestGetExitRootTable(t *testing.T) {
 	}
 	tx.Commit()
 
-	exitRootEntries, err := zkEvmImpl.GetExitRootTable(ctx)
+	exitRootEntries, err := zkEvmImpl.GetExitRootTable(ctx, nil)
 	assert.NoError(err)
 	t.Logf("exitRootEntries: %+v", exitRootEntries)
 	for i, er := range exitRootEntries {

--- a/zk/l1infotree/info_tree_l2_rpc_syncer.go
+++ b/zk/l1infotree/info_tree_l2_rpc_syncer.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	EXIT_ROOT_TABLE = "zkevm_getExitRootTable"
+	ExitRootTable = "zkevm_getExitRootTable"
 )
 
-type L2InfoTreeSyncer struct {
+// InfoTreeL2RpcSyncer is a struct that is used to sync the Info Tree from an L2 Sequencer RPC.
+type InfoTreeL2RpcSyncer struct {
 	ctx            context.Context
 	zkCfg          *ethconfig.Zk
 	isSyncStarted  atomic.Bool
@@ -23,27 +24,31 @@ type L2InfoTreeSyncer struct {
 	infoTreeChan   chan []zkTypes.L1InfoTreeUpdate
 }
 
-func NewL2InfoTreeSyncer(ctx context.Context, zkCfg *ethconfig.Zk) *L2InfoTreeSyncer {
-	return &L2InfoTreeSyncer{
+// NewInfoTreeL2RpcSyncer creates a new InfoTreeL2RpcSyncer.
+// It is used to sync the Info Tree from an L2 Sequencer RPC.
+// The sequencer must have the full Info Tree synced from the L1.
+func NewInfoTreeL2RpcSyncer(ctx context.Context, zkCfg *ethconfig.Zk) *InfoTreeL2RpcSyncer {
+	return &InfoTreeL2RpcSyncer{
 		ctx:          ctx,
 		zkCfg:        zkCfg,
 		infoTreeChan: make(chan []zkTypes.L1InfoTreeUpdate),
 	}
 }
 
-func (s *L2InfoTreeSyncer) IsSyncStarted() bool {
+func (s *InfoTreeL2RpcSyncer) IsSyncStarted() bool {
 	return s.isSyncStarted.Load()
 }
 
-func (s *L2InfoTreeSyncer) IsSyncFinished() bool {
+func (s *InfoTreeL2RpcSyncer) IsSyncFinished() bool {
 	return s.isSyncFinished.Load()
 }
 
-func (s *L2InfoTreeSyncer) GetInfoTreeChan() chan []zkTypes.L1InfoTreeUpdate {
+func (s *InfoTreeL2RpcSyncer) GetInfoTreeChan() chan []zkTypes.L1InfoTreeUpdate {
 	return s.infoTreeChan
 }
 
-func (s *L2InfoTreeSyncer) ConsumeInfoTree() {
+// ConsumeInfoTree consumes the Info Tree from the Info Tree chan.
+func (s *InfoTreeL2RpcSyncer) ConsumeInfoTree() {
 	for {
 		select {
 		case <-s.ctx.Done():
@@ -58,7 +63,8 @@ func (s *L2InfoTreeSyncer) ConsumeInfoTree() {
 	}
 }
 
-func (s *L2InfoTreeSyncer) RunSyncInfoTree() {
+// RunSyncInfoTree runs the sync process for the Info Tree from an L2 Sequencer RPC and put the updates in the Info Tree chan.
+func (s *InfoTreeL2RpcSyncer) RunSyncInfoTree() {
 	if s.isSyncStarted.Load() {
 		return
 	}
@@ -108,7 +114,7 @@ type exitRootQuery struct {
 }
 
 func getExitRootTable(endpoint string, query exitRootQuery) ([]zkTypes.L1InfoTreeUpdate, error) {
-	res, err := jsonClient.JSONRPCCall(endpoint, EXIT_ROOT_TABLE, query)
+	res, err := jsonClient.JSONRPCCall(endpoint, ExitRootTable, query)
 	if err != nil {
 		return nil, err
 	}

--- a/zk/l1infotree/l2_info_tree_syncer.go
+++ b/zk/l1infotree/l2_info_tree_syncer.go
@@ -1,0 +1,122 @@
+package l1infotree
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/ledgerwatch/erigon/eth/ethconfig"
+	zkTypes "github.com/ledgerwatch/erigon/zk/types"
+	jsonClient "github.com/ledgerwatch/erigon/zkevm/jsonrpc/client"
+	"github.com/ledgerwatch/log/v3"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	EXIT_ROOT_TABLE = "zkevm_getExitRootTable"
+)
+
+type L2InfoTreeSyncer struct {
+	ctx            context.Context
+	zkCfg          *ethconfig.Zk
+	isSyncStarted  atomic.Bool
+	isSyncFinished atomic.Bool
+	infoTreeChan   chan []zkTypes.L1InfoTreeUpdate
+}
+
+func NewL2InfoTreeSyncer(ctx context.Context, zkCfg *ethconfig.Zk) *L2InfoTreeSyncer {
+	return &L2InfoTreeSyncer{
+		ctx:          ctx,
+		zkCfg:        zkCfg,
+		infoTreeChan: make(chan []zkTypes.L1InfoTreeUpdate),
+	}
+}
+
+func (s *L2InfoTreeSyncer) IsSyncStarted() bool {
+	return s.isSyncStarted.Load()
+}
+
+func (s *L2InfoTreeSyncer) IsSyncFinished() bool {
+	return s.isSyncFinished.Load()
+}
+
+func (s *L2InfoTreeSyncer) GetInfoTreeChan() chan []zkTypes.L1InfoTreeUpdate {
+	return s.infoTreeChan
+}
+
+func (s *L2InfoTreeSyncer) ConsumeInfoTree() {
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-s.infoTreeChan:
+		default:
+			if !s.isSyncStarted.Load() {
+				return
+			}
+			time.Sleep(time.Second)
+		}
+	}
+}
+
+func (s *L2InfoTreeSyncer) RunSyncInfoTree() {
+	if s.isSyncStarted.Load() {
+		return
+	}
+	s.isSyncStarted.Store(true)
+	s.isSyncFinished.Store(false)
+
+	totalSynced := uint64(0)
+	batchSize := s.zkCfg.L2InfoTreeUpdatesBatchSize
+
+	go func() {
+		retry := 0
+		for {
+			select {
+			case <-s.ctx.Done():
+				s.isSyncFinished.Store(true)
+				break
+			default:
+				query := exitRootQuery{
+					From: totalSynced + 1,
+					To:   totalSynced + batchSize,
+				}
+				infoTree, err := getExitRootTable(s.zkCfg.L2RpcUrl, query)
+				if err != nil {
+					log.Debug("getExitRootTable retry error", "err", err)
+					retry++
+					if retry > 5 {
+						return
+					}
+					time.Sleep(time.Duration(retry*2) * time.Second)
+				}
+
+				if len(infoTree) == 0 {
+					s.isSyncFinished.Store(true)
+					return
+				}
+
+				s.infoTreeChan <- infoTree
+				totalSynced = query.To
+			}
+		}
+	}()
+}
+
+type exitRootQuery struct {
+	From uint64 `json:"from"`
+	To   uint64 `json:"to"`
+}
+
+func getExitRootTable(endpoint string, query exitRootQuery) ([]zkTypes.L1InfoTreeUpdate, error) {
+	res, err := jsonClient.JSONRPCCall(endpoint, EXIT_ROOT_TABLE, query)
+	if err != nil {
+		return nil, err
+	}
+
+	var updates []zkTypes.L1InfoTreeUpdate
+	if err = json.Unmarshal(res.Result, &updates); err != nil {
+		return nil, err
+	}
+
+	return updates, nil
+}

--- a/zk/l1infotree/updater.go
+++ b/zk/l1infotree/updater.go
@@ -29,6 +29,19 @@ type Syncer interface {
 	StopQueryBlocks()
 	ConsumeQueryBlocks()
 	WaitQueryBlocksToFinish()
+	QueryForRootLog(to uint64) (*types.Log, error)
+}
+
+type L2InfoReaderRpc interface {
+	GetExitRootTable(endpoint string) ([]zkTypes.L1InfoTreeUpdate, error)
+}
+
+type L2Syncer interface {
+	IsSyncStarted() bool
+	IsSyncFinished() bool
+	GetInfoTreeChan() chan []zkTypes.L1InfoTreeUpdate
+	RunSyncInfoTree()
+	ConsumeInfoTree()
 }
 
 type Updater struct {
@@ -36,12 +49,14 @@ type Updater struct {
 	syncer       Syncer
 	progress     uint64
 	latestUpdate *zkTypes.L1InfoTreeUpdate
+	l2Syncer     L2Syncer
 }
 
-func NewUpdater(cfg *ethconfig.Zk, syncer Syncer) *Updater {
+func NewUpdater(cfg *ethconfig.Zk, syncer Syncer, l2Syncer L2Syncer) *Updater {
 	return &Updater{
-		cfg:    cfg,
-		syncer: syncer,
+		cfg:      cfg,
+		syncer:   syncer,
+		l2Syncer: l2Syncer,
 	}
 }
 
@@ -222,6 +237,137 @@ LOOP:
 	}
 
 	return allLogs, nil
+}
+
+func (u *Updater) CheckL2RpcForInfoTreeUpdates(logPrefix string, tx kv.RwTx) (infoTrees []zkTypes.L1InfoTreeUpdate, err error) {
+	u.l2Syncer.RunSyncInfoTree()
+	go u.l2Syncer.ConsumeInfoTree()
+
+	infoTreeChan := u.l2Syncer.GetInfoTreeChan()
+
+LOOP:
+	for {
+		select {
+		case infoTree := <-infoTreeChan:
+			infoTrees = append(infoTrees, infoTree...)
+		default:
+			if u.l2Syncer.IsSyncFinished() {
+				log.Info(fmt.Sprintf("[%s] Received %v L2 Info Tree updates", logPrefix, len(infoTrees)))
+				break LOOP
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// ok we have all the info tree updates from the l2, now we need to process them
+	sort.Slice(infoTrees, func(i, j int) bool {
+		return infoTrees[i].Index < infoTrees[j].Index
+	})
+
+	hermezDb := hermez_db.NewHermezDb(tx)
+	tree, err := InitialiseL1InfoTree(hermezDb)
+	if err != nil {
+		return nil, fmt.Errorf("InitialiseL1InfoTree: %w", err)
+	}
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	processed := 0
+
+	for _, update := range infoTrees {
+		select {
+		case <-ticker.C:
+			log.Info(fmt.Sprintf("[%s] Processed %d/%d info tree updates from L2 RPC, %d%% complete", logPrefix, processed, len(infoTrees), processed*100/len(infoTrees)))
+		default:
+		}
+
+		// create root
+		if u.latestUpdate == nil {
+			// query for root log by:
+			// (from: 0) > (to: update index 1 block number)
+			// then return logs[0]
+			rootLog, err := u.syncer.QueryForRootLog(update.BlockNumber)
+			if err != nil {
+				return nil, fmt.Errorf("QueryForRootLog: %w", err)
+			}
+
+			switch rootLog.Topics[0] {
+			case contracts.UpdateL1InfoTreeTopic:
+				header, err := u.syncer.GetHeader(rootLog.BlockNumber)
+				if err != nil {
+					return nil, fmt.Errorf("GetHeader: %w", err)
+				}
+
+				tmpUpdate, err := createL1InfoTreeUpdate(*rootLog, header)
+				if err != nil {
+					return nil, fmt.Errorf("createL1InfoTreeUpdate: %w", err)
+				}
+				tmpUpdate.Index = 0
+
+				leafHash := HashLeafData(tmpUpdate.GER, tmpUpdate.ParentHash, tmpUpdate.Timestamp)
+				if tree.LeafExists(leafHash) {
+					log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", leafHash)
+					continue
+				}
+
+				newRoot, err := tree.AddLeaf(uint32(tmpUpdate.Index), leafHash)
+				if err != nil {
+					return nil, fmt.Errorf("tree.AddLeaf: %w", err)
+				}
+
+				if err = handleL1InfoTreeUpdate(hermezDb, tmpUpdate); err != nil {
+					return nil, fmt.Errorf("handleL1InfoTreeUpdate: %w", err)
+				}
+
+				if err = hermezDb.WriteL1InfoTreeLeaf(tmpUpdate.Index, leafHash); err != nil {
+					return nil, fmt.Errorf("WriteL1InfoTreeLeaf: %w", err)
+				}
+
+				if err = hermezDb.WriteL1InfoTreeRoot(common.BytesToHash(newRoot[:]), tmpUpdate.Index); err != nil {
+					return nil, fmt.Errorf("WriteL1InfoTreeRoot: %w", err)
+				}
+
+				processed++
+			}
+		}
+
+		u.latestUpdate = &update
+
+		leafHash := HashLeafData(u.latestUpdate.GER, u.latestUpdate.ParentHash, u.latestUpdate.Timestamp)
+		if tree.LeafExists(leafHash) {
+			log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", leafHash)
+			continue
+		}
+
+		newRoot, err := tree.AddLeaf(uint32(u.latestUpdate.Index), leafHash)
+		if err != nil {
+			return nil, fmt.Errorf("tree.AddLeaf: %w", err)
+		}
+
+		if err = handleL1InfoTreeUpdate(hermezDb, u.latestUpdate); err != nil {
+			return nil, fmt.Errorf("handleL1InfoTreeUpdate: %w", err)
+		}
+
+		if err = hermezDb.WriteL1InfoTreeLeaf(u.latestUpdate.Index, leafHash); err != nil {
+			return nil, fmt.Errorf("WriteL1InfoTreeLeaf: %w", err)
+		}
+
+		if err = hermezDb.WriteL1InfoTreeRoot(common.BytesToHash(newRoot[:]), u.latestUpdate.Index); err != nil {
+			return nil, fmt.Errorf("WriteL1InfoTreeRoot: %w", err)
+		}
+
+		processed++
+	}
+
+	if len(infoTrees) > 0 {
+		u.progress = infoTrees[len(infoTrees)-1].BlockNumber + 1
+	}
+
+	if err = stages.SaveStageProgress(tx, stages.L1InfoTree, u.progress); err != nil {
+		return nil, fmt.Errorf("SaveStageProgress: %w", err)
+	}
+
+	return infoTrees, nil
 }
 
 func chunkLogs(slice []types.Log, chunkSize int) [][]types.Log {

--- a/zk/stages/stage_l1_info_tree.go
+++ b/zk/stages/stage_l1_info_tree.go
@@ -52,7 +52,7 @@ func SpawnL1InfoTreeStage(
 	if err != nil {
 		return err
 	}
-	// cfg.zkCfg.L2InfoTreeUpdatesEnabled must be enabled, this method uses an updated rpc method that uses to and from.
+	// L2InfoTreeUpdatesEnabled must be enabled, this method uses an updated rpc method that uses to and from.
 	if progress == 0 && !sequencer.IsSequencer() && cfg.zkCfg.L2InfoTreeUpdatesEnabled {
 		select {
 		default:
@@ -69,7 +69,7 @@ func SpawnL1InfoTreeStage(
 				latestIndex = latestUpdate.Index
 			}
 
-			log.Info(fmt.Sprintf("[%s] Info tree updates", logPrefix), "count", len(infoTrees), "latestIndex", latestIndex)
+			log.Info(fmt.Sprintf("[%s] Synced Info Tree updates from L2 Sequencer RPC", logPrefix), "count", len(infoTrees), "latestIndex", latestIndex)
 
 			if freshTx {
 				if funcErr = tx.Commit(); funcErr != nil {
@@ -81,7 +81,7 @@ func SpawnL1InfoTreeStage(
 		}
 	}
 
-	if err := cfg.updater.WarmUp(tx); err != nil {
+	if err = cfg.updater.WarmUp(tx); err != nil {
 		return fmt.Errorf("cfg.updater.WarmUp: %w", err)
 	}
 

--- a/zk/stages/stage_l1_info_tree.go
+++ b/zk/stages/stage_l1_info_tree.go
@@ -6,7 +6,9 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
+	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/zk/l1infotree"
+	"github.com/ledgerwatch/erigon/zk/sequencer"
 	"github.com/ledgerwatch/log/v3"
 )
 
@@ -46,6 +48,39 @@ func SpawnL1InfoTreeStage(
 		defer tx.Rollback()
 	}
 
+	progress, err := stages.GetStageProgress(tx, stages.L1InfoTree)
+	if err != nil {
+		return err
+	}
+	// cfg.zkCfg.L2InfoTreeUpdatesEnabled must be enabled, this method uses an updated rpc method that uses to and from.
+	if progress == 0 && !sequencer.IsSequencer() && cfg.zkCfg.L2InfoTreeUpdatesEnabled {
+		select {
+		default:
+			// If we are a rpc node, and we are starting from the beginning, we need to check for updates from the L2
+			infoTrees, err := cfg.updater.CheckL2RpcForInfoTreeUpdates(logPrefix, tx)
+			if err != nil {
+				log.Warn(fmt.Sprintf("[%s] L2 Info Tree sync failed, getting Info Tree from L1", logPrefix), "err", err)
+				break
+			}
+
+			var latestIndex uint64
+			latestUpdate := cfg.updater.GetLatestUpdate()
+			if latestUpdate != nil {
+				latestIndex = latestUpdate.Index
+			}
+
+			log.Info(fmt.Sprintf("[%s] Info tree updates", logPrefix), "count", len(infoTrees), "latestIndex", latestIndex)
+
+			if freshTx {
+				if funcErr = tx.Commit(); funcErr != nil {
+					return fmt.Errorf("tx.Commit: %w", funcErr)
+				}
+			}
+
+			return nil
+		}
+	}
+
 	if err := cfg.updater.WarmUp(tx); err != nil {
 		return fmt.Errorf("cfg.updater.WarmUp: %w", err)
 	}
@@ -60,6 +95,7 @@ func SpawnL1InfoTreeStage(
 	if latestUpdate != nil {
 		latestIndex = latestUpdate.Index
 	}
+
 	log.Info(fmt.Sprintf("[%s] Info tree updates", logPrefix), "count", len(allLogs), "latestIndex", latestIndex)
 
 	if freshTx {

--- a/zk/stages/stage_l1_info_tree_test.go
+++ b/zk/stages/stage_l1_info_tree_test.go
@@ -86,7 +86,7 @@ func TestSpawnL1InfoTreeStage(t *testing.T) {
 	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
 
 	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest")
-	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer)
+	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewL2InfoTreeSyncer(ctx, &ethconfig.Zk{}))
 	cfg := StageL1InfoTreeCfg(db1, &ethconfig.Zk{}, updater)
 
 	// act

--- a/zk/stages/stage_l1_info_tree_test.go
+++ b/zk/stages/stage_l1_info_tree_test.go
@@ -86,7 +86,7 @@ func TestSpawnL1InfoTreeStage(t *testing.T) {
 	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
 
 	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest")
-	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewL2InfoTreeSyncer(ctx, &ethconfig.Zk{}))
+	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{}))
 	cfg := StageL1InfoTreeCfg(db1, &ethconfig.Zk{}, updater)
 
 	// act

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -122,7 +122,7 @@ func TestSpawnSequencingStage(t *testing.T) {
 	ethermanMock.EXPECT().BlockByNumber(gomock.Any(), nil).Return(latestL1Block, nil).AnyTimes()
 
 	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{ethermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest")
-	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewL2InfoTreeSyncer(ctx, &ethconfig.Zk{}))
+	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{}))
 
 	cacheMock := cMocks.NewMockCache(mockCtrl)
 	cacheMock.EXPECT().View(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -122,7 +122,7 @@ func TestSpawnSequencingStage(t *testing.T) {
 	ethermanMock.EXPECT().BlockByNumber(gomock.Any(), nil).Return(latestL1Block, nil).AnyTimes()
 
 	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{ethermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest")
-	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer)
+	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewL2InfoTreeSyncer(ctx, &ethconfig.Zk{}))
 
 	cacheMock := cMocks.NewMockCache(mockCtrl)
 	cacheMock.EXPECT().View(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()

--- a/zk/stages/utils.go
+++ b/zk/stages/utils.go
@@ -13,11 +13,11 @@ import (
 	"net/url"
 
 	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/types"
 	db2 "github.com/ledgerwatch/erigon/smt/pkg/db"
 	jsonClient "github.com/ledgerwatch/erigon/zkevm/jsonrpc/client"
 	jsonTypes "github.com/ledgerwatch/erigon/zkevm/jsonrpc/types"
-	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 )
 
 const (

--- a/zk/types/zk_types.go
+++ b/zk/types/zk_types.go
@@ -45,13 +45,13 @@ type Batch struct {
 }
 
 type L1InfoTreeUpdate struct {
-	Index           uint64
-	GER             common.Hash
-	MainnetExitRoot common.Hash
-	RollupExitRoot  common.Hash
-	ParentHash      common.Hash
-	Timestamp       uint64
-	BlockNumber     uint64
+	Index           uint64      `json:"index,omitempty"`
+	GER             common.Hash `json:"ger,omitempty"`
+	MainnetExitRoot common.Hash `json:"mainnet_exit_root,omitempty"`
+	RollupExitRoot  common.Hash `json:"rollup_exit_root,omitempty"`
+	ParentHash      common.Hash `json:"parent_hash,omitempty"`
+	Timestamp       uint64      `json:"min_timestamp,omitempty"`
+	BlockNumber     uint64      `json:"block_number,omitempty"`
 }
 
 func (l *L1InfoTreeUpdate) Marshall() []byte {


### PR DESCRIPTION
The L2 Info Tree syncer will collect all the Info Tree from the L2 in a configurable batch size. `zkevm.l2-info-tree-updates-batch-size`. You will need to enable this using flag `zkevm.l2-info-tree-updates-enabled`. It will try to use `zkevm_getExitRootTable` with updated params "to" and "from".

A fail safe is in place. If we error out during L2 sync phase then we continue to use L1 method, if we succeed then return. We only enter the L2 sync phase when (RPC node, progress == 0, config enabled).