### PR TITLE
fix: unreadable symbols in DS stream on client side

### DIFF
--- a/zk/stages/stage_batches.go
+++ b/zk/stages/stage_batches.go
@@ -69,7 +69,6 @@ type DatastreamClient interface {
 	GetProgressAtomic() *atomic.Uint64
 	Start() error
 	Stop() error
-	PrepUnwind()
 	HandleStart() error
 }
 
@@ -840,7 +839,11 @@ func newStreamClient(ctx context.Context, cfg BatchesCfg, latestForkId uint64) (
 		}
 	} else {
 		dsClient = cfg.dsClient
-		stopFn = func() {}
+		stopFn = func() {
+			if err := dsClient.Stop(); err != nil {
+				log.Warn("Failed to stop datastream client", "err", err)
+			}
+		}
 	}
 
 	return dsClient, stopFn, nil

--- a/zk/stages/stage_batches_datastream.go
+++ b/zk/stages/stage_batches_datastream.go
@@ -30,7 +30,7 @@ func (r *DatastreamClientRunner) StartRead(errorChan chan struct{}, diffBlock ui
 	} else {
 		r.dsClient.RenewEntryChannel()
 	}
-	r.dsClient.RenewEntryChannel()
+
 	if r.isReading.Load() {
 		return fmt.Errorf("tried starting datastream client runner thread while another is running")
 	}


### PR DESCRIPTION
- Fixed `allowStops` flag in stream client, that was introduced for testing but default false value broke Stop implementation.
- Read CmdStop response to avoid leaving it in connection buffer as connection is kept alive.
- Fixed `streaming` flag not always set properly.
- Fixed setting lastError properly in some cases, improved err handling/shadowing.
- Improved Stop() calls handling. Stream stopped at stage end now, instead of start of next stage iteration, which led to server could send more data that we would need to drain.