### PR TITLE
Switching from thread 1 to 0 for `secp256k1.ContextForThread`

### DIFF
--- a/zk/stages/stage_sequence_execute_blocks.go
+++ b/zk/stages/stage_sequence_execute_blocks.go
@@ -3,7 +3,6 @@ package stages
 import (
 	"fmt"
 
-
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
 
@@ -302,7 +301,7 @@ func addSenders(
 	txHash2SenderCache map[common.Hash]common.Address,
 ) error {
 	signer := types.MakeSigner(cfg.chainConfig, newNum.Uint64(), 0)
-	cryptoContext := secp256k1.ContextForThread(1)
+	cryptoContext := secp256k1.ContextForThread(0)
 	senders := make([]common.Address, 0, len(finalTransactions))
 	var from common.Address
 	for _, transaction := range finalTransactions {


### PR DESCRIPTION
Hoping to address #1697  by defaulting to thread 0 rather than 1.