### PR TITLE
fix(tx-gas-logger): recover from panic on logger

### DIFF
--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -879,6 +879,9 @@ func (tx *MdbxTx) IsRo() bool     { return tx.readOnly }
 func (tx *MdbxTx) ViewID() uint64 { return tx.tx.ID() }
 
 func (tx *MdbxTx) CollectMetrics() {
+	if tx == nil {
+		return
+	}
 	if tx.db.opts.label != kv.ChainDB {
 		return
 	}

--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -105,7 +105,7 @@ func SpawnExecuteBlocksStageZk(s *StageState, u Unwinder, tx kv.RwTx, toBlock ui
 
 	stateStream := !initialCycle && cfg.stateStream && to-s.BlockNumber < stateStreamLimit
 
-	logger := utils.NewTxGasLogger(logInterval, s.BlockNumber, total, gasState, s.LogPrefix(), &batch, tx, stages.SyncMetrics[stages.Execution])
+	logger := utils.NewTxGasLogger(ctx, logInterval, s.BlockNumber, total, gasState, s.LogPrefix(), &batch, tx, stages.SyncMetrics[stages.Execution])
 	logger.Start()
 	defer logger.Stop()
 

--- a/zk/utils/tx_gas_logger.go
+++ b/zk/utils/tx_gas_logger.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"time"
@@ -13,6 +14,7 @@ import (
 )
 
 type TxGasLogger struct {
+	ctx             context.Context
 	logEvery        *time.Ticker
 	initialBlock    uint64
 	logBlock        uint64
@@ -30,8 +32,9 @@ type TxGasLogger struct {
 	metric          metrics.Gauge
 }
 
-func NewTxGasLogger(logInterval time.Duration, logBlock, total, gasLimit uint64, logPrefix string, batch *kv.PendingMutations, tx kv.RwTx, metric metrics.Gauge) *TxGasLogger {
+func NewTxGasLogger(ctx context.Context, logInterval time.Duration, logBlock, total, gasLimit uint64, logPrefix string, batch *kv.PendingMutations, tx kv.RwTx, metric metrics.Gauge) *TxGasLogger {
 	return &TxGasLogger{
+		ctx:          ctx,
 		logEvery:     time.NewTicker(logInterval),
 		initialBlock: logBlock,
 		logBlock:     logBlock,
@@ -49,13 +52,20 @@ func NewTxGasLogger(logInterval time.Duration, logBlock, total, gasLimit uint64,
 
 func (g *TxGasLogger) Start() {
 	go func() {
+		defer g.logEvery.Stop()
 		for {
-			func() {
-				// if tx gets committed during metrics collection, ensure we recover and start logging again
-				defer func() {
-					recover()
-				}()
-				for range g.logEvery.C {
+			select {
+			case <-g.ctx.Done():
+				log.Info(fmt.Sprintf("[%s] Stopping TxGasLogger", g.logPrefix))
+				return
+			case <-g.logEvery.C:
+				func() {
+					// if tx gets committed during metrics collection, ensure we recover and start logging again
+					defer func() {
+						if r := recover(); r != nil {
+							log.Warn(fmt.Sprintf("[%s] Encountered a panic during TxGasLogger, recovering...", g.logPrefix), "error", r)
+						}
+					}()
 					g.logProgress()
 					g.logTx = g.lastLogTx
 					g.logBlock = g.currentBlockNum
@@ -65,9 +75,8 @@ func (g *TxGasLogger) Start() {
 						g.tx.CollectMetrics()
 					}
 					g.metric.SetUint64(g.logBlock)
-				}
-			}()
-			time.Sleep(time.Second)
+				}()
+			}
 		}
 	}()
 }


### PR DESCRIPTION
There may be a case where we panic on the logger go routtine during metrics collection. We first check if tx is not nil, but then execute a bunch of code. There is a small case where tx can become nil after the check but before we want to use it.

https://github.com/0xPolygonHermez/cdk-erigon/issues/1633#issue-2788150875