### PR TITLE
merge: fix: recover sender only for those txs that are included (#1636)

### DIFF
--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -420,6 +420,22 @@ func sequencingBatchStep(
 				}
 
 				txHash := transaction.Hash()
+
+				if _, ok := transaction.GetSender(); !ok {
+					signer := types.MakeSigner(cfg.chainConfig, executionAt, 0)
+					sender, err := signer.Sender(transaction)
+					if err != nil {
+						log.Warn("[extractTransaction] Failed to recover sender from transaction, skipping and removing from pool",
+							"error", err,
+							"hash", transaction.Hash())
+						badTxHashes = append(badTxHashes, txHash)
+						batchState.blockState.transactionsToDiscard = append(batchState.blockState.transactionsToDiscard, batchState.blockState.transactionHashesToSlots[txHash])
+						continue
+					}
+
+					transaction.SetSender(sender)
+				}
+
 				effectiveGas := batchState.blockState.getL1EffectiveGases(cfg, i)
 
 				// The copying of this structure is intentional

--- a/zk/stages/stage_sequence_execute_transactions.go
+++ b/zk/stages/stage_sequence_execute_transactions.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ledgerwatch/erigon/core/vm/evmtypes"
 	"github.com/ledgerwatch/erigon/zk/utils"
 	"github.com/ledgerwatch/log/v3"
-	"github.com/ledgerwatch/secp256k1"
 )
 
 func getNextPoolTransactions(ctx context.Context, cfg SequenceBlockCfg, executionAt, forkId uint64, alreadyYielded mapset.Set[[32]byte]) ([]types.Transaction, []common.Hash, bool, error) {
@@ -89,8 +88,7 @@ func extractTransactionsFromSlot(slot *types2.TxsRlp, currentHeight uint64, cfg 
 	ids := make([]common.Hash, 0, len(slot.TxIds))
 	transactions := make([]types.Transaction, 0, len(slot.Txs))
 	toRemove := make([]common.Hash, 0)
-	signer := types.MakeSigner(cfg.chainConfig, currentHeight, 0)
-	cryptoContext := secp256k1.ContextForThread(1)
+
 	for idx, txBytes := range slot.Txs {
 		transaction, err := types.DecodeTransaction(txBytes)
 		if err == io.EOF {
@@ -106,17 +104,7 @@ func extractTransactionsFromSlot(slot *types2.TxsRlp, currentHeight uint64, cfg 
 			continue
 		}
 
-		// now attempt to recover the sender
-		sender, err := signer.SenderWithContext(cryptoContext, transaction)
-		if err != nil {
-			log.Warn("[extractTransaction] Failed to recover sender from transaction, skipping and removing from pool",
-				"error", err,
-				"hash", transaction.Hash())
-			toRemove = append(toRemove, slot.TxIds[idx])
-			continue
-		}
-
-		transaction.SetSender(sender)
+		// Recover sender later only for those transactions that are included in the block
 		transactions = append(transactions, transaction)
 		ids = append(ids, slot.TxIds[idx])
 	}


### PR DESCRIPTION
* fix: recover sender only for those txs that are included

* Moved recovering sender out of addTransaction. Default context used for sender recovery.

Merging https://github.com/0xPolygonHermez/cdk-erigon/pull/1636