### PR TITLE
fix(gas-pool): create a gas pool per block in normalcy mode on sequencer

### DIFF
--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -138,6 +138,7 @@ func sequencingBatchStep(
 	batchState := newBatchState(forkId, batchNumberForStateInitialization, executionAt+1, cfg.zk.HasExecutors(), cfg.zk.IsL1Recovery(), cfg.txPool, resequenceBatchJob)
 	blockDataSizeChecker := NewBlockDataChecker(cfg.zk.ShouldCountersBeUnlimited(batchState.isL1Recovery()))
 	streamWriter := newSequencerBatchStreamWriter(batchContext, batchState)
+	normalcyGasPool := new(core.GasPool).AddGas(transactionGasLimit) // used in normalcy mode per block
 
 	// injected batch
 	if executionAt == 0 {
@@ -471,7 +472,7 @@ func sequencingBatchStep(
 
 				// The copying of this structure is intentional
 				backupDataSizeChecker := *blockDataSizeChecker
-				receipt, execResult, txCounters, anyOverflow, err := attemptAddTransaction(cfg, sdb, ibs, batchCounters, &blockContext, header, transaction, effectiveGas, batchState.isL1Recovery(), batchState.forkId, l1TreeUpdateIndex, &backupDataSizeChecker)
+				receipt, execResult, txCounters, anyOverflow, err := attemptAddTransaction(cfg, sdb, ibs, batchCounters, &blockContext, header, transaction, effectiveGas, batchState.isL1Recovery(), batchState.forkId, l1TreeUpdateIndex, &backupDataSizeChecker, normalcyGasPool)
 				if err != nil {
 					if batchState.isLimboRecovery() {
 						panic("limbo transaction has already been executed once so they must not fail while re-executing")

--- a/zk/stages/stage_sequence_execute_injected_batch.go
+++ b/zk/stages/stage_sequence_execute_injected_batch.go
@@ -136,9 +136,11 @@ func handleInjectedBatch(
 
 	batchCounters := vm.NewBatchCounterCollector(batchContext.sdb.smt.GetDepth(), uint16(forkId), batchContext.cfg.zk.VirtualCountersSmtReduction, batchContext.cfg.zk.ShouldCountersBeUnlimited(false), nil)
 
+	normalcyGasPool := new(core.GasPool).AddGas(transactionGasLimit)
+
 	// process the tx and we can ignore the counters as an overflow at this stage means no network anyway
 	effectiveGas := DeriveEffectiveGasPrice(*batchContext.cfg, decodedBlocks[0].Transactions[0])
-	receipt, execResult, _, _, err := attemptAddTransaction(*batchContext.cfg, batchContext.sdb, ibs, batchCounters, blockContext, header, decodedBlocks[0].Transactions[0], effectiveGas, false, forkId, 0 /* use 0 for l1InfoIndex in injected batch */, nil)
+	receipt, execResult, _, _, err := attemptAddTransaction(*batchContext.cfg, batchContext.sdb, ibs, batchCounters, blockContext, header, decodedBlocks[0].Transactions[0], effectiveGas, false, forkId, 0 /* use 0 for l1InfoIndex in injected batch */, nil, normalcyGasPool)
 	if err != nil {
 		return nil, nil, nil, 0, err
 	}


### PR DESCRIPTION
### Issue

During sequencing stage we create a gas pool per transaction of a block. this is default by design as zkevm block gas limit is infinite. The RPC creates a gas pool per block and executes transactions on that pool. If in normalcy mode the gas pool will be 30m, so if we transact 2 tx's in the same block it will cause an overflow on the RPC, but the sequencer will create a block with 2 tx's.

### Solution

If in normalcy mode we take a gas pool higher up per block in sequencing stage and execute the transactions on that pool. If we get an overflow then we can add the transaction to the next block. this will then sync up with the RPC in normalcy mode and will not cause the RPC to become out of sync not being able to execute the block with 2 tx's.