### PR TITLE
2.61 deadlocks

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2391,6 +2391,8 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 
 	if ctx.IsSet(TxPoolGossipDisableFlag.Name) {
 		cfg.DisableTxPoolGossip = ctx.Bool(TxPoolGossipDisableFlag.Name)
+	} else {
+		cfg.DisableTxPoolGossip = txpoolcfg.DefaultConfig.NoGossip
 	}
 }
 

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -751,14 +751,14 @@ func (db *MdbxKV) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 		// otherwise carry on
 	}
 
-	if !db.trackTxBegin() {
-		return nil, fmt.Errorf("db closed")
-	}
-
 	// will return nil err if context is cancelled (may appear to acquire the semaphore)
 	if semErr := db.readTxLimiter.Acquire(ctx, 1); semErr != nil {
 		db.trackTxEnd()
 		return nil, fmt.Errorf("mdbx.MdbxKV.BeginRo: roTxsLimiter error %w", semErr)
+	}
+
+	if !db.trackTxBegin() {
+		return nil, fmt.Errorf("db closed")
 	}
 
 	defer func() {

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -753,7 +753,6 @@ func (db *MdbxKV) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 
 	// will return nil err if context is cancelled (may appear to acquire the semaphore)
 	if semErr := db.readTxLimiter.Acquire(ctx, 1); semErr != nil {
-		db.trackTxEnd()
 		return nil, fmt.Errorf("mdbx.MdbxKV.BeginRo: roTxsLimiter error %w", semErr)
 	}
 

--- a/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
+++ b/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
@@ -83,7 +83,7 @@ var DefaultConfig = Config{
 	PriceBump:          10,  // Price bump percentage to replace an already existing transaction
 	BlobPriceBump:      100,
 
-	NoGossip: false,
+	NoGossip: true, // centralised sequencing for [zkevm] doesn't need tx gossiping
 
 	OverrideShanghaiTime: nil,
 }

--- a/turbo/jsonrpc/send_transaction.go
+++ b/turbo/jsonrpc/send_transaction.go
@@ -97,19 +97,6 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutility
 		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}
 
-	// this has been moved to prior to adding of transactions to capture the
-	// pre state of the db - which is used for logging in the messages below
-	tx, err = api.db.BeginRo(ctx)
-	if err != nil {
-		return common.Hash{}, err
-	}
-	defer tx.Rollback()
-
-	cc, err = api.chainConfig(ctx, tx)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
 	if txn.Protected() {
 		txnChainId := txn.GetChainID()
 		chainId := cc.ChainID

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -319,6 +319,10 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		londonBlock := mock.ChainConfig.LondonBlock
 		shanghaiTime := mock.ChainConfig.ShanghaiTime
 
+		// we want to enable gossip testing for the majority of tests even though in a zk context we don't want it enabled - having it disabled stops the
+		// p2p sentry pickup on events from the txpool
+		txpoolcfg.DefaultConfig.NoGossip = false
+
 		mock.TxPool, err = txpool.New(newTxs, mock.DB, txpoolcfg.DefaultConfig, &ethconfig.Defaults, kvcache.NewDummy(), *chainID, shanghaiTime, londonBlock, mock.DB)
 		if err != nil {
 			tb.Fatal(err)

--- a/zk/datastream/client/stream_client_test.go
+++ b/zk/datastream/client/stream_client_test.go
@@ -118,7 +118,7 @@ func TestStreamClientReadResultEntry(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		c := NewClient(context.Background(), "", false, 0, 500*time.Millisecond, 0)
+		c := NewClient(context.Background(), "", false, 0, 2*time.Second, 0)
 		server, conn := net.Pipe()
 		defer server.Close()
 		defer c.Stop()

--- a/zk/stages/stage_sequence_execute_transactions.go
+++ b/zk/stages/stage_sequence_execute_transactions.go
@@ -21,9 +21,6 @@ import (
 )
 
 func getNextPoolTransactions(ctx context.Context, cfg SequenceBlockCfg, executionAt, forkId uint64, alreadyYielded mapset.Set[[32]byte]) ([]types.Transaction, []common.Hash, bool, error) {
-	cfg.txPool.LockFlusher()
-	defer cfg.txPool.UnlockFlusher()
-
 	var ids []common.Hash
 	var transactions []types.Transaction
 	var allConditionsOk bool
@@ -57,9 +54,6 @@ func getNextPoolTransactions(ctx context.Context, cfg SequenceBlockCfg, executio
 }
 
 func getLimboTransaction(ctx context.Context, cfg SequenceBlockCfg, txHash *common.Hash, executionAt uint64) ([]types.Transaction, error) {
-	cfg.txPool.LockFlusher()
-	defer cfg.txPool.UnlockFlusher()
-
 	var transactions []types.Transaction
 	// ensure we don't spin forever looking for transactions, attempt for a while then exit up to the caller
 	if err := cfg.txPoolDb.View(ctx, func(poolTx kv.Tx) error {

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -1262,14 +1262,6 @@ func (p *TxPool) NonceFromAddress(addr [20]byte) (nonce uint64, inPool bool) {
 	return p.all.nonce(senderID)
 }
 
-func (p *TxPool) LockFlusher() {
-	p.flushMtx.Lock()
-}
-
-func (p *TxPool) UnlockFlusher() {
-	p.flushMtx.Unlock()
-}
-
 // removeMined - apply new highest block (or batch of blocks)
 //
 // 1. New best block arrives, which potentially changes the balance and the nonce of some senders.
@@ -1410,16 +1402,16 @@ func MainLoop(ctx context.Context, db kv.RwDB, coreDB kv.RoDB, p *TxPool, newTxs
 	for {
 		select {
 		case <-ctx.Done():
-			p.LockFlusher()
 			innerContext, innerContextcancel := context.WithCancel(context.Background())
+			p.flushMtx.Lock()
 			written, err := p.flush(innerContext, db)
+			p.flushMtx.Unlock()
 			if err != nil {
 				log.Error("[txpool] flush is local history", "err", err)
 			} else {
 				writeToDBBytesCounter.Set(written)
 			}
 			innerContextcancel()
-			p.UnlockFlusher()
 			return
 		case <-logEvery.C:
 			p.logStats()
@@ -1439,9 +1431,9 @@ func MainLoop(ctx context.Context, db kv.RwDB, coreDB kv.RoDB, p *TxPool, newTxs
 		case <-commitEvery.C:
 			if db != nil && p.Started() {
 				t := time.Now()
-				p.LockFlusher()
+				p.flushMtx.Lock()
 				written, err := p.flush(ctx, db)
-				p.UnlockFlusher()
+				p.flushMtx.Unlock()
 				if err != nil {
 					log.Error("[txpool] flush is local history", "err", err)
 					continue
@@ -1468,6 +1460,14 @@ func MainLoop(ctx context.Context, db kv.RwDB, coreDB kv.RoDB, p *TxPool, newTxs
 				announcements = announcements.DedupCopy()
 
 				notifyMiningAboutNewSlots()
+
+				if p.cfg.NoGossip {
+					// drain newTxs for emptying newTx channel
+					// newTx channel will be filled only with local transactions
+					// early return to avoid outbound transaction propagation
+					log.Debug("[txpool] tx gossip disabled", "state", "drain new transactions")
+					return
+				}
 
 				var localTxTypes []byte
 				var localTxSizes []uint32
@@ -1542,9 +1542,10 @@ func MainLoop(ctx context.Context, db kv.RwDB, coreDB kv.RoDB, p *TxPool, newTxs
 }
 
 func (p *TxPool) flush(ctx context.Context, db kv.RwDB) (written uint64, err error) {
-	defer writeToDBTimer.UpdateDuration(time.Now())
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
+	defer writeToDBTimer.UpdateDuration(time.Now())
 	//it's important that write db tx is done inside lock, to make last writes visible for all read operations
 	if err := db.Update(ctx, func(tx kv.RwTx) error {
 		err = p.flushLocked(tx)

--- a/zk/txpool/pool_zk.go
+++ b/zk/txpool/pool_zk.go
@@ -150,6 +150,8 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 // zk: the implementation of best here is changed only to not take into account block gas limits as we don't care about
 // these in zk.  Instead we do a quick check on the transaction maximum gas in zk
 func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas, availableBlobGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, error) {
+	// we need to take a lock here to avoid a potential deadlock with the pool flush routine.  Nested locks are not a good pattern
+	// but it is difficult to avoid here as the flush routine needs to wait until the best queue is unlocked before it can flush
 	p.flushMtx.Lock()
 	defer p.flushMtx.Unlock()
 

--- a/zk/txpool/pool_zk.go
+++ b/zk/txpool/pool_zk.go
@@ -150,6 +150,9 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 // zk: the implementation of best here is changed only to not take into account block gas limits as we don't care about
 // these in zk.  Instead we do a quick check on the transaction maximum gas in zk
 func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas, availableBlobGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, error) {
+	p.flushMtx.Lock()
+	defer p.flushMtx.Unlock()
+
 	p.lock.Lock()
 	defer p.lock.Unlock()
 


### PR DESCRIPTION
aiming to tackle the deadlocks we have seen on production networks.  Running a stress test with a lot of transactional traffic and RPC calls alongside it shows the changes have at least improved things.

txpool gossip is also now disabled by default as that was a lot of unnecessary work on busy networks when we don't use p2p for anything.