### PR TITLE
feat(health-check): add tx pool and last block mined to health check

### DIFF
--- a/cmd/rpcdaemon/health/check_block.go
+++ b/cmd/rpcdaemon/health/check_block.go
@@ -2,7 +2,10 @@ package health
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"time"
 
 	"github.com/ledgerwatch/erigon/rpc"
 )
@@ -21,4 +24,46 @@ func checkBlockNumber(blockNumber rpc.BlockNumber, api EthAPI) error {
 	}
 
 	return nil
+}
+
+func checkBlockTime(api EthAPI) (*uint, error) {
+	if api == nil {
+		return nil, fmt.Errorf("no connection to the Erigon server or `eth` namespace isn't enabled")
+	}
+	fullTx := false
+	data, err := api.GetBlockByNumber(context.TODO(), -1, &fullTx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("last block time not found")
+	}
+
+	timestamp, ok := data["timestamp"].(hexutil.Uint64)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type for block: %T", data["transactions"])
+	}
+
+	blockTime := time.Unix(int64(timestamp), 0).UTC()
+	now := time.Now().UTC()
+	if blockTime.After(now) {
+		return nil, fmt.Errorf("last block time is in the future: %v", lastBlockTime)
+	}
+	diff := now.Sub(blockTime)
+	seconds := uint(diff.Seconds())
+
+	return &seconds, nil
+}
+
+func blockTimeStringOrError(err error, blockTime *uint) string {
+	if err == nil && blockTime != nil {
+		return fmt.Sprintf("last block was mined more than %v seconds ago", *blockTime)
+	}
+
+	if errors.Is(err, errCheckDisabled) {
+		return "DISABLED"
+	}
+
+	return fmt.Sprintf("ERROR: %v", err)
 }

--- a/cmd/rpcdaemon/health/check_peers.go
+++ b/cmd/rpcdaemon/health/check_peers.go
@@ -10,12 +10,12 @@ var (
 	errNotEnoughPeers = errors.New("not enough peers")
 )
 
-func checkMinPeers(minPeerCount uint, api NetAPI) error {
+func checkMinPeers(ctx context.Context, minPeerCount uint, api NetAPI) error {
 	if api == nil {
 		return fmt.Errorf("no connection to the Erigon server or `net` namespace isn't enabled")
 	}
 
-	peerCount, err := api.PeerCount(context.TODO())
+	peerCount, err := api.PeerCount(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/rpcdaemon/health/check_txpool.go
+++ b/cmd/rpcdaemon/health/check_txpool.go
@@ -1,0 +1,56 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"github.com/ledgerwatch/erigon/turbo/jsonrpc"
+)
+
+func checkTxPool(txApi TxPoolAPI, ethApi EthAPI) error {
+	if txApi == nil {
+		return fmt.Errorf("no connection to the Erigon server or `tx_pool` namespace isn't enabled")
+	}
+
+	if ethApi == nil {
+		return fmt.Errorf("no connection to the Erigon server or `eth` namespace isn't enabled")
+	}
+
+	var err error
+
+	data, err := txApi.Content(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	contentMap, ok := data.(map[string]map[string]map[string]*jsonrpc.RPCTransaction)
+	if !ok {
+		return fmt.Errorf("unexpected response type for tx_pool: %T", data)
+	}
+
+	pendingData, ok := contentMap["pending"]
+	if !ok {
+		return nil
+	}
+
+	if pendingData != nil && len(pendingData) > 0 {
+		// pending pool has transactions lets check last block if it was 0 tx
+		var blockData map[string]interface{}
+		fullTx := false
+		blockData, err = ethApi.GetBlockByNumber(context.TODO(), -1, &fullTx)
+		if err != nil {
+			return err
+		}
+
+		var transactions []interface{}
+		transactions, ok = blockData["transactions"].([]interface{})
+		if !ok {
+			return nil
+		}
+
+		if len(transactions) == 0 {
+			return fmt.Errorf("found transactions in pending pool but last block has no transactions")
+		}
+	}
+
+	return nil
+}

--- a/cmd/rpcdaemon/health/health.go
+++ b/cmd/rpcdaemon/health/health.go
@@ -16,8 +16,10 @@ import (
 )
 
 type requestBody struct {
-	MinPeerCount *uint            `json:"min_peer_count"`
-	BlockNumber  *rpc.BlockNumber `json:"known_block"`
+	MinPeerCount  *uint            `json:"min_peer_count"`
+	BlockNumber   *rpc.BlockNumber `json:"known_block"`
+	TxPoolEnable  bool             `json:"tx_pool_enable"`
+	LastBlockTime bool             `json:"last_block_time"`
 }
 
 const (
@@ -27,6 +29,8 @@ const (
 	minPeerCount     = "min_peer_count"
 	checkBlock       = "check_block"
 	maxSecondsBehind = "max_seconds_behind"
+	txPoolEnable     = "tx_pool_enable"
+	lastBlockTime    = "last_block_time"
 )
 
 var (
@@ -43,25 +47,28 @@ func ProcessHealthcheckIfNeeded(
 		return false
 	}
 
-	netAPI, ethAPI := parseAPI(rpcAPI)
+	netAPI, ethAPI, txPoolAPI := parseAPI(rpcAPI)
 
 	headers := r.Header.Values(healthHeader)
 	if len(headers) != 0 {
-		processFromHeaders(headers, ethAPI, netAPI, w, r)
+		processFromHeaders(headers, ethAPI, netAPI, txPoolAPI, w, r)
 	} else {
-		processFromBody(w, r, netAPI, ethAPI)
+		processFromBody(w, r, netAPI, ethAPI, txPoolAPI)
 	}
 
 	return true
 }
 
-func processFromHeaders(headers []string, ethAPI EthAPI, netAPI NetAPI, w http.ResponseWriter, r *http.Request) {
+func processFromHeaders(headers []string, ethAPI EthAPI, netAPI NetAPI, txPoolAPI TxPoolAPI, w http.ResponseWriter, r *http.Request) {
 	var (
-		errCheckSynced  = errCheckDisabled
-		errCheckPeer    = errCheckDisabled
-		errCheckBlock   = errCheckDisabled
-		errCheckSeconds = errCheckDisabled
+		errCheckSynced        = errCheckDisabled
+		errCheckPeer          = errCheckDisabled
+		errCheckBlock         = errCheckDisabled
+		errCheckSeconds       = errCheckDisabled
+		errCheckTxPool        = errCheckDisabled
+		errCheckLastBlockTime = errCheckDisabled
 	)
+	var blockTime *uint
 
 	for _, header := range headers {
 		lHeader := strings.ToLower(header)
@@ -97,17 +104,26 @@ func processFromHeaders(headers []string, ethAPI EthAPI, netAPI NetAPI, w http.R
 			now := time.Now().Unix()
 			errCheckSeconds = checkTime(r, int(now)-seconds, ethAPI)
 		}
+		if lHeader == txPoolEnable {
+			errCheckTxPool = checkTxPool(txPoolAPI, ethAPI)
+		}
+		if lHeader == lastBlockTime {
+			blockTime, errCheckLastBlockTime = checkBlockTime(ethAPI)
+		}
 	}
 
-	reportHealthFromHeaders(errCheckSynced, errCheckPeer, errCheckBlock, errCheckSeconds, w)
+	reportHealthFromHeaders(errCheckSynced, errCheckPeer, errCheckBlock, errCheckSeconds, errCheckTxPool, errCheckLastBlockTime, blockTime, w)
 }
 
-func processFromBody(w http.ResponseWriter, r *http.Request, netAPI NetAPI, ethAPI EthAPI) {
+func processFromBody(w http.ResponseWriter, r *http.Request, netAPI NetAPI, ethAPI EthAPI, txPoolAPI TxPoolAPI) {
 	body, errParse := parseHealthCheckBody(r.Body)
 	defer r.Body.Close()
 
 	var errMinPeerCount = errCheckDisabled
 	var errCheckBlock = errCheckDisabled
+	var errCheckTxPool = errCheckDisabled
+	var errCheckLastBlockTime = errCheckDisabled
+	var blockTime *uint
 
 	if errParse != nil {
 		log.Root().Warn("unable to process healthcheck request", "err", errParse)
@@ -120,10 +136,17 @@ func processFromBody(w http.ResponseWriter, r *http.Request, netAPI NetAPI, ethA
 		if body.BlockNumber != nil {
 			errCheckBlock = checkBlockNumber(*body.BlockNumber, ethAPI)
 		}
-		// TODO add time from the last sync cycle
+		// 3. tx_pool pending pool
+		if body.TxPoolEnable == true {
+			errCheckTxPool = checkTxPool(txPoolAPI, ethAPI)
+		}
+		// last block time
+		if body.LastBlockTime == true {
+			blockTime, errCheckLastBlockTime = checkBlockTime(ethAPI)
+		}
 	}
 
-	err := reportHealthFromBody(errParse, errMinPeerCount, errCheckBlock, w)
+	err := reportHealthFromBody(errParse, errMinPeerCount, errCheckBlock, errCheckTxPool, errCheckLastBlockTime, blockTime, w)
 	if err != nil {
 		log.Root().Warn("unable to process healthcheck request", "err", err)
 	}
@@ -145,53 +168,73 @@ func parseHealthCheckBody(reader io.Reader) (requestBody, error) {
 	return body, nil
 }
 
-func reportHealthFromBody(errParse, errMinPeerCount, errCheckBlock error, w http.ResponseWriter) error {
+func reportHealthFromBody(errParse, errMinPeerCount, errCheckBlock, errCheckTxPool, errCheckLastBlockTime error, lastBlockTime *uint, w http.ResponseWriter) error {
 	statusCode := http.StatusOK
-	errors := make(map[string]string)
+	res := make(map[string]string)
 
 	if shouldChangeStatusCode(errParse) {
 		statusCode = http.StatusInternalServerError
 	}
-	errors["healthcheck_query"] = errorStringOrOK(errParse)
+	res["healthcheck_query"] = errorStringOrOK(errParse)
 
 	if shouldChangeStatusCode(errMinPeerCount) {
 		statusCode = http.StatusInternalServerError
 	}
-	errors["min_peer_count"] = errorStringOrOK(errMinPeerCount)
+	res["min_peer_count"] = errorStringOrOK(errMinPeerCount)
 
 	if shouldChangeStatusCode(errCheckBlock) {
 		statusCode = http.StatusInternalServerError
 	}
-	errors["check_block"] = errorStringOrOK(errCheckBlock)
+	res["check_block"] = errorStringOrOK(errCheckBlock)
 
-	return writeResponse(w, errors, statusCode)
+	if shouldChangeStatusCode(errCheckTxPool) {
+		statusCode = http.StatusInternalServerError
+	}
+	res["tx_pool"] = errorStringOrOK(errCheckTxPool)
+
+	if shouldChangeStatusCode(errCheckLastBlockTime) {
+		statusCode = http.StatusInternalServerError
+	}
+	res["last_block_time"] = blockTimeStringOrError(errCheckLastBlockTime, lastBlockTime)
+
+	return writeResponse(w, res, statusCode)
 }
 
-func reportHealthFromHeaders(errCheckSynced, errCheckPeer, errCheckBlock, errCheckSeconds error, w http.ResponseWriter) error {
+func reportHealthFromHeaders(errCheckSynced, errCheckPeer, errCheckBlock, errCheckSeconds, errCheckTxPool, errCheckLastBlockTime error, lastBlock *uint, w http.ResponseWriter) error {
 	statusCode := http.StatusOK
-	errs := make(map[string]string)
+	res := make(map[string]string)
 
 	if shouldChangeStatusCode(errCheckSynced) {
 		statusCode = http.StatusInternalServerError
 	}
-	errs[synced] = errorStringOrOK(errCheckSynced)
+	res[synced] = errorStringOrOK(errCheckSynced)
 
 	if shouldChangeStatusCode(errCheckPeer) {
 		statusCode = http.StatusInternalServerError
 	}
-	errs[minPeerCount] = errorStringOrOK(errCheckPeer)
+	res[minPeerCount] = errorStringOrOK(errCheckPeer)
 
 	if shouldChangeStatusCode(errCheckBlock) {
 		statusCode = http.StatusInternalServerError
 	}
-	errs[checkBlock] = errorStringOrOK(errCheckBlock)
+	res[checkBlock] = errorStringOrOK(errCheckBlock)
 
 	if shouldChangeStatusCode(errCheckSeconds) {
 		statusCode = http.StatusInternalServerError
 	}
-	errs[maxSecondsBehind] = errorStringOrOK(errCheckSeconds)
+	res[maxSecondsBehind] = errorStringOrOK(errCheckSeconds)
 
-	return writeResponse(w, errs, statusCode)
+	if shouldChangeStatusCode(errCheckTxPool) {
+		statusCode = http.StatusInternalServerError
+	}
+	res[txPoolEnable] = errorStringOrOK(errCheckTxPool)
+
+	if shouldChangeStatusCode(errCheckLastBlockTime) {
+		statusCode = http.StatusInternalServerError
+	}
+	res[lastBlockTime] = blockTimeStringOrError(errCheckLastBlockTime, lastBlock)
+
+	return writeResponse(w, res, statusCode)
 }
 
 func writeResponse(w http.ResponseWriter, errs map[string]string, statusCode int) error {

--- a/cmd/rpcdaemon/health/health_test.go
+++ b/cmd/rpcdaemon/health/health_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/ledgerwatch/erigon/turbo/jsonrpc"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -425,6 +426,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			netApiError:    nil,
 			ethApiBlockResult: map[string]interface{}{
 				"transactions": []interface{}{},
+				"number":       (*hexutil.Big)(big.NewInt(100)),
 			},
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
@@ -439,7 +441,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 				minPeerCount:     "DISABLED",
 				checkBlock:       "DISABLED",
 				maxSecondsBehind: "DISABLED",
-				txPoolEnable:     "ERROR: found transactions in pending pool but last block has no transactions",
+				txPoolEnable:     "ERROR: found transactions in pending pool but last 5 blocks have no transactions",
 			},
 		},
 	}

--- a/cmd/rpcdaemon/health/health_test.go
+++ b/cmd/rpcdaemon/health/health_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/ledgerwatch/erigon/turbo/jsonrpc"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -40,6 +41,15 @@ func (e *ethApiStub) Syncing(_ context.Context) (interface{}, error) {
 	return e.syncingResult, e.syncingError
 }
 
+type txPoolApiStub struct {
+	txPoolResult interface{}
+	txPoolError  error
+}
+
+func (t *txPoolApiStub) Content(_ context.Context) (interface{}, error) {
+	return t.txPoolResult, t.txPoolError
+}
+
 func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 	cases := []struct {
 		headers             []string
@@ -49,6 +59,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 		ethApiBlockError    error
 		ethApiSyncingResult interface{}
 		ethApiSyncingError  error
+		txPoolResult        interface{}
+		txPoolError         error
 		expectedStatusCode  int
 		expectedBody        map[string]string
 	}{
@@ -61,6 +73,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusOK,
 			expectedBody: map[string]string{
 				synced:           "HEALTHY",
@@ -78,6 +92,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: struct{}{},
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "ERROR: not synced",
@@ -95,6 +111,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: struct{}{},
 			ethApiSyncingError:  errors.New("problem checking sync"),
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "ERROR: problem checking sync",
@@ -112,6 +130,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusOK,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -129,6 +149,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -146,6 +168,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -163,6 +187,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -180,6 +206,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusOK,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -197,6 +225,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -214,6 +244,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    errors.New("problem checking block"),
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -231,6 +263,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -250,6 +284,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusOK,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -269,6 +305,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -288,6 +326,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -305,6 +345,8 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusInternalServerError,
 			expectedBody: map[string]string{
 				synced:           "DISABLED",
@@ -324,12 +366,80 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
 			expectedStatusCode:  http.StatusOK,
 			expectedBody: map[string]string{
 				synced:           "HEALTHY",
 				minPeerCount:     "HEALTHY",
 				checkBlock:       "HEALTHY",
 				maxSecondsBehind: "HEALTHY",
+			},
+		},
+		// 16 - check last block time
+		{
+			headers:        []string{"last_block_time"},
+			netApiResponse: hexutil.Uint(1),
+			netApiError:    nil,
+			ethApiBlockResult: map[string]interface{}{
+				"timestamp": hexutil.Uint64(time.Now().Add(-1 * time.Minute).Unix()),
+			},
+			ethApiBlockError:    nil,
+			ethApiSyncingResult: false,
+			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
+			expectedStatusCode:  http.StatusOK,
+			expectedBody: map[string]string{
+				synced:           "DISABLED",
+				minPeerCount:     "DISABLED",
+				checkBlock:       "DISABLED",
+				maxSecondsBehind: "DISABLED",
+				lastBlockTime:    "last block was mined more than 60 seconds ago",
+			},
+		},
+		// 17 - tx pool healthy
+		{
+			headers:             []string{"tx_pool_enable"},
+			netApiResponse:      hexutil.Uint(1),
+			netApiError:         nil,
+			ethApiBlockResult:   map[string]interface{}{},
+			ethApiBlockError:    nil,
+			ethApiSyncingResult: false,
+			ethApiSyncingError:  nil,
+			txPoolResult:        map[string]map[string]map[string]*jsonrpc.RPCTransaction{},
+			txPoolError:         nil,
+			expectedStatusCode:  http.StatusOK,
+			expectedBody: map[string]string{
+				synced:           "DISABLED",
+				minPeerCount:     "DISABLED",
+				checkBlock:       "DISABLED",
+				maxSecondsBehind: "DISABLED",
+				txPoolEnable:     "HEALTHY",
+			},
+		},
+		// 18 - tx pending with 0 tx block
+		{
+			headers:        []string{"tx_pool_enable"},
+			netApiResponse: hexutil.Uint(1),
+			netApiError:    nil,
+			ethApiBlockResult: map[string]interface{}{
+				"transactions": []interface{}{},
+			},
+			ethApiBlockError:    nil,
+			ethApiSyncingResult: false,
+			ethApiSyncingError:  nil,
+			txPoolResult: map[string]map[string]map[string]*jsonrpc.RPCTransaction{
+				"pending": {"1": {"1": &jsonrpc.RPCTransaction{}}},
+			},
+			txPoolError:        nil,
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedBody: map[string]string{
+				synced:           "DISABLED",
+				minPeerCount:     "DISABLED",
+				checkBlock:       "DISABLED",
+				maxSecondsBehind: "DISABLED",
+				txPoolEnable:     "ERROR: found transactions in pending pool but last block has no transactions",
 			},
 		},
 	}
@@ -367,9 +477,20 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			Public: false,
 		}
 
-		apis := make([]rpc.API, 2)
+		txPoolAPI := rpc.API{
+			Namespace: "",
+			Version:   "",
+			Service: &txPoolApiStub{
+				txPoolResult: c.txPoolResult,
+				txPoolError:  c.txPoolError,
+			},
+			Public: false,
+		}
+
+		apis := make([]rpc.API, 3)
 		apis[0] = netAPI
 		apis[1] = ethAPI
+		apis[2] = txPoolAPI
 
 		ProcessHealthcheckIfNeeded(w, r, apis)
 

--- a/cmd/rpcdaemon/health/interfaces.go
+++ b/cmd/rpcdaemon/health/interfaces.go
@@ -16,3 +16,7 @@ type EthAPI interface {
 	GetBlockByNumber(_ context.Context, number rpc.BlockNumber, fullTx *bool) (map[string]interface{}, error)
 	Syncing(ctx context.Context) (interface{}, error)
 }
+
+type TxPoolAPI interface {
+	Content(_ context.Context) (interface{}, error)
+}

--- a/cmd/rpcdaemon/health/interfaces.go
+++ b/cmd/rpcdaemon/health/interfaces.go
@@ -9,14 +9,14 @@ import (
 )
 
 type NetAPI interface {
-	PeerCount(_ context.Context) (hexutil.Uint, error)
+	PeerCount(ctx context.Context) (hexutil.Uint, error)
 }
 
 type EthAPI interface {
-	GetBlockByNumber(_ context.Context, number rpc.BlockNumber, fullTx *bool) (map[string]interface{}, error)
+	GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx *bool) (map[string]interface{}, error)
 	Syncing(ctx context.Context) (interface{}, error)
 }
 
 type TxPoolAPI interface {
-	Content(_ context.Context) (interface{}, error)
+	Content(ctx context.Context) (interface{}, error)
 }

--- a/cmd/rpcdaemon/health/parse_api.go
+++ b/cmd/rpcdaemon/health/parse_api.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ledgerwatch/erigon/rpc"
 )
 
-func parseAPI(api []rpc.API) (netAPI NetAPI, ethAPI EthAPI) {
+func parseAPI(api []rpc.API) (netAPI NetAPI, ethAPI EthAPI, txPoolAPI TxPoolAPI) {
 	for _, rpc := range api {
 		if rpc.Service == nil {
 			continue
@@ -17,6 +17,10 @@ func parseAPI(api []rpc.API) (netAPI NetAPI, ethAPI EthAPI) {
 		if ethCandidate, ok := rpc.Service.(EthAPI); ok {
 			ethAPI = ethCandidate
 		}
+
+		if txPoolCandidate, ok := rpc.Service.(TxPoolAPI); ok {
+			txPoolAPI = txPoolCandidate
+		}
 	}
-	return netAPI, ethAPI
+	return netAPI, ethAPI, txPoolAPI
 }


### PR DESCRIPTION
### Description

Augment TxPool and last block time to health endpoint.

### Usage

_Body_
`"tx_pool_enable": true`
_Header_
`X-ERIGON-HEALTHCHECK: tx_pool_enable`

Will show if there are tx's in the pending pool but last block has no tx's

_Body_
`"last_block_time": true`
_Header_
`X-ERIGON-HEALTHCHECK: last_block_time`

Will show last block was mined more that N seconds ago