### PR TITLE
Batch commit zkHash data for sequencer 

### DIFF
--- a/zk/stages/stage_sequence_execute_blocks.go
+++ b/zk/stages/stage_sequence_execute_blocks.go
@@ -184,9 +184,17 @@ func finaliseBlock(
 		return nil, err
 	}
 
+	quit := batchContext.ctx.Done()
+	_ = quit
+	batchContext.sdb.eridb.OpenBatch(quit)
 	// this is actually the interhashes stage
 	newRoot, err := zkIncrementIntermediateHashes(batchContext.ctx, batchContext.s.LogPrefix(), batchContext.s, batchContext.sdb.tx, batchContext.sdb.eridb, batchContext.sdb.smt, newHeader.Number.Uint64()-1, newHeader.Number.Uint64())
 	if err != nil {
+		batchContext.sdb.eridb.RollbackBatch()
+		return nil, err
+	}
+
+	if err = batchContext.sdb.eridb.CommitBatch(); err != nil {
 		return nil, err
 	}
 

--- a/zk/stages/stage_sequence_execute_blocks.go
+++ b/zk/stages/stage_sequence_execute_blocks.go
@@ -185,7 +185,6 @@ func finaliseBlock(
 	}
 
 	quit := batchContext.ctx.Done()
-	_ = quit
 	batchContext.sdb.eridb.OpenBatch(quit)
 	// this is actually the interhashes stage
 	newRoot, err := zkIncrementIntermediateHashes(batchContext.ctx, batchContext.s.LogPrefix(), batchContext.s, batchContext.sdb.tx, batchContext.sdb.eridb, batchContext.sdb.smt, newHeader.Number.Uint64()-1, newHeader.Number.Uint64())


### PR DESCRIPTION
Based on the test results using X Layer mainnet data (72GB), batch commit takes less time.

Not sure whether there are other risks, and stress testing will continue on local machine.