### PR TITLE
Zkevm sequencer as rpc

### DIFF
--- a/cmd/integration/commands/stages_zkevm.go
+++ b/cmd/integration/commands/stages_zkevm.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"context"
-	"github.com/ledgerwatch/erigon/zk/zk_config"
-	"github.com/ledgerwatch/erigon/zk/zk_config/cfg_dynamic_genesis"
 	"math/big"
 	"path/filepath"
 	"strings"
+
+	"github.com/ledgerwatch/erigon/zk/zk_config"
+	"github.com/ledgerwatch/erigon/zk/zk_config/cfg_dynamic_genesis"
 
 	"github.com/c2h5oh/datasize"
 	chain3 "github.com/ledgerwatch/erigon-lib/chain"
@@ -119,6 +120,7 @@ func newSyncZk(ctx context.Context, db kv.RwDB) (consensus.Engine, *vm.Config, *
 			agg,
 			nil,
 			engine,
+			nil,
 			nil,
 			nil,
 			nil,

--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -47,6 +47,10 @@ type StageState struct {
 	BlockNumber uint64 // BlockNumber is the current block number of the stage at the beginning of the state execution.
 }
 
+func (s *StageState) PrevUnwindPoint() *uint64 {
+	return s.state.PrevUnwindPoint()
+}
+
 func (s *StageState) LogPrefix() string { return s.state.LogPrefix() }
 
 // Update updates the stage state (current block number) in the database. Can be called multiple times during stage execution.

--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -48,6 +48,9 @@ type StageState struct {
 }
 
 func (s *StageState) PrevUnwindPoint() *uint64 {
+	if s.state == nil {
+		return nil
+	}
 	return s.state.PrevUnwindPoint()
 }
 

--- a/p2p/sentry/sentry_multi_client/sentry_api.go
+++ b/p2p/sentry/sentry_multi_client/sentry_api.go
@@ -9,6 +9,7 @@ import (
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	proto_sentry "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
+	"github.com/ledgerwatch/erigon-lib/kv"
 
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
 	"github.com/ledgerwatch/erigon/p2p/sentry"
@@ -25,7 +26,19 @@ func (cs *MultiClient) SetStatus(ctx context.Context) {
 		cs.logger.Error("MultiClient.SetStatus: GetStatusData error", "err", err)
 		return
 	}
+	cs.loopStatuses(ctx, statusMsg)
+}
 
+func (cs *MultiClient) SetStatusWithTx(ctx context.Context, tx kv.Tx) {
+	statusMsg, err := cs.statusDataProvider.GetStatusDataWithTx(ctx, tx)
+	if err != nil {
+		cs.logger.Error("MultiClient.SetStatus: GetStatusData error", "err", err)
+		return
+	}
+	cs.loopStatuses(ctx, statusMsg)
+}
+
+func (cs *MultiClient) loopStatuses(ctx context.Context, statusMsg *proto_sentry.StatusData) {
 	for _, sentry := range cs.sentries {
 		if !sentry.Ready() {
 			continue

--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -113,6 +113,14 @@ func (s *StatusDataProvider) GetStatusData(ctx context.Context) (*proto_sentry.S
 	return s.makeStatusData(chainHead), err
 }
 
+func (s *StatusDataProvider) GetStatusDataWithTx(ctx context.Context, tx kv.Tx) (*proto_sentry.StatusData, error) {
+	chainHead, err := ReadChainHeadWithTx(tx)
+	if err != nil {
+		return nil, err
+	}
+	return s.makeStatusData(chainHead), nil
+}
+
 func ReadChainHeadWithTx(tx kv.Tx) (ChainHead, error) {
 	header := rawdb.ReadCurrentHeaderHavingBody(tx)
 	if header == nil {

--- a/turbo/app/import_cmd.go
+++ b/turbo/app/import_cmd.go
@@ -22,16 +22,17 @@ import (
 	"github.com/ledgerwatch/erigon/consensus/merge"
 	"github.com/ledgerwatch/erigon/turbo/execution/eth1/eth1_chain_reader.go"
 	"github.com/ledgerwatch/erigon/turbo/services"
+	"github.com/ledgerwatch/erigon/turbo/stages"
 
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth"
+	stages2 "github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/debug"
 	turboNode "github.com/ledgerwatch/erigon/turbo/node"
-	"github.com/ledgerwatch/erigon/turbo/stages"
 )
 
 const (
@@ -224,7 +225,7 @@ func InsertChain(ethereum *eth.Ethereum, chain *core.ChainPack, logger log.Logge
 	sentryControlServer.Hd.MarkAllVerified()
 	blockReader, _ := ethereum.BlockIO()
 
-	hook := stages.NewHook(ethereum.SentryCtx(), ethereum.ChainDB(), ethereum.Notifications(), ethereum.StagedSync(), blockReader, ethereum.ChainConfig(), logger, sentryControlServer.SetStatus)
+	hook := stages.NewHook(ethereum.SentryCtx(), ethereum.ChainDB(), ethereum.Notifications(), ethereum.StagedSync(), blockReader, ethereum.ChainConfig(), logger, sentryControlServer.SetStatusWithTx, stages2.Finish)
 	err := stages.StageLoopIteration(ethereum.SentryCtx(), ethereum.ChainDB(), wrap.TxContainer{}, ethereum.StagedSync(), initialCycle, logger, blockReader, hook, false)
 	if err != nil {
 		return err

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -349,7 +349,7 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, blockHas
 		}
 		if e.hook != nil {
 			if err := e.db.View(ctx, func(tx kv.Tx) error {
-				return e.hook.AfterRun(tx, finishProgressBefore)
+				return e.hook.AfterRun(tx, finishProgressBefore, e.executionPipeline.PrevUnwindPoint())
 			}); err != nil {
 				sendForkchoiceErrorWithoutWaiting(outcomeCh, err)
 				return

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -686,7 +686,7 @@ func (ms *MockSentry) insertPoWBlocks(chain *core.ChainPack) error {
 		ms.ReceiveWg.Add(1)
 	}
 	initialCycle := MockInsertAsInitialCycle
-	hook := stages2.NewHook(ms.Ctx, ms.DB, ms.Notifications, ms.Sync, ms.BlockReader, ms.ChainConfig, ms.Log, ms.sentriesClient.SetStatusWithTx, stages.Finish)
+	hook := stages2.NewHook(ms.Ctx, ms.DB, ms.Notifications, ms.Sync, ms.BlockReader, ms.ChainConfig, ms.Log, nil, stages.Finish)
 
 	if err = stages2.StageLoopIteration(ms.Ctx, ms.DB, wrap.TxContainer{}, ms.Sync, initialCycle, ms.Log, ms.BlockReader, hook, false); err != nil {
 		return err

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -686,7 +686,7 @@ func (ms *MockSentry) insertPoWBlocks(chain *core.ChainPack) error {
 		ms.ReceiveWg.Add(1)
 	}
 	initialCycle := MockInsertAsInitialCycle
-	hook := stages2.NewHook(ms.Ctx, ms.DB, ms.Notifications, ms.Sync, ms.BlockReader, ms.ChainConfig, ms.Log, nil)
+	hook := stages2.NewHook(ms.Ctx, ms.DB, ms.Notifications, ms.Sync, ms.BlockReader, ms.ChainConfig, ms.Log, ms.sentriesClient.SetStatusWithTx, stages.Finish)
 
 	if err = stages2.StageLoopIteration(ms.Ctx, ms.DB, wrap.TxContainer{}, ms.Sync, initialCycle, ms.Log, ms.BlockReader, hook, false); err != nil {
 		return err

--- a/turbo/stages/mock/sentry_mock_test.go
+++ b/turbo/stages/mock/sentry_mock_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
+	stages2 "github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/stages"
@@ -503,7 +504,7 @@ func TestAnchorReplace2(t *testing.T) {
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
 
 	initialCycle := mock.MockInsertAsInitialCycle
-	hook := stages.NewHook(m.Ctx, m.DB, m.Notifications, m.Sync, m.BlockReader, m.ChainConfig, m.Log, nil)
+	hook := stages.NewHook(m.Ctx, m.DB, m.Notifications, m.Sync, m.BlockReader, m.ChainConfig, m.Log, nil, stages2.Finish)
 	if err := stages.StageLoopIteration(m.Ctx, m.DB, wrap.TxContainer{}, m.Sync, initialCycle, m.Log, m.BlockReader, hook, false); err != nil {
 		t.Fatal(err)
 	}

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -108,6 +108,7 @@ func NewSequencerZkStages(ctx context.Context,
 	txPoolDb kv.RwDB,
 	verifier *legacy_executor_verifier.LegacyExecutorVerifier,
 	infoTreeUpdater *l1infotree.Updater,
+	hook *Hook,
 ) []*stagedsync.Stage {
 	dirs := cfg.Dirs
 	blockReader := freezeblocks.NewBlockReader(snapshots, nil)
@@ -147,6 +148,7 @@ func NewSequencerZkStages(ctx context.Context,
 			verifier,
 			uint16(cfg.YieldSize),
 			infoTreeUpdater,
+			hook,
 		),
 		stagedsync.StageHashStateCfg(db, dirs, cfg.HistoryV3, agg),
 		zkStages.StageZkInterHashesCfg(db, true, true, false, dirs.Tmp, blockReader, controlServer.Hd, cfg.HistoryV3, agg, cfg.Zk),

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/chain"
 	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/kv"
 	cMocks "github.com/ledgerwatch/erigon-lib/kv/kvcache/mocks"
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
 	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
@@ -163,6 +164,7 @@ func TestSpawnSequencingStage(t *testing.T) {
 		txPoolDb:         txPoolDb,
 		engine:           engineMock,
 		legacyVerifier:   legacyVerifier,
+		doneHook:         &MockDoneHook{},
 	}
 	historyCfg := stagedsync.StageHistoryCfg(db1, prune.DefaultMode, "")
 	quiet := true
@@ -198,6 +200,13 @@ func TestSpawnSequencingStage(t *testing.T) {
 	// batch/block sealing timeouts are small, so it could happen that an extra block is not added to the batch
 	// No requirement prevents adding and extra block to the batch or not adding it. For more specific cases, create a separate test.
 	assert.True(t, expectedBlockNum <= blockNumber && blockNumber <= expectedBlockNum+1, "value is not in range")
-	assert.Equal(t, uint64(1), stateVersion)
+	assert.Equal(t, uint64(2), stateVersion)
 	tx.Rollback()
+}
+
+type MockDoneHook struct {
+}
+
+func (m *MockDoneHook) AfterRun(tx kv.Tx, finishProgressBefore uint64, prevUnwindPoint *uint64) error {
+	return nil
 }

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -146,7 +146,7 @@ func TestSpawnSequencingStage(t *testing.T) {
 	zkCfg := &ethconfig.Zk{
 		SequencerResequence: false,
 		// lower batch close time ensures only 1 block will be created on 1 turn, as the test expects
-		SequencerBatchSealTime:      3 * time.Millisecond, // normally it is greater that block seal time, allows one more block to be added to the batch
+		SequencerBatchSealTime:      2 * time.Millisecond, // normally it is greater that block seal time, allows one more block to be added to the batch
 		SequencerBlockSealTime:      2 * time.Millisecond,
 		SequencerEmptyBlockSealTime: 2 * time.Millisecond,
 		InfoTreeUpdateInterval:      2 * time.Millisecond,
@@ -200,7 +200,7 @@ func TestSpawnSequencingStage(t *testing.T) {
 	// batch/block sealing timeouts are small, so it could happen that an extra block is not added to the batch
 	// No requirement prevents adding and extra block to the batch or not adding it. For more specific cases, create a separate test.
 	assert.True(t, expectedBlockNum <= blockNumber && blockNumber <= expectedBlockNum+1, "value is not in range")
-	assert.Equal(t, uint64(2), stateVersion)
+	assert.Equal(t, uint64(1), stateVersion)
 	tx.Rollback()
 }
 


### PR DESCRIPTION
Allows the sequencer to report on `newHeads` as soon as new blocks are produced.

Logs also reported per block rather than waiting for the end of a batch.

A few interfaces changed here to support nested MDBX transactions and to have the `Hook` created in backend.go support not having a working StageSync in it (nil pointer).