### PR TITLE
cleaner shut down

### DIFF
--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -409,7 +409,7 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 		writeTxLimiter: opts.writeTxLimiter,
 
 		txsCountMutex:         txsCountMutex,
-		txsAllDoneOnCloseCond: sync.NewCond(txsCountMutex),
+		txsAllDoneOnCloseCond: sync.NewCond(&sync.Mutex{}),
 
 		leakDetector: dbg.NewLeakDetector("db."+opts.label.String(), dbg.SlowTx()),
 


### PR DESCRIPTION
shared mutex in the sync.Cond caused a panic on unlocking an unlocked
 mutex as it was shared with other logic