### PR TITLE
nonce issue detection and remedy in execution

### DIFF
--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -319,6 +320,7 @@ func sequencingBatchStep(
 
 		innerBreak := false
 		emptyBlockOverflow := false
+		sendersToTriggerStatechanges := make(map[common.Address]struct{})
 
 	OuterLoopTransactions:
 		for {
@@ -475,6 +477,17 @@ func sequencingBatchStep(
 							"hash", txHash,
 							"to", transaction.GetTo(),
 						)
+						continue
+					}
+
+					if errors.Is(err, core.ErrNonceTooHigh) || errors.Is(err, core.ErrNonceTooLow) {
+						// here we have a case where some situation has caused a nonce issue to find its way into the pending pool
+						// we want to skip transactions for this sender in this batch for now and ask the pool to trigger a sender
+						// state change for this sender.  This will cause the pool to skip any transactions from this sender until
+						// the sender's nonce is corrected in the pending pool
+						log.Info(fmt.Sprintf("[%s] nonce issue detected for sender, skipping transactions for now", logPrefix), "sender", txSender.Hex(), "nonceIssue", err)
+						sendersToSkip[txSender] = struct{}{}
+						sendersToTriggerStatechanges[txSender] = struct{}{}
 						continue
 					}
 
@@ -670,6 +683,11 @@ func sequencingBatchStep(
 		// remove mined transactions from the pool
 		toRemove := append(batchState.blockState.builtBlockElements.txSlots, batchState.blockState.transactionsToDiscard...)
 		if err := cfg.txPool.RemoveMinedTransactions(ctx, sdb.tx, header.GasLimit, toRemove); err != nil {
+			return err
+		}
+
+		// now trigger sender state changes in the pool where we encountered nonce issues during execution
+		if err := cfg.txPool.TriggerSenderStateChanges(ctx, sdb.tx, header.GasLimit, sendersToTriggerStatechanges); err != nil {
 			return err
 		}
 

--- a/zk/tests/unwinds/unwind.sh
+++ b/zk/tests/unwinds/unwind.sh
@@ -117,6 +117,7 @@ different_files=(
     "SyncStage.txt"
     "BadHeaderNumber.txt"
     "CallToIndex.txt"
+    "DbInfo.txt"
 )
 
 is_in_array() {

--- a/zk/txpool/pool_zk.go
+++ b/zk/txpool/pool_zk.go
@@ -198,7 +198,7 @@ func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 			// remove ldn txs when not in london
 			toRemove = append(toRemove, mt)
 			toSkip.Add(mt.Tx.IDHash)
-			log.Trace("Removing London transaction in non-London environment", "txID", mt.Tx.IDHash)
+			log.Info("Removing London transaction in non-London environment", "txID", mt.Tx.IDHash)
 			continue
 		}
 
@@ -215,7 +215,7 @@ func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 		}
 		if len(rlpTx) == 0 {
 			toRemove = append(toRemove, mt)
-			log.Trace("Removing transaction with empty RLP", "txID", mt.Tx.IDHash)
+			log.Info("Removing transaction with empty RLP", "txID", common.BytesToHash(mt.Tx.IDHash[:]))
 			continue
 		}
 
@@ -254,7 +254,8 @@ func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 	if len(toRemove) > 0 {
 		for _, mt := range toRemove {
 			p.pending.Remove(mt)
-			log.Trace("Removed transaction from pending pool", "txID", mt.Tx.IDHash)
+			p.discardLocked(mt, UnsupportedTx)
+			log.Debug("Removed transaction from pending pool", "txID", mt.Tx.IDHash)
 		}
 	}
 	return true, count, nil


### PR DESCRIPTION
here we pause handling further transactions for the sender in this batch and also trigger the pool to perform a sender state change to remove nonce too low transactions and move nonce too high to queued