### PR TITLE
nonce issue detection and remedy in execution

### DIFF
--- a/zk/txpool/pool_zk.go
+++ b/zk/txpool/pool_zk.go
@@ -204,7 +204,7 @@ func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 			// remove ldn txs when not in london
 			toRemove = append(toRemove, mt)
 			toSkip.Add(mt.Tx.IDHash)
-			p.Trace("Removing London transaction in non-London environment", "txID", mt.Tx.IDHash)
+			log.Info("Removing London transaction in non-London environment", "txID", mt.Tx.IDHash)
 			continue
 		}
 
@@ -221,7 +221,7 @@ func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 		}
 		if len(rlpTx) == 0 {
 			toRemove = append(toRemove, mt)
-			p.Trace("Removing transaction with empty RLP", "txID", mt.Tx.IDHash)
+			log.Info("Removing transaction with empty RLP", "txID", common.BytesToHash(mt.Tx.IDHash[:]))
 			continue
 		}
 
@@ -260,7 +260,8 @@ func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 	if len(toRemove) > 0 {
 		for _, mt := range toRemove {
 			p.pending.Remove(mt)
-			p.Trace("Removed transaction from pending pool", "txID", mt.Tx.IDHash)
+			p.discardLocked(mt, UnsupportedTx)
+			log.Debug("Removed transaction from pending pool", "txID", mt.Tx.IDHash)
 		}
 	}
 	return true, count, nil
@@ -341,6 +342,42 @@ func (p *TxPool) RemoveMinedTransactions(ctx context.Context, tx kv.Tx, blockGas
 			baseFee, blockGasLimit, p.pending, p.baseFee, p.queued, p.discardLocked)
 
 	}
+	return nil
+}
+
+func (p *TxPool) TriggerSenderStateChanges(ctx context.Context, tx kv.Tx, blockGasLimit uint64, senders map[common.Address]struct{}) error {
+	if len(senders) == 0 {
+		return nil
+	}
+
+	cache := p.cache()
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	sendersToUpdate := make(map[uint64]struct{})
+	for sender := range senders {
+		if id, ok := p.senders.senderIDs[sender]; ok {
+			sendersToUpdate[id] = struct{}{}
+		}
+	}
+
+	baseFee := p.pendingBaseFee.Load()
+
+	cacheView, err := cache.View(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	for senderID := range sendersToUpdate {
+		nonce, balance, err := p.senders.info(cacheView, senderID)
+		if err != nil {
+			return err
+		}
+		p.onSenderStateChange(senderID, nonce, balance, p.all,
+			baseFee, blockGasLimit, p.pending, p.baseFee, p.queued, p.discardLocked)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
* nonce issue detection and remedy in execution

here we pause handling further transactions for the sender in this batch and also trigger the pool to perform a sender state change to remove nonce too low transactions and move nonce too high to queued

* mop up discarded transactions during yielding correctly