### PR TITLE
Optimize calculating of the L1 Tree

### DIFF
--- a/zk/l1infotree/updater.go
+++ b/zk/l1infotree/updater.go
@@ -145,8 +145,6 @@ LOOP:
 		if err != nil {
 			return nil, fmt.Errorf("InitialiseL1InfoTree: %w", err)
 		}
-	} else {
-		log.Debug(fmt.Sprintf("[%s] Checking for L1 info tree updates, no logs to process", logPrefix))
 	}
 
 	// process the logs in chunks

--- a/zk/l1infotree/updater.go
+++ b/zk/l1infotree/updater.go
@@ -138,9 +138,15 @@ LOOP:
 	defer ticker.Stop()
 	processed := 0
 
-	tree, err := InitialiseL1InfoTree(hermezDb)
-	if err != nil {
-		return nil, fmt.Errorf("InitialiseL1InfoTree: %w", err)
+	var tree *L1InfoTree
+	if len(allLogs) > 0 {
+		log.Info(fmt.Sprintf("[%s] Checking for L1 info tree updates, logs count:%v", logPrefix, len(allLogs)))
+		tree, err = InitialiseL1InfoTree(hermezDb)
+		if err != nil {
+			return nil, fmt.Errorf("InitialiseL1InfoTree: %w", err)
+		}
+	} else {
+		log.Debug(fmt.Sprintf("[%s] Checking for L1 info tree updates, no logs to process", logPrefix))
 	}
 
 	// process the logs in chunks


### PR DESCRIPTION


Optimize the time for obtaining the L1 Tree, recalculating the root tree only when there are logs.


pprof from X Layer mainnet stress test
![image](https://github.com/user-attachments/assets/f04101a5-4ec4-4f29-81fe-c8c6b06b1888)

[prof-dev-1.bin.zip](https://github.com/user-attachments/files/18776306/prof-dev-1.bin.zip)



