### PR TITLE
feat(info-tree-compare): script to check info trees on 2 nodes

### DIFF
--- a/zk/debug_tools/mdbx-compare/Makefile
+++ b/zk/debug_tools/mdbx-compare/Makefile
@@ -1,0 +1,14 @@
+ifeq ($(words $(ARGS)),2)
+  # ARGS is OK
+else
+  $(error "Usage: make infotree ARGS=\"datadir1 datadir2\"")
+endif
+
+## infotree
+.PHONY: infotree
+infotree:
+	@echo "running mdbx-compare for infotree"
+	@chmod +x infotree-compare.sh
+	@./infotree-compare.sh $(ARGS)
+
+## make infotree ARGS="/path/to/data1/chaindata /path/to/data2/chaindata"

--- a/zk/debug_tools/mdbx-compare/infotree-compare.sh
+++ b/zk/debug_tools/mdbx-compare/infotree-compare.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e  # Exit immediately if a command exits with a non-zero status
+set -o pipefail  # Capture errors in pipelines
+
+# Variables
+datadir1=${1}
+datadir2=${2}
+tablesToCheck=(
+    "l1_info_roots"
+    "l1_info_leaves"
+    "l1_info_tree_updates"
+    "l1_info_tree_updates_by_ger"
+)
+
+# Run MDBX-Compare debug tool
+echo "[$(date)] Running MDBX Compare tool..."
+for table in "${tablesToCheck[@]}"; do
+    echo "[$(date)] Checking table: $table"
+    go run main.go compare --datadir1=$datadir1 --datadir2=$datadir2 --table="$table"
+done
+
+echo "[$(date)] Info tree's match!"


### PR DESCRIPTION
### Description
Add script to the mdbx-compare tool to compare all l1 info tree related tables

### Example Usage
cd zk/debug_tools/mdbx-compare
make infotree ARGS="/path/to/data1/chaindata /path/to/data2/chaindata"