### PR TITLE
Fix order of local and remote in comparing root debug tool

### DIFF
--- a/zk/debug_tools/rpc-blockhashes-compare/main.go
+++ b/zk/debug_tools/rpc-blockhashes-compare/main.go
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	// get blocks
-	blockRemote, blockLocal, err = getBlocks(ctx, rpcClientLocal, rpcClientRemote, checkBlockNumber)
+	blockLocal, blockRemote, err = getBlocks(ctx, rpcClientLocal, rpcClientRemote, checkBlockNumber)
 	if err != nil {
 		log.Error(fmt.Sprintf("blockNum: %d, error getBlocks: %s", checkBlockNumber, err))
 		return


### PR DESCRIPTION
The original display order is wrong