### PR TITLE
lock the pool flush mutex before calling yield

### DIFF
--- a/zk/stages/stage_sequence_execute_transactions.go
+++ b/zk/stages/stage_sequence_execute_transactions.go
@@ -31,6 +31,9 @@ func getNextPoolTransactions(ctx context.Context, cfg SequenceBlockCfg, executio
 	ti := utils.StartTimer("txpool", "get-transactions")
 	defer ti.LogTimer()
 
+	cfg.txPool.PreYield()
+	defer cfg.txPool.PostYield()
+
 	if err := cfg.txPoolDb.View(ctx, func(poolTx kv.Tx) error {
 		slots := types2.TxsRlp{}
 		if allConditionsOk, _, err = cfg.txPool.YieldBest(cfg.yieldSize, &slots, poolTx, executionAt, gasLimit, 0, alreadyYielded); err != nil {


### PR DESCRIPTION
There was a race condition here where opening the db view for yielding didn't contain info from the DB that wasn't flushed completely yet. Now the flush can't start running until the DB view has been used and vice versa for yielding, we now wait for the flush to finish.

Tested using the polycli load tool which is what highlighted this issue in the first place