### PR TITLE
Add read batches with concurrency to datastream server

### DIFF
--- a/zk/datastream/mocks/data_stream_server_mock.go
+++ b/zk/datastream/mocks/data_stream_server_mock.go
@@ -325,6 +325,10 @@ func (m *MockDataStreamServer) ReadBatches(arg0, arg1 uint64) ([][]*types0.FullL
 	return ret0, ret1
 }
 
+func (m *MockDataStreamServer) ReadBatchesWithConcurrency(arg0, arg1 uint64) ([][]*types0.FullL2Block, error) {
+	return m.ReadBatches(arg0, arg1)
+}
+
 // ReadBatches indicates an expected call of ReadBatches.
 func (mr *MockDataStreamServerMockRecorder) ReadBatches(arg0, arg1 any) *MockDataStreamServerReadBatchesCall {
 	mr.mock.ctrl.T.Helper()

--- a/zk/datastream/server/data_stream_server.go
+++ b/zk/datastream/server/data_stream_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
@@ -715,6 +716,95 @@ LOOP_ENTRIES:
 			continue
 		}
 	}
+
+	return batches, nil
+}
+
+func (srv *ZkEVMDataStreamServer) ReadBatchesWithConcurrency(start uint64, end uint64) ([][]*types.FullL2Block, error) {
+	batches := make([][]*types.FullL2Block, end-start+1)
+	batchPositions := make([]uint64, end-start+1)
+	var wg sync.WaitGroup
+	errCh := make(chan error, end-start+1)
+
+	for i := start; i <= end; i++ {
+		wg.Add(1)
+		go func(batchNum uint64) {
+			defer wg.Done()
+			bookmark := types.NewBookmarkProto(batchNum, datastream.BookmarkType_BOOKMARK_TYPE_BATCH)
+			marshalled, err := bookmark.Marshal()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			pos, err := srv.streamServer.GetBookmark(marshalled)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			batchPositions[batchNum-start] = pos
+		}(i)
+	}
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		return nil, err
+	default:
+	}
+
+	// worker pool
+	maxWorkers := 16
+	jobs := make(chan uint64, end-start+1)
+	wg = sync.WaitGroup{}
+
+	for i := 0; i < maxWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for batchNum := range jobs {
+				iterator := newDataStreamServerIterator(srv.streamServer, batchPositions[batchNum-start])
+				blocks := []*types.FullL2Block{}
+			LOOP_ENTRIES:
+				for {
+					parsedProto, _, err := client.ReadParsedProto(iterator)
+					if err != nil {
+						errCh <- err
+						return
+					}
+					if parsedProto == nil {
+						break
+					}
+					switch parsedProto := parsedProto.(type) {
+					case *types.BatchStart:
+						continue
+					case *types.BatchEnd:
+						if parsedProto.Number == batchNum {
+							break LOOP_ENTRIES
+						}
+					case *types.FullL2Block:
+						if parsedProto.BatchNumber == batchNum {
+							blocks = append(blocks, parsedProto)
+						}
+					default:
+						continue
+					}
+				}
+				batches[batchNum-start] = blocks
+			}
+		}()
+	}
+
+	for i := start; i <= end; i++ {
+		select {
+		case err := <-errCh:
+			close(jobs)
+			return nil, err
+		default:
+			jobs <- i
+		}
+	}
+	close(jobs)
+	wg.Wait()
 
 	return batches, nil
 }

--- a/zk/datastream/server/interfaces.go
+++ b/zk/datastream/server/interfaces.go
@@ -44,6 +44,7 @@ type DataStreamServer interface {
 	UnwindToBlock(blockNumber uint64) error
 	UnwindToBatchStart(batchNumber uint64) error
 	ReadBatches(start uint64, end uint64) ([][]*types.FullL2Block, error)
+	ReadBatchesWithConcurrency(start uint64, end uint64) ([][]*types.FullL2Block, error)
 	WriteWholeBatchToStream(logPrefix string, tx kv.Tx, reader DbReader, prevBatchNum, batchNum uint64) error
 	WriteBlocksToStreamConsecutively(ctx context.Context, logPrefix string, tx kv.Tx, reader DbReader, from, to uint64) error
 	WriteBlockWithBatchStartToStream(logPrefix string, tx kv.Tx, reader DbReader, forkId, batchNum, prevBlockBatchNum uint64, prevBlock, block eritypes.Block) (err error)

--- a/zk/stages/stage_sequence_execute_resequence.go
+++ b/zk/stages/stage_sequence_execute_resequence.go
@@ -23,7 +23,7 @@ func resequence(
 
 	log.Info(fmt.Sprintf("[%s] Last batch %d is lower than highest batch in datastream %d, resequencing...", s.LogPrefix(), lastBatch, highestBatchInDs))
 
-	batches, err := cfg.dataStreamServer.ReadBatches(lastBatch+1, highestBatchInDs)
+	batches, err := cfg.dataStreamServer.ReadBatchesWithConcurrency(lastBatch+1, highestBatchInDs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The original `ReadBatches` in `data_stream_server.go` is sequential and we need to wait quite a long time before resequencing. I add a new function `ReadBatchesWithConcurrency` which decrease the time from 467s to 165s (65%) when reading 300 stress test batches from datastream. It actually can be used to replace the existing one `ReadBatches()`, if you thought it ok.