### PR TITLE
fix(rpc): stop eth_getblockreceipts from crashing when sending hash

### DIFF
--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -696,7 +696,7 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 	}
 	defer tx.Rollback()
 
-	blockNum, blockHash, _, err := rpchelper.GetBlockNumber_zkevm(rpc.BlockNumberOrHashWithNumber(*number.BlockNumber), tx, api.filters)
+	blockNum, blockHash, _, err := rpchelper.GetBlockNumber_zkevm(number, tx, api.filters)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

Stop the eth_getBlockReceipts handler from crashing when sending a block hash instead of block number. 