### PR TITLE
tweak(witness-cache): cache 1 down from highest seen

### DIFF
--- a/zk/stages/stage_witness.go
+++ b/zk/stages/stage_witness.go
@@ -128,7 +128,7 @@ func SpawnStageWitness(
 		return fmt.Errorf("GetStageProgress: %w", err)
 	}
 	if toBatch > highestBatch {
-		toBatch = highestBatch
+		toBatch = highestBatch - 1 // we cannot cache the highest batch because it might not be full yet
 	}
 
 	hermezDb := hermez_db.NewHermezDb(tx)


### PR DESCRIPTION
We cannot cache the very latest batch as it might not be full yet and we will get an error.