### PR TITLE
improve(smt/pkg/utils): improve the performance of HashContractBytecodeBigInt()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/holiman/uint256 v1.3.1
 	github.com/huandu/xstrings v1.4.0
 	github.com/huin/goupnp v1.2.0
-	github.com/iden3/go-iden3-crypto v0.0.15
+	github.com/iden3/go-iden3-crypto v0.0.17
 	github.com/jackc/pgx/v4 v4.18.2
 	github.com/jackpal/go-nat-pmp v1.0.2
 	github.com/jedib0t/go-pretty/v6 v6.5.9
@@ -81,6 +81,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.1
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6
+	github.com/okx/poseidongold v0.0.2
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pelletier/go-toml/v2 v2.2.1
 	github.com/pion/randutil v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,6 @@ require (
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.6
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/holiman/uint256 v1.3.1
-	github.com/huandu/xstrings v1.4.0
 	github.com/huin/goupnp v1.2.0
 	github.com/iden3/go-iden3-crypto v0.0.17
 	github.com/jackc/pgx/v4 v4.18.2
@@ -81,7 +80,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.1
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6
-	github.com/okx/poseidongold v0.0.2
+	github.com/okx/poseidongold v0.0.3
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pelletier/go-toml/v2 v2.2.1
 	github.com/pion/randutil v0.1.0
@@ -187,6 +186,7 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd // indirect
 	github.com/hermeznetwork/tracerr v0.3.2 // indirect
+	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/ianlancetaylor/cgosymbolizer v0.0.0-20220405231054-a1ae3e4bba26 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -509,6 +509,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/iden3/go-iden3-crypto v0.0.15 h1:4MJYlrot1l31Fzlo2sF56u7EVFeHHJkxGXXZCtESgK4=
 github.com/iden3/go-iden3-crypto v0.0.15/go.mod h1:dLpM4vEPJ3nDHzhWFXDjzkn1qHoBeOT/3UEhXsEsP3E=
+github.com/iden3/go-iden3-crypto v0.0.17 h1:NdkceRLJo/pI4UpcjVah4lN/a3yzxRUGXqxbWcYh9mY=
 github.com/iden3/go-iden3-crypto v0.0.17/go.mod h1:dLpM4vEPJ3nDHzhWFXDjzkn1qHoBeOT/3UEhXsEsP3E=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/go.sum
+++ b/go.sum
@@ -509,6 +509,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/iden3/go-iden3-crypto v0.0.15 h1:4MJYlrot1l31Fzlo2sF56u7EVFeHHJkxGXXZCtESgK4=
 github.com/iden3/go-iden3-crypto v0.0.15/go.mod h1:dLpM4vEPJ3nDHzhWFXDjzkn1qHoBeOT/3UEhXsEsP3E=
+github.com/iden3/go-iden3-crypto v0.0.17/go.mod h1:dLpM4vEPJ3nDHzhWFXDjzkn1qHoBeOT/3UEhXsEsP3E=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -752,6 +753,8 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6 h1:iZ5rEHU561k2tdi/atkIsrP5/3AX3BjyhYtC96nJ260=
 github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6/go.mod h1:A+9rV4WFp4DKg1Ym1v6YtCrJ2vvlt1ZA/iml0CNuu2A=
+github.com/okx/poseidongold v0.0.2 h1:HDyZdfqZMi8Vy7+583Ch1gMPPFtVHR4gozKEz0j2B+M=
+github.com/okx/poseidongold v0.0.2/go.mod h1:5ZSHtmCUvyWfMhQH+9wi6b41z4JJwgO06baYZdBPRXw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7
 gfx.cafe/util/go/generic v0.0.0-20230721185457-c559e86c829c h1:alCfDKmPC0EC0KGlZWrNF0hilVWBkzMz+aAYTJ/2hY4=
 gfx.cafe/util/go/generic v0.0.0-20230721185457-c559e86c829c/go.mod h1:WvSX4JsCRBuIXj0FRBFX9YLg+2SoL3w8Ww19uZO9yNE=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/0xPolygonHermez/zkevm-data-streamer v0.2.7 h1:73sYxRQ9cOmtYBEyHePgEwrVULR+YruSQxVXCt/SmzU=
-github.com/0xPolygonHermez/zkevm-data-streamer v0.2.7/go.mod h1:7nM7Ihk+fTG1TQPwdZoGOYd3wprqqyIyjtS514uHzWE=
 github.com/0xPolygonHermez/zkevm-data-streamer v0.2.8 h1:0Sc91seArqR3BQs49SGwGXWjf0MQYW98sEUYrao7duU=
 github.com/0xPolygonHermez/zkevm-data-streamer v0.2.8/go.mod h1:7nM7Ihk+fTG1TQPwdZoGOYd3wprqqyIyjtS514uHzWE=
 github.com/99designs/gqlgen v0.17.40 h1:/l8JcEVQ93wqIfmH9VS1jsAkwm6eAF1NwQn3N+SDqBY=
@@ -507,8 +505,6 @@ github.com/ianlancetaylor/cgosymbolizer v0.0.0-20220405231054-a1ae3e4bba26 h1:UT
 github.com/ianlancetaylor/cgosymbolizer v0.0.0-20220405231054-a1ae3e4bba26/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/iden3/go-iden3-crypto v0.0.15 h1:4MJYlrot1l31Fzlo2sF56u7EVFeHHJkxGXXZCtESgK4=
-github.com/iden3/go-iden3-crypto v0.0.15/go.mod h1:dLpM4vEPJ3nDHzhWFXDjzkn1qHoBeOT/3UEhXsEsP3E=
 github.com/iden3/go-iden3-crypto v0.0.17 h1:NdkceRLJo/pI4UpcjVah4lN/a3yzxRUGXqxbWcYh9mY=
 github.com/iden3/go-iden3-crypto v0.0.17/go.mod h1:dLpM4vEPJ3nDHzhWFXDjzkn1qHoBeOT/3UEhXsEsP3E=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
@@ -754,8 +750,8 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6 h1:iZ5rEHU561k2tdi/atkIsrP5/3AX3BjyhYtC96nJ260=
 github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6/go.mod h1:A+9rV4WFp4DKg1Ym1v6YtCrJ2vvlt1ZA/iml0CNuu2A=
-github.com/okx/poseidongold v0.0.2 h1:HDyZdfqZMi8Vy7+583Ch1gMPPFtVHR4gozKEz0j2B+M=
-github.com/okx/poseidongold v0.0.2/go.mod h1:5ZSHtmCUvyWfMhQH+9wi6b41z4JJwgO06baYZdBPRXw=
+github.com/okx/poseidongold v0.0.3 h1:bb6cN2J2WVJDcqOUvIQI9wkLaEwRdqhB9eCEm/Cpb4E=
+github.com/okx/poseidongold v0.0.3/go.mod h1:5ZSHtmCUvyWfMhQH+9wi6b41z4JJwgO06baYZdBPRXw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=

--- a/smt/pkg/utils/util_test.go
+++ b/smt/pkg/utils/util_test.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -53,10 +55,16 @@ func BenchmarkConvertBigIntToHex(b *testing.B) {
 }
 
 func BenchmarkHashContractBytecode(b *testing.B) {
-	str := strings.Repeat("e", 1000)
+	str := strings.Repeat("7e", 500)
+	h1 := HashContractBytecodeBigIntV1(str)
+	h2 := HashContractBytecodeBigInt(str)
+	if h1.Cmp(h2) != 0 {
+		panic("hashes do not match")
+	}
+	b.ResetTimer()
 	b.Run("1", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			HashContractBytecode(str)
+			HashContractBytecodeBigIntV1(str)
 		}
 	})
 	b.Run("2", func(b *testing.B) {
@@ -64,6 +72,30 @@ func BenchmarkHashContractBytecode(b *testing.B) {
 			HashContractBytecodeBigInt(str)
 		}
 	})
+	b.Run("3", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			HashContractBytecode(str)
+		}
+	})
+}
+
+func TestHashContractBytecodeConsistency(t *testing.T) {
+	size := 1234 // not divisible by 56
+	data := make([]byte, size)
+	rand.Read(data)
+	strData := hex.EncodeToString(data)
+	if !strings.HasPrefix(strData, "0x") {
+		strData = "0x" + strData
+	}
+	h1 := HashContractBytecodeBigIntV1(strings.ToLower(strData))
+	h2 := HashContractBytecodeBigInt(strData)
+	if h1.Cmp(h2) != 0 {
+		t.Errorf("(lower case) Expected %v, but got %v", h1, h2)
+	}
+	h3 := HashContractBytecodeBigInt(strings.ToUpper(strData[2:]))
+	if h1.Cmp(h3) != 0 {
+		t.Errorf("(upper case) Expected %v, but got %v", h1, h3)
+	}
 }
 
 func TestConvertBigIntToHex(t *testing.T) {

--- a/smt/pkg/utils/utils.go
+++ b/smt/pkg/utils/utils.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	poseidon "github.com/gateway-fm/vectorized-poseidon-gold/src/vectorizedposeidongold"
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/length"
+	poseidon "github.com/okx/poseidongold/go"
 	"golang.org/x/exp/slices"
 )
 
@@ -751,7 +751,7 @@ func HashContractBytecode(bc string) string {
 	return ConvertBigIntToHex(HashContractBytecodeBigInt(bc))
 }
 
-func HashContractBytecodeBigInt(bc string) *big.Int {
+func HashContractBytecodeBigIntV1(bc string) *big.Int {
 	bytecode := bc
 
 	if strings.HasPrefix(bc, "0x") {
@@ -807,6 +807,89 @@ func HashContractBytecodeBigInt(bc string) *big.Int {
 				tmpScalar, _ = scalar.SetString(tmpElem, 16)
 				elementsToHash = append(elementsToHash, tmpScalar.Uint64())
 				tmpElem = ""
+				counter = 0
+			}
+		}
+
+		copy(in[:], elementsToHash[4:12])
+		copy(capacity[:], elementsToHash[:4])
+
+		tmpHash = Hash(in, capacity)
+	}
+
+	return ArrayToScalar(tmpHash[:])
+}
+
+func charToDigit(c byte) int {
+	if c >= '0' && c <= '9' {
+		return int(c - '0')
+	}
+	if c >= 'a' && c <= 'f' {
+		return int(c - 'a' + 10)
+	}
+	if c >= 'A' && c <= 'F' {
+		return int(c - 'A' + 10)
+	}
+	// should not reach here
+	return 0
+}
+
+func HashContractBytecodeBigInt(bc string) *big.Int {
+	bytecode := bc
+
+	if strings.HasPrefix(bc, "0x") {
+		bytecode = bc[2:]
+	}
+
+	if len(bytecode)%2 != 0 {
+		bytecode = "0" + bytecode
+	}
+
+	// MT is 56 (multiplier)
+	MT := BYTECODE_ELEMENTS_HASH * BYTECODE_BYTES_ELEMENT
+	bb := make([]byte, MT*(((len(bytecode)/2+1)/MT)+1))
+	for i := 0; i < len(bytecode)/2; i++ {
+		// use strconv.ParseInt
+		// x, _ := strconv.ParseInt(bytecode[2*i:2*i+2], 16, 64)
+		// bb[i] = byte(x)
+		// simple
+		bb[i] = byte(charToDigit(bytecode[2*i])<<4 + charToDigit(bytecode[2*i+1]))
+	}
+	for i := len(bytecode) / 2; i < len(bb); i++ {
+		bb[i] = 0
+	}
+
+	bbPtr := len(bytecode) / 2
+	bb[bbPtr] = 0x01
+	bbPtr = len(bb) - 1
+	bb[bbPtr] |= 0x80
+
+	numBytes := float64(len(bb))
+	numHashes := int(math.Ceil(numBytes / (BYTECODE_ELEMENTS_HASH * BYTECODE_BYTES_ELEMENT)))
+	tmpHash := [4]uint64{0, 0, 0, 0}
+	bytesPointer := 0
+
+	maxBytesToAdd := BYTECODE_ELEMENTS_HASH * BYTECODE_BYTES_ELEMENT
+	var elementsToHash []uint64
+	var in [8]uint64
+	var capacity [4]uint64
+	for i := 0; i < numHashes; i++ {
+		elementsToHash = tmpHash[:]
+
+		subsetBytecode := bb[bytesPointer : bytesPointer+maxBytesToAdd]
+		bytesPointer += maxBytesToAdd
+
+		var tmpElem uint64
+		tmpElem = 0
+		counter := 0
+
+		for j := 0; j < maxBytesToAdd; j++ {
+			tmpElem += uint64(subsetBytecode[j]) << (8 * counter)
+			counter += 1
+
+			if counter == BYTECODE_BYTES_ELEMENT {
+				elementsToHash = append(elementsToHash, tmpElem)
+				tmpElem = 0
 				counter = 0
 			}
 		}


### PR DESCRIPTION
Changes:
1. replace [vectorized-poseidon-gold](https://github.com/gateway-fm/vectorized-poseidon-gold) by OKX [poseidongold](https://github.com/okx/poseidongold) (this leads to around 25% improvement). poseidongold repo implements a Go wrapper of Rust-based Poseidon hashing from Plonky2. This is 2X faster than vectorized-poseidon-gold from gateway-fm.
2. remove string concatenations and implement custom conversion in HashContractBytecodeBigInt() (this leads to around 2X improvement). The combined effect of these two changes is 2X speedup for HashContractBytecodeBigInt().

To test the performance, you can do:
```
$ cd smt/pkg/utils
$ go test -benchmem -run=^$ -bench ^BenchmarkHashContractBytecode$ .
```

For example:
```
goos: linux
goarch: amd64
pkg: github.com/ledgerwatch/erigon/smt/pkg/utils
cpu: AMD Ryzen 9 7950X 16-Core Processor            
BenchmarkHashContractBytecode/1-32         38618             28042 ns/op           15072 B/op        563 allocs/op
BenchmarkHashContractBytecode/2-32        119170             10211 ns/op            3528 B/op         53 allocs/op
BenchmarkHashContractBytecode/3-32        110352             10487 ns/op            3736 B/op         56 allocs/op
PASS
```

To check the performance stated at item 1 above, you can do:
```
$ git clone https://github.com/okx/poseidongold.git
$ cd poseidongold/go
$ go test -benchmem -run=^$ -bench .
```

For example:
```
goos: linux
goarch: amd64
pkg: github.com/okx/poseidongold/go
cpu: AMD Ryzen 9 7950X 16-Core Processor            
BenchmarkHashWithResult-32               1314997               881.7 ns/op             0 B/op          0 allocs/op
BenchmarkVectorizedPoseidongold-32        763915              1530 ns/op               0 B/op          0 allocs/op
PASS
```