### PR TITLE
improve(sequencer): cache decoded transactions and remove duplicated sleep

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -601,6 +601,16 @@ var (
 		Usage: "Reuse the L1 info index for resequencing",
 		Value: true,
 	}
+	SequencerDecodedTxCacheSize = cli.IntFlag{
+		Name:  "zkevm.sequencer-decoded-tx-cache-size",
+		Usage: "Sequencer decoded transaction cache size",
+		Value: 4096,
+	}
+	SequencerDecodedTxCacheTTL = cli.DurationFlag{
+		Name:  "zkevm.sequencer-decoded-tx-cache-ttl",
+		Usage: "Sequencer decoded transaction cache time-to-live",
+		Value: 600 * time.Second,
+	}
 	ExecutorUrls = cli.StringFlag{
 		Name:  "zkevm.executor-urls",
 		Usage: "A comma separated list of grpc addresses that host executors",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -48,6 +48,8 @@ type Zk struct {
 	SequencerResequence                    bool
 	SequencerResequenceStrict              bool
 	SequencerResequenceReuseL1InfoIndex    bool
+	SequencerDecodedTxCacheSize            int
+	SequencerDecodedTxCacheTTL             time.Duration
 	ExecutorUrls                           []string
 	ExecutorStrictMode                     bool
 	ExecutorRequestTimeout                 time.Duration

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -216,6 +216,8 @@ var DefaultFlags = []cli.Flag{
 	&utils.SequencerResequence,
 	&utils.SequencerResequenceStrict,
 	&utils.SequencerResequenceReuseL1InfoIndex,
+	&utils.SequencerDecodedTxCacheSize,
+	&utils.SequencerDecodedTxCacheTTL,
 	&utils.ExecutorUrls,
 	&utils.ExecutorStrictMode,
 	&utils.ExecutorRequestTimeout,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -219,6 +219,8 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		SequencerResequence:                    ctx.Bool(utils.SequencerResequence.Name),
 		SequencerResequenceStrict:              ctx.Bool(utils.SequencerResequenceStrict.Name),
 		SequencerResequenceReuseL1InfoIndex:    ctx.Bool(utils.SequencerResequenceReuseL1InfoIndex.Name),
+		SequencerDecodedTxCacheSize:            ctx.Int(utils.SequencerDecodedTxCacheSize.Name),
+		SequencerDecodedTxCacheTTL:             ctx.Duration(utils.SequencerDecodedTxCacheTTL.Name),
 		ExecutorUrls:                           strings.Split(strings.ReplaceAll(ctx.String(utils.ExecutorUrls.Name), " ", ""), ","),
 		ExecutorStrictMode:                     ctx.Bool(utils.ExecutorStrictMode.Name),
 		ExecutorRequestTimeout:                 ctx.Duration(utils.ExecutorRequestTimeout.Name),

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -409,11 +409,10 @@ func sequencingBatchStep(
 				}
 			} else if !batchState.isL1Recovery() {
 
-				var allConditionsOK bool
 				var newTransactions []types.Transaction
 				var newIds []common.Hash
 
-				newTransactions, newIds, allConditionsOK, err = getNextPoolTransactions(ctx, cfg, executionAt, batchState.forkId, batchState.yieldedTransactions)
+				newTransactions, newIds, _, err = getNextPoolTransactions(ctx, cfg, executionAt, batchState.forkId, batchState.yieldedTransactions)
 				if err != nil {
 					return err
 				}
@@ -422,19 +421,10 @@ func sequencingBatchStep(
 				for idx, tx := range newTransactions {
 					batchState.blockState.transactionHashesToSlots[tx.Hash()] = newIds[idx]
 				}
-
-				if len(batchState.blockState.transactionsForInclusion) == 0 {
-					if allConditionsOK {
-						time.Sleep(batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool)
-					} else {
-						time.Sleep(batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool / 5) // we do not need to sleep too long for txpool not ready
-					}
-				} else {
-					log.Trace(fmt.Sprintf("[%s] Yielded transactions from the pool", logPrefix), "txCount", len(batchState.blockState.transactionsForInclusion))
-				}
 			}
 
 			if len(batchState.blockState.transactionsForInclusion) == 0 {
+				log.Trace(fmt.Sprintf("[%s] Sleep on SequencerTimeoutOnEmptyTxPool", logPrefix), "time in ms", batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool.Milliseconds())
 				time.Sleep(batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool)
 			} else {
 				log.Trace(fmt.Sprintf("[%s] Yielded transactions from the pool", logPrefix), "txCount", len(batchState.blockState.transactionsForInclusion))
@@ -717,6 +707,14 @@ func sequencingBatchStep(
 		toRemove := append(batchState.blockState.builtBlockElements.txSlots, batchState.blockState.transactionsToDiscard...)
 		if err := cfg.txPool.RemoveMinedTransactions(ctx, sdb.tx, header.GasLimit, toRemove); err != nil {
 			return err
+		}
+
+		// remove the decoded transactions from the cache
+		for _, txHash := range batchState.blockState.builtBlockElements.txSlots {
+			cfg.decodedTxCache.Remove(txHash)
+		}
+		for _, txHash := range batchState.blockState.transactionsToDiscard {
+			cfg.decodedTxCache.Remove(txHash)
 		}
 
 		// now trigger sender state changes in the pool where we encountered nonce issues during execution

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	libstate "github.com/ledgerwatch/erigon-lib/state"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/ledgerwatch/erigon-lib/chain"
 	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/consensus"
@@ -81,6 +82,8 @@ type SequenceBlockCfg struct {
 	yieldSize      uint16
 
 	infoTreeUpdater *l1infotree.Updater
+
+	decodedTxCache *expirable.LRU[common.Hash, *types.Transaction]
 }
 
 func StageSequenceBlocksCfg(
@@ -112,6 +115,8 @@ func StageSequenceBlocksCfg(
 	infoTreeUpdater *l1infotree.Updater,
 ) SequenceBlockCfg {
 
+	decodedTxCache := expirable.NewLRU[common.Hash, *types.Transaction](zk.SequencerDecodedTxCacheSize, nil, zk.SequencerDecodedTxCacheTTL)
+
 	return SequenceBlockCfg{
 		db:               db,
 		prune:            pm,
@@ -137,6 +142,7 @@ func StageSequenceBlocksCfg(
 		legacyVerifier:   legacyVerifier,
 		yieldSize:        yieldSize,
 		infoTreeUpdater:  infoTreeUpdater,
+		decodedTxCache:   decodedTxCache,
 	}
 }
 


### PR DESCRIPTION
This PR replaced closed PR https://github.com/0xPolygonHermez/cdk-erigon/pull/1748

This PR makes two changes:

- Cache Decoded Transactions - we observed that transactions are decoded repeatedly in [zk/stages/stage_sequence_execute_transactions.go](https://github.com/0xPolygonHermez/cdk-erigon/blob/zkevm/zk/stages/stage_sequence_execute_transactions.go) at line 88. We propose to cache them in memory using a LRU cache (from  https://github.com/hashicorp/golang-lru package). This LRU requires 2 parameters: size and TTL for the entries. I exposed these two parameters to be configured via the zkevm.sequencer-decoded-tx-cache-size and zkevm.sequencer-decoded-tx-cache-ttl flags, respectively. Their default values are 4096 (size) and 10 minutes (TTL), respectively. The memory footprint seems to be low (<100kB) for 4096 cached transactions. In the worst case, the overhead of this cache should be 128 * size bytes (e.g., 512 kB for 4096 entries). This tx caching improved the TPS by 10-20% on a local XLayer devnet.

- Remove duplicated sleep on SequencerTimeoutOnEmptyTxPool in [stage_sequence_execute.go](https://github.com/0xPolygonHermez/cdk-erigon/blob/zkevm/zk/stages/stage_sequence_execute.go) starting at line 426. Also, by lowering the SequencerTimeoutOnEmptyTxPool from 250ms to 10ms we got 20% improvement in TPS on a local XLayer devnet. This can be controlled by zkevm.sequencer-timeout-on-empty-tx-pool flag in the config yaml.