### PR TITLE
fix(debug): ensure err returned for debug flag so the node exits

### DIFF
--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -49,8 +49,10 @@ func SpawnExecuteBlocksStageZk(s *StageState, u Unwinder, tx kv.RwTx, toBlock ui
 	defer func() {
 		if cfg.zk.DebugLimit > 0 {
 			if err != nil {
-				log.Error("Execution Failed", "err", err, "block", highestBlockExecuted)
-				os.Exit(2)
+				if !errors.Is(err, common.ErrStopped) {
+					log.Error("Execution Failed", "err", err, "block", highestBlockExecuted)
+					os.Exit(2)
+				}
 			}
 		}
 	}()

--- a/zk/stages/stage_interhashes.go
+++ b/zk/stages/stage_interhashes.go
@@ -161,6 +161,10 @@ func SpawnZkIntermediateHashesStage(s *stagedsync.StageState, u stagedsync.Unwin
 			if shouldIncrement {
 				eridb.RollbackBatch()
 			}
+			if cfg.zk.DebugLimit > 0 {
+				err = fmt.Errorf("wrong trie root of block %d: %x, expected (from header): %x. Block hash: %x", to, root, expectedRootHash, headerHash)
+				return trie.EmptyRoot, err
+			}
 			panic(fmt.Sprintf("[%s] Wrong trie root of block %d: %x, expected (from header): %x. Block hash: %x", logPrefix, to, root, expectedRootHash, headerHash))
 		}
 


### PR DESCRIPTION
- Ensure node can exit when flag set (inters)
- Ensure 'stopped' error is not returned as exit code in execution