### PR TITLE
tweak(l1-syncer): panic on exceeding 20 retries - [Requires Alert]

### DIFF
--- a/zk/syncer/l1_syncer.go
+++ b/zk/syncer/l1_syncer.go
@@ -449,11 +449,10 @@ func (s *L1Syncer) getSequencedLogs(jobs <-chan fetchJob, results chan jobResult
 					log.Debug("getSequencedLogs retry error", "err", err)
 					retry++
 					if retry > 5 {
-						results <- jobResult{
-							Error: err,
-							Logs:  nil,
-						}
-						return
+						log.Error("L1 syncer (getSequencedLogs) exceeded 5 retries", "err", err)
+					}
+					if retry > 20 {
+						panic("L1 syncer (getSequencedLogs) exceeded 20 retries")
 					}
 					time.Sleep(time.Duration(retry*2) * time.Second)
 					continue

--- a/zk/syncer/l1_syncer.go
+++ b/zk/syncer/l1_syncer.go
@@ -449,7 +449,7 @@ func (s *L1Syncer) getSequencedLogs(jobs <-chan fetchJob, results chan jobResult
 					log.Debug("getSequencedLogs retry error", "err", err)
 					retry++
 					if retry > 5 {
-						log.Error("L1 syncer (getSequencedLogs) exceeded 5 retries", "err", err)
+						log.Error("L1 syncer (getSequencedLogs) exceeded 5 retries", "retry", retry, "err", err)
 					}
 					if retry > 20 {
 						panic("L1 syncer (getSequencedLogs) exceeded 20 retries")


### PR DESCRIPTION
### Description

If we get rate limited on the L1 Syncer, we should not return ever. This would cause the InfoTree stage to begin as downloading has started. this is bad! Instead we should log errors up until 20 retries, then panic and do a full restart.