### PR TITLE
feat: check counters overflow on eth_estimateGas

### DIFF
--- a/core/vm/zk_counters.go
+++ b/core/vm/zk_counters.go
@@ -124,6 +124,35 @@ func (c Counters) UsedAsMap() map[string]int {
 	}
 }
 
+func (c Counters) OverflownAsString() string {
+	var res string
+	if c[SHA].remaining < 0 {
+		res += fmt.Sprintf("[%s: %v]", CounterKeyNames[SHA], c[SHA].remaining)
+	}
+	if c[A].remaining < 0 {
+		res += fmt.Sprintf("[%s: %v]", CounterKeyNames[A], c[A].remaining)
+	}
+	if c[B].remaining < 0 {
+		res += fmt.Sprintf("[%s: %v]", CounterKeyNames[B], c[B].remaining)
+	}
+	if c[K].remaining < 0 {
+		res += fmt.Sprintf("[%s: %v]", CounterKeyNames[K], c[K].remaining)
+	}
+	if c[M].remaining < 0 {
+		res += fmt.Sprintf("[%s: %v]", CounterKeyNames[M], c[M].remaining)
+	}
+	if c[P].remaining < 0 {
+		res += fmt.Sprintf("[%s: %v]", CounterKeyNames[P], c[P].remaining)
+	}
+	if c[S].remaining < 0 {
+		res += fmt.Sprintf("[%s: %v]", CounterKeyNames[S], c[S].remaining)
+	}
+	if c[D].remaining < 0 {
+		res += fmt.Sprintf("[%s: %v]", CounterKeyNames[D], c[D].remaining)
+	}
+	return res
+}
+
 func (c *Counters) GetArithmetics() *Counter {
 	return (*c)[A]
 }


### PR DESCRIPTION
Deployed contract locally with keccak loop at: 0x2985886A1aa68bFcd5E251A0Ae601f1fcC77Bd74

Checking gasEstimate:
```
cast estimate --from 0xe859276098f208D003ca6904C6cC26629Ee364Ce 0x2985886A1aa68bFcd5E251A0Ae601f1fcC77Bd74 "ketchup(uint)" 1000 --rpc-timeout 30 -r http://localhost:8123                                           

Error: server returned an error response: error code -32000: counters overflow: [K: -1941]
```
Checking counters:
```
cast rpc zkevm_estimateCounters '{"gas": "0x1c9c380", "gasPrice": "0x989680", "input": "0x3038f55a00000000000000000000000000000000000000000000000000000000000003e8", "to": "0x2985886A1aa68bFcd5E251A0Ae601f1fcC77Bd74", "from": "0xe859276098f208D003ca6904C6cC26629Ee364Ce", "value": "0x0"}' -r localhost:8123  | jq

{
  "countersUsed": {
    "gas": 1048848,
    "keccakHashes": 4200,
    "poseidonhashes": 632,
    "poseidonPaddings": 20,
    "memAligns": 30446,
    "arithmetics": 106864,
    "binaries": 316144,
    "steps": 6986084,
    "SHA256hashes": 0
  },
  "countersLimits": {
    "gas": 30000000,
    "keccakHashes": 2258,
    "poseidonhashes": 257070,
    "poseidonPaddings": 142307,
    "memAligns": 249037,
    "arithmetics": 249037,
    "binaries": 498074,
    "steps": 7969178,
    "SHA256hashes": 1769
  },
  "revertInfo": {
    "message": "",
    "data": null
  },
  "oocError": "[K: -1942]"
}
```

Executing tx (using gas limit to avoid estimateGas call, virtual counters enabled in config):
`cast send --legacy --gas-limit 30000000 --from 0xe859276098f208D003ca6904C6cC26629Ee364Ce 0x2985886A1aa68bFcd5E251A0Ae601f1fcC77Bd74 "ketchup(uint)" 1000 --private-key <PRIVATE_KEY> --rpc-timeout 100 -r http://localhost:8123`

Sequencer log:
`INFO[02-26|14:01:21.545] [5/13 Execution] single transaction 0xb3b4fb400d729c45ad43020eb8e3a58204c8008f97bcebe00c7b765caff12c60 cannot fit into batch - overflow context="[VCOUNTER] Counters stats: defaultTotalSteps: initial: 7969178, used: 6986525, remaining: 982653; arith: initial: 249037, used: 106870, remaining: 142167; binary: initial: 498074, used: 316179, remaining: 181895; memAlign: initial: 249037, used: 30446, remaining: 218591; keccaks: initial: 2258, used: 4202, remaining: -1944; padding: initial: 142307, used: 20, remaining: 142287; poseidon: initial: 257070, used: 930, remaining: 256140; sha256: initial: 1769, used: 0, remaining: 1769;" times_seen=2`
