### PR TITLE
feat(flags): log active zkevm flags on node startup

### DIFF
--- a/cmd/cdk-erigon/main.go
+++ b/cmd/cdk-erigon/main.go
@@ -64,6 +64,7 @@ func runErigon(cliCtx *cli.Context) error {
 	logger := log.New()
 	nodeCfg := node.NewNodConfigUrfave(cliCtx, logger)
 	ethCfg := node.NewEthConfigUrfave(cliCtx, nodeCfg, logger)
+	utils.LogActiveZkevmFlags(logger, cliCtx)
 
 	ethNode, err := node.New(cliCtx.Context, nodeCfg, ethCfg, logger)
 	if err != nil {

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -320,4 +320,5 @@ var DefaultFlags = []cli.Flag{
 	&utils.BadTxAllowance,
 	&utils.BadTxStoreValue,
 	&utils.BadTxPurge,
+	&utils.ZkevmLogExcludeFlags,
 }


### PR DESCRIPTION
### Example

![Screenshot 2025-03-11 at 12 35 47](https://github.com/user-attachments/assets/f1282078-245e-4f09-926a-65aec8270094)
