### PR TITLE
Refactor transaction processing by replacing hash-based lookups with parallel arrays

### DIFF
--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -408,6 +408,7 @@ func sequencingBatchStep(
 					return err
 				}
 			} else if !batchState.isL1Recovery() {
+				
 				var newTransactions []types.Transaction
 				var newIds []common.Hash
 

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -408,7 +408,6 @@ func sequencingBatchStep(
 					return err
 				}
 			} else if !batchState.isL1Recovery() {
-
 				var newTransactions []types.Transaction
 				var newIds []common.Hash
 

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -418,9 +418,7 @@ func sequencingBatchStep(
 				}
 
 				batchState.blockState.transactionsForInclusion = append(batchState.blockState.transactionsForInclusion, newTransactions...)
-				for idx, tx := range newTransactions {
-					batchState.blockState.transactionHashesToSlots[tx.Hash()] = newIds[idx]
-				}
+				batchState.blockState.transactionSlotIds = append(batchState.blockState.transactionSlotIds, newIds...)
 			}
 
 			if len(batchState.blockState.transactionsForInclusion) == 0 {
@@ -429,7 +427,6 @@ func sequencingBatchStep(
 			} else {
 				log.Trace(fmt.Sprintf("[%s] Yielded transactions from the pool", logPrefix), "txCount", len(batchState.blockState.transactionsForInclusion))
 			}
-
 			badTxHashes := make([]common.Hash, 0)
 			minedTxHashes := make([]common.Hash, 0)
 
@@ -446,7 +443,7 @@ func sequencingBatchStep(
 				}
 
 				txHash := transaction.Hash()
-
+				slotId := batchState.blockState.transactionSlotIds[i]
 				txSender, ok := transaction.GetSender()
 				if !ok {
 					signer := types.MakeSigner(cfg.chainConfig, executionAt, 0)
@@ -456,7 +453,7 @@ func sequencingBatchStep(
 							"error", err,
 							"hash", transaction.Hash())
 						badTxHashes = append(badTxHashes, txHash)
-						batchState.blockState.transactionsToDiscard = append(batchState.blockState.transactionsToDiscard, batchState.blockState.transactionHashesToSlots[txHash])
+						batchState.blockState.transactionsToDiscard = append(batchState.blockState.transactionsToDiscard, slotId)
 						continue
 					}
 
@@ -516,7 +513,7 @@ func sequencingBatchStep(
 					// we mark it for being discarded
 					log.Warn(fmt.Sprintf("[%s] error adding transaction to batch, discarding from pool", logPrefix), "hash", txHash, "err", err)
 					badTxHashes = append(badTxHashes, txHash)
-					batchState.blockState.transactionsToDiscard = append(batchState.blockState.transactionsToDiscard, batchState.blockState.transactionHashesToSlots[txHash])
+					batchState.blockState.transactionsToDiscard = append(batchState.blockState.transactionsToDiscard, slotId)
 				}
 
 				switch anyOverflow {
@@ -599,7 +596,7 @@ func sequencingBatchStep(
 
 				if err == nil {
 					blockDataSizeChecker = &backupDataSizeChecker
-					batchState.onAddedTransaction(transaction, receipt, execResult, effectiveGas)
+					batchState.onAddedTransaction(transaction, slotId, receipt, execResult, effectiveGas)
 					minedTxHashes = append(minedTxHashes, txHash)
 				}
 

--- a/zk/stages/stage_sequence_execute_state.go
+++ b/zk/stages/stage_sequence_execute_state.go
@@ -61,7 +61,7 @@ func newBatchState(forkId, batchNumber, blockNumber uint64, hasExecutorForThisBa
 		hasAnyTransactionsInThisBatch: false,
 		builtBlocks:                   make([]uint64, 0, 128),
 		yieldedTransactions:           mapset.NewSet[[32]byte](),
-		blockState:                    newBlockState(),
+		blockState:                    &BlockState{},
 		batchL1RecoveryData:           nil,
 		limboRecoveryData:             nil,
 		resequenceBatchJob:            resequenceBatchJob,
@@ -164,11 +164,7 @@ func (bs *BatchState) getCoinbase(cfg *SequenceBlockCfg) common.Address {
 	return cfg.zk.AddressSequencer
 }
 
-func (bs *BatchState) onAddedTransaction(transaction types.Transaction, receipt *types.Receipt, execResult *core.ExecutionResult, effectiveGas uint8) {
-	slotId, ok := bs.blockState.transactionHashesToSlots[transaction.Hash()]
-	if !ok {
-		log.Warn("[batchState] transaction hash not found in transaction hashes to slots map", "hash", transaction.Hash())
-	}
+func (bs *BatchState) onAddedTransaction(transaction types.Transaction, slotId common.Hash, receipt *types.Receipt, execResult *core.ExecutionResult, effectiveGas uint8) {
 	bs.blockState.builtBlockElements.onFinishAddingTransaction(transaction, receipt, execResult, effectiveGas, slotId)
 	bs.hasAnyTransactionsInThisBatch = true
 }
@@ -254,16 +250,10 @@ func newLimboRecoveryData(limboHeaderTimestamp uint64, limboTxHash *common.Hash)
 // TYPE BLOCK STATE
 type BlockState struct {
 	transactionsForInclusion []types.Transaction
-	transactionHashesToSlots map[common.Hash]common.Hash
+	transactionSlotIds       []common.Hash
 	builtBlockElements       BuiltBlockElements
 	blockL1RecoveryData      *zktx.DecodedBatchL2Data
 	transactionsToDiscard    []common.Hash
-}
-
-func newBlockState() *BlockState {
-	return &BlockState{
-		transactionHashesToSlots: make(map[common.Hash]common.Hash),
-	}
 }
 
 func (bs *BlockState) hasAnyTransactionForInclusion() bool {


### PR DESCRIPTION
## Motivation: Refactor and make it simpler and clear

## What changed
- Replaced transactionHashesToSlots map with parallel transactionSlotIds array
- Use direct array indexing instead of map lookups
- Pass slotId directly to transaction handling functions
- Remove error checking for missing map entries
Code get cleaner!

## How it works
The code now uses parallel arrays where transactionsForInclusion[i] and transactionSlotIds[i] refer to the same transaction. When processing transactions in the loop, we already have the index, so we can directly access both the transaction and its corresponding slot ID without needing to calculate hashes for lookups.

## Small Acceleration
Recall that compute transaction hash is very very fast. 1000 transaction hash only needs 2us = 0.002ms. We can ignore the time differences and acceleration here. 
https://github.com/0xPolygonHermez/cdk-erigon/issues/1603

Setting: default large yieldSize=1000, huge transactions that make the batch overflow, 1 batch = 30 transactions 
Before: calculate 1000 transaction hashes for all yield transactions. Yield 1000 transactions but only process 30, that would be a small waste of time. 
After: calculate transaction hash one-by-one, only when it is executing `InnerLoopTransactions`.


