### PR TITLE
fix close() wait on unlocked mutex

### DIFF
--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -719,6 +719,7 @@ func (db *MdbxKV) trackTxEnd() {
 
 func (db *MdbxKV) waitTxsAllDoneOnClose() {
 	for !db.hasTxsAllDoneAndClosed() {
+		db.txsAllDoneOnCloseCond.L.Lock()
 		db.txsAllDoneOnCloseCond.Wait()
 	}
 }


### PR DESCRIPTION
Fixes small issue where kv_mdbx unit tests panics on unlocking unlocked mutex in #1774.

Before: `make test-erigon-lib` fails
After: test passes