### PR TITLE
To solve RPC blockhash mismatch issue

### DIFF
--- a/zk/datastream/client/stream_client_test.go
+++ b/zk/datastream/client/stream_client_test.go
@@ -401,7 +401,7 @@ func TestStreamClientGetL2BlockByNumber(t *testing.T) {
 
 	c := NewClient(context.Background(), "", false, 500*time.Millisecond, 0, DefaultEntryChannelSize)
 	c.header = &types.HeaderEntry{
-		TotalEntries: 4,
+		TotalEntries: 5,
 	}
 	c.conn = clientConn
 	c.allowStops = false


### PR DESCRIPTION
Regarding [this](https://github.com/0xPolygonHermez/cdk-erigon/issues/1805) issue.
# Reason of the issue
The reason for the blockhash mismatch in RPC is as follows: Currently, when the RPC datastream client processes an EntryTypeL2Block, it enters a loop to read entries such as L2Tx. However, if the entry number limit is reached, the client stops reading, even if some L2Tx entries in the block have not been read. It then considers the transactions it has read so far as the complete set for that block. Consequently, when RPC recalculates the blockhash, it does so with an incomplete transaction list, resulting in a computed blockhash that doesn’t match the claimed blockhash.

# Solution
The solution is as follows: If the entry number limit is reached during reading, discard the L2Tx entries retrieved in that round and return nil to the entry channel. In the next synchronization round, the client will attempt to read again. If the entry number limit is sufficient to cover all L2Tx in the block, the reading will succeed.