### PR TITLE
No more waiting for AnyRecovery

### DIFF
--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -424,8 +424,10 @@ func sequencingBatchStep(
 			}
 
 			if len(batchState.blockState.transactionsForInclusion) == 0 {
-				log.Trace(fmt.Sprintf("[%s] Sleep on SequencerTimeoutOnEmptyTxPool", logPrefix), "time in ms", batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool.Milliseconds())
-				time.Sleep(batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool)
+				if !batchState.isAnyRecovery() {
+					log.Trace(fmt.Sprintf("[%s] Sleep on SequencerTimeoutOnEmptyTxPool", logPrefix), "time in ms", batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool.Milliseconds())
+					time.Sleep(batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool)
+				}
 			} else {
 				log.Trace(fmt.Sprintf("[%s] Yielded transactions from the pool", logPrefix), "txCount", len(batchState.blockState.transactionsForInclusion))
 			}


### PR DESCRIPTION
Before, we also need to wait for the `SequencerTimeoutOnEmptyTxPool` during resequencing. But it's unnecessary. This will drastically speed up resequencing and X Layer's Local Replay feature.