### PR TITLE
tweak(witness): make sure the batch is closed at the tip

### DIFF
--- a/zk/stages/stage_witness.go
+++ b/zk/stages/stage_witness.go
@@ -122,9 +122,23 @@ func SpawnStageWitness(
 		return fmt.Errorf("GetStageProgress: %w", err)
 	}
 
+	latestBatchEndBlock, err := reader.GetLatestBatchEndBlock()
+	if err != nil {
+		return fmt.Errorf("GetLatestBatchEndBlock: %w", err)
+	}
+
+	if latestBlock > latestBatchEndBlock {
+		latestBlock = latestBatchEndBlock
+	}
+
 	latestExecutedBatchNo, err := reader.GetBatchNoByL2Block(latestBlock)
 	if err != nil {
 		return fmt.Errorf("GetBatchNoByL2Block: %w", err)
+	}
+
+	if latestExecutedBatchNo == 0 {
+		log.Warn(fmt.Sprintf("[%s] No executed batches found", logPrefix))
+		return nil
 	}
 
 	latestCachedWitnessBatchNo, err := reader.GetLatestCachedWitnessBatchNo()


### PR DESCRIPTION
Cache 1 down from the tip if we try to cache all the way to the tip. There may be a case where we are half way through execution of a batch and we try to cache that batch.