### PR TITLE
feat(relay): add datastream relay service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ COPY --from=builder /app/build/bin/state /usr/local/bin/state
 COPY --from=builder /app/build/bin/txpool /usr/local/bin/txpool
 COPY --from=builder /app/build/bin/verkle /usr/local/bin/verkle
 COPY --from=builder /app/build/bin/acl /usr/local/bin/acl
+COPY --from=builder /app/build/bin/relay /usr/local/bin/relay
 
 EXPOSE 8545 \
        8551 \
@@ -95,7 +96,8 @@ EXPOSE 8545 \
        42069/udp \
        8080 \
        9090 \
-       6060
+       6060 \
+       7900
 
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 ARG BUILD_DATE

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -76,6 +76,7 @@ COPY --from=builder /app/build/bin/txpool /usr/local/bin/txpool
 COPY --from=builder /app/build/bin/verkle /usr/local/bin/verkle
 COPY --from=builder /app/build/bin/caplin /usr/local/bin/caplin
 COPY --from=builder /app/build/bin/acl /usr/local/bin/acl
+COPY --from=builder /app/build/bin/relay /usr/local/bin/relay
 
 COPY --from=builder /go/pkg/mod /go/pkg/mod
 
@@ -88,7 +89,8 @@ EXPOSE 8545 \
        42069/udp \
        8080 \
        9090 \
-       6060
+       6060 \
+       7900
 
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 ARG BUILD_DATE

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ COMMANDS += verkle
 COMMANDS += evm
 COMMANDS += sentinel
 COMMANDS += acl
+COMMANDS += relay
 
 # build each command using %.cmd rule
 $(COMMANDS): %: %.cmd

--- a/cmd/relay/README.md
+++ b/cmd/relay/README.md
@@ -1,0 +1,69 @@
+# ZkEVM Data Stream Relay
+
+A lightweight service that connects to a data stream server, receives data, and forwards it to multiple clients.
+
+## Overview
+
+The datastream relay acts as a client towards the main data stream server and as a server towards connected clients. This architecture allows scaling the number of connected clients by distributing the load across multiple relay instances.
+
+This implementation directly uses the `datastreamer.NewRelay` function from the [0xPolygonHermez/zkevm-data-streamer](https://github.com/0xPolygonHermez/zkevm-data-streamer) package.
+
+## Features
+
+- Connects to a zkEVM datastream server and receives entries in real-time
+- Serves multiple clients with the same data
+- Maintains a local stream file for persistence
+- Forwards all entry types (batches, L2 blocks, transactions, etc.)
+- Preserves bookmarks for efficient client synchronization
+
+## Usage
+
+```
+./relay [flags]
+```
+
+### Command Line Flags
+
+```
+--server string           Datastream server address to connect to (default "127.0.0.1:6900")
+--port uint               Port to expose for clients to connect (default 7900)
+--datafile string         Relay data file name (default "$HOME/Library/Erigon/datarelay.bin")
+--write-timeout duration  Timeout for write operations on client connections (default 5s)
+--inactivity-timeout duration  Timeout to kill an inactive client connection (default 30s)
+--check-interval duration  Time interval to check for inactive clients (default 5s)
+```
+
+### Example Docker Compose
+
+```bash
+# Start a relay using Docker Compose connecting to a local datastream
+RELAY_DSHOST=host.docker.internal:6900 docker-compose up relay
+```
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Server["Datastream Server"]
+    Relay["Relay"]
+    File["Local Stream File"]
+    Client1["Client 1"]
+    Client2["Client 2"]
+    ClientN["Client N"]
+    
+    Server <-->|TCP| Relay
+    Relay <-->|Read/Write| File
+    Relay -->|TCP| Client1
+    Relay -->|TCP| Client2
+    Relay -->|TCP| ClientN
+```
+
+The relay:
+1. Connects to the main datastream server
+2. Receives streamed entries
+3. Writes entries to its local stream file
+4. Serves connected clients from this file
+
+## Implementation Details
+
+This relay is a thin wrapper around the official zkEVM datastream relay implementation, providing a simple configuration interface through command-line flags. 

--- a/cmd/relay/README.md
+++ b/cmd/relay/README.md
@@ -6,7 +6,7 @@ A lightweight service that connects to a data stream server, receives data, and 
 
 The datastream relay acts as a client towards the main data stream server and as a server towards connected clients. This architecture allows scaling the number of connected clients by distributing the load across multiple relay instances.
 
-This implementation directly uses the `datastreamer.NewRelay` function from the [0xPolygonHermez/zkevm-data-streamer](https://github.com/0xPolygonHermez/zkevm-data-streamer) package.
+This implementation directly uses the `datastreamer.NewRelay` function from the [gateway-fm/zkevm-data-streamer](https://github.com/gateway-fm/zkevm-data-streamer) package.
 
 ## Features
 

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -8,9 +8,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
-	"github.com/0xPolygonHermez/zkevm-data-streamer/log"
 	"github.com/erigontech/erigon/common/paths"
+	"github.com/gateway-fm/zkevm-data-streamer/datastreamer"
+	"github.com/gateway-fm/zkevm-data-streamer/log"
 )
 
 const (
@@ -44,7 +44,7 @@ func main() {
 	log.Infof(">> Relay server starting: port[%d] file[%s] server[%s] log[%s]",
 		*port, *dataFile, *serverAddr, *logLevel)
 
-	// Create relay server - directly use the implementation from 0xPolygonHermez/zkevm-data-streamer
+	// Create relay server - directly use the implementation from gateway-fm/zkevm-data-streamer
 	relay, err := datastreamer.NewRelay(
 		*serverAddr,         // Server address
 		uint16(*port),       // Port

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
+	"github.com/0xPolygonHermez/zkevm-data-streamer/log"
+	"github.com/erigontech/erigon/common/paths"
+)
+
+const (
+	streamerSystemID    = 137
+	streamerVersion     = 1
+	streamTypeSequencer = 1
+)
+
+func main() {
+	// Define command-line flags
+	serverAddr := flag.String("server", "127.0.0.1:6900", "datastream server address to connect to")
+	port := flag.Uint("port", 7900, "port to expose for clients to connect")
+	dataFile := flag.String("datafile", filepath.Join(paths.DefaultDataDir(), "datarelay.bin"), "relay data file name")
+	logLevel := flag.String("log", "info", "log level (debug, info, warn, error)")
+	writeTimeoutMs := flag.Uint("writetimeout", 3000, "timeout for write operations on client connections in ms (0=no timeout)")
+	inactivityTimeoutSec := flag.Uint("inactivitytimeout", 120, "timeout to kill an inactive client connection in seconds (0=no timeout)")
+
+	flag.Parse()
+
+	// Setup logging
+	log.Init(log.Config{
+		Environment: "development",
+		Level:       *logLevel,
+		Outputs:     []string{"stdout"},
+	})
+
+	writeTimeout := time.Duration(*writeTimeoutMs) * time.Millisecond
+	inactivityTimeout := time.Duration(*inactivityTimeoutSec) * time.Second
+	checkInterval := 5 * time.Second
+
+	log.Infof(">> Relay server starting: port[%d] file[%s] server[%s] log[%s]",
+		*port, *dataFile, *serverAddr, *logLevel)
+
+	// Create relay server - directly use the implementation from 0xPolygonHermez/zkevm-data-streamer
+	relay, err := datastreamer.NewRelay(
+		*serverAddr,         // Server address
+		uint16(*port),       // Port
+		streamerVersion,     // Version
+		streamerSystemID,    // System ID
+		streamTypeSequencer, // Stream type
+		*dataFile,           // Data file
+		writeTimeout,        // Write timeout
+		inactivityTimeout,   // Inactivity timeout
+		checkInterval,       // Check interval
+		nil,                 // No custom logger
+	)
+
+	if err != nil {
+		log.Errorf(">> Relay server: NewRelay error! (%v)", err)
+		os.Exit(1)
+	}
+
+	// Start relay server
+	err = relay.Start()
+	if err != nil {
+		log.Errorf(">> Relay server: Start error! (%v)", err)
+		os.Exit(1)
+	}
+
+	log.Infof(">> Relay server started successfully")
+
+	// Set up signal handling
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Wait for signal
+	sig := <-sigChan
+	log.Infof("Received signal %v, shutting down...", sig)
+
+	// Stop the relay server gracefully
+	if err := relay.Stop(); err != nil {
+		log.Errorf(">> Error stopping relay server: %v", err)
+		os.Exit(1)
+	}
+	log.Info(">> Relay server stopped")
+}

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -64,6 +64,7 @@ COPY --from=builder /app/build/bin/sentry /usr/local/bin/sentry
 COPY --from=builder /app/build/bin/state /usr/local/bin/state
 COPY --from=builder /app/build/bin/txpool /usr/local/bin/txpool
 COPY --from=builder /app/build/bin/verkle /usr/local/bin/verkle
+COPY --from=builder /app/build/bin/relay /usr/local/bin/relay
 
 
 EXPOSE 8545 \
@@ -75,7 +76,8 @@ EXPOSE 8545 \
        42069/udp \
        8080 \
        9090 \
-       6060
+       6060 \
+       7900
 
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 ARG BUILD_DATE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
 # Default UID: 1000
 # Default GID: 1000
 # Ports: `9090` execution engine (private api), `9091` sentry, `9092` consensus engine, `9093` snapshot downloader, `9094` TxPool
-# Ports: `8545` json rpc, `8551` consensus json rpc, `30303` eth p2p protocol, `42069` bittorrent protocol,
+# Ports: `8545` json rpc, `8551` consensus json rpc, `30303` eth p2p protocol, `42069` bittorrent protocol, `7900` data stream relay
 
 # Connections: erigon -> (sentries, downloader), rpcdaemon -> (erigon, txpool), txpool -> erigon
 
@@ -68,9 +68,18 @@ services:
       --private.api.addr=erigon:9090 --txpool.api.addr=txpool:9094 --datadir=/home/erigon/.local/share/erigon
     ports: [ "8545:8545" ]
 
-
-
-
+  relay:
+    image: thorax/erigon:${TAG:-latest}
+    user: ${DOCKER_UID:-1000}:${DOCKER_GID:-1000}
+    entrypoint: relay
+    command: |
+      ${RELAY_FLAGS-} --server=${RELAY_DSHOST:-127.0.0.1:6900} --port=${RELAY_PORT:-7900}
+      --datafile=${RELAY_FILE:-/home/erigon/.local/share/erigon/datarelay.bin} --log=${RELAY_LOG:-info}
+      --writetimeout=${RELAY_WRITETIMEOUT:-3000} --inactivitytimeout=${RELAY_INACTIVITYTIMEOUT:-120}
+    ports: [ "${RELAY_PORT:-7900}:${RELAY_PORT:-7900}" ]
+    volumes:
+      - ${XDG_DATA_HOME:-~/.local/share}/erigon:/home/erigon/.local/share/erigon
+      
   prometheus:
     image: prom/prometheus:v2.51.2
     user: ${DOCKER_UID:-1000}:${DOCKER_GID:-1000} # Uses erigon user from Dockerfile

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -36,9 +36,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
-	log2 "github.com/0xPolygonHermez/zkevm-data-streamer/log"
 	"github.com/erigontech/mdbx-go/mdbx"
+	"github.com/gateway-fm/zkevm-data-streamer/datastreamer"
+	log2 "github.com/gateway-fm/zkevm-data-streamer/log"
 	lru "github.com/hashicorp/golang-lru/arc/v2"
 	"github.com/holiman/uint256"
 	"google.golang.org/grpc"

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/erigontech/erigon-lib v1.0.0
 	github.com/erigontech/erigonwatch v0.1.16
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
-	github.com/gateway-fm/zkevm-data-streamer v0.2.9-preview1
+	github.com/gateway-fm/zkevm-data-streamer v0.2.9
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35
 	github.com/gfx-labs/sse v0.0.0-20231226060816-f747e26a9baa
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ replace github.com/erigontech/erigon-lib => ./erigon-lib
 
 require (
 	gfx.cafe/util/go/generic v0.0.0-20230721185457-c559e86c829c
-	github.com/0xPolygonHermez/zkevm-data-streamer v0.2.8
 	github.com/99designs/gqlgen v0.17.40
 	github.com/Giulio2002/bls v0.0.0-20241013174947-019133587795
 	github.com/Masterminds/sprig/v3 v3.2.3
@@ -44,6 +43,7 @@ require (
 	github.com/erigontech/erigon-lib v1.0.0
 	github.com/erigontech/erigonwatch v0.1.16
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
+	github.com/gateway-fm/zkevm-data-streamer v0.2.9-preview1
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35
 	github.com/gfx-labs/sse v0.0.0-20231226060816-f747e26a9baa
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c h1:uYNKzPntb8c6DKvP9E
 github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gateway-fm/vectorized-poseidon-gold v1.0.0 h1:Du0ZW+fkZhgRNGx/gAkHnMj3/Rl8uJkAEe+ZDPX3PDw=
 github.com/gateway-fm/vectorized-poseidon-gold v1.0.0/go.mod h1:VLGQpyjrOg8+FugH/+d8tfYd/c3z4Xqa+zbUBITygaw=
-github.com/gateway-fm/zkevm-data-streamer v0.2.9-preview1 h1:Jf8VsDh7V/gIv9V/UfYDnwW1wEqLexag7tI+H/H076A=
-github.com/gateway-fm/zkevm-data-streamer v0.2.9-preview1/go.mod h1:kUFkHKNFYLn6bDWVieKYoyLgwXYHlR6XGcV2nTTYSFk=
+github.com/gateway-fm/zkevm-data-streamer v0.2.9 h1:ezR6IJakWvtNXFEhWXtwuot0JikKCJIB9rk2wnUsH3A=
+github.com/gateway-fm/zkevm-data-streamer v0.2.9/go.mod h1:kKQSu8Ob9yNR+3ocx9dHlWmQ4Gnct3jRtQqKR69CmyM=
 github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35 h1:I8QswD9gf3VEpr7bpepKKOm7ChxFITIG+oc1I5/S0no=
 github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35/go.mod h1:DMDd04jjQgdynaAwbEgiRERIGpC8fDjx0+y06an7Psg=
 github.com/gfx-labs/sse v0.0.0-20231226060816-f747e26a9baa h1:b6fBm4SLM8jywQHNmc3ZCl6zQEhEyZl6bp7is4en72M=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7
 gfx.cafe/util/go/generic v0.0.0-20230721185457-c559e86c829c h1:alCfDKmPC0EC0KGlZWrNF0hilVWBkzMz+aAYTJ/2hY4=
 gfx.cafe/util/go/generic v0.0.0-20230721185457-c559e86c829c/go.mod h1:WvSX4JsCRBuIXj0FRBFX9YLg+2SoL3w8Ww19uZO9yNE=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/0xPolygonHermez/zkevm-data-streamer v0.2.8 h1:0Sc91seArqR3BQs49SGwGXWjf0MQYW98sEUYrao7duU=
-github.com/0xPolygonHermez/zkevm-data-streamer v0.2.8/go.mod h1:7nM7Ihk+fTG1TQPwdZoGOYd3wprqqyIyjtS514uHzWE=
 github.com/99designs/gqlgen v0.17.40 h1:/l8JcEVQ93wqIfmH9VS1jsAkwm6eAF1NwQn3N+SDqBY=
 github.com/99designs/gqlgen v0.17.40/go.mod h1:b62q1USk82GYIVjC60h02YguAZLqYZtvWml8KkhJps4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -317,6 +315,8 @@ github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c h1:uYNKzPntb8c6DKvP9E
 github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gateway-fm/vectorized-poseidon-gold v1.0.0 h1:Du0ZW+fkZhgRNGx/gAkHnMj3/Rl8uJkAEe+ZDPX3PDw=
 github.com/gateway-fm/vectorized-poseidon-gold v1.0.0/go.mod h1:VLGQpyjrOg8+FugH/+d8tfYd/c3z4Xqa+zbUBITygaw=
+github.com/gateway-fm/zkevm-data-streamer v0.2.9-preview1 h1:Jf8VsDh7V/gIv9V/UfYDnwW1wEqLexag7tI+H/H076A=
+github.com/gateway-fm/zkevm-data-streamer v0.2.9-preview1/go.mod h1:kUFkHKNFYLn6bDWVieKYoyLgwXYHlR6XGcV2nTTYSFk=
 github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35 h1:I8QswD9gf3VEpr7bpepKKOm7ChxFITIG+oc1I5/S0no=
 github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35/go.mod h1:DMDd04jjQgdynaAwbEgiRERIGpC8fDjx0+y06an7Psg=
 github.com/gfx-labs/sse v0.0.0-20231226060816-f747e26a9baa h1:b6fBm4SLM8jywQHNmc3ZCl6zQEhEyZl6bp7is4en72M=

--- a/zk/datastream/mocks/stream_server_mock.go
+++ b/zk/datastream/mocks/stream_server_mock.go
@@ -12,7 +12,7 @@ package mocks
 import (
 	reflect "reflect"
 
-	datastreamer "github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
+	datastreamer "github.com/gateway-fm/zkevm-data-streamer/datastreamer"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/zk/datastream/server/data_stream_server.go
+++ b/zk/datastream/server/data_stream_server.go
@@ -2,11 +2,11 @@ package server
 
 import (
 	"fmt"
+	"github.com/gateway-fm/zkevm-data-streamer/datastreamer"
+	dslog "github.com/gateway-fm/zkevm-data-streamer/log"
 	"sync"
 	"time"
 
-	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
-	dslog "github.com/0xPolygonHermez/zkevm-data-streamer/log"
 	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/log/v3"

--- a/zk/datastream/server/interfaces.go
+++ b/zk/datastream/server/interfaces.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
-	dslog "github.com/0xPolygonHermez/zkevm-data-streamer/log"
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/kv"
 	eritypes "github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/zk/datastream/types"
 	"github.com/erigontech/erigon/zk/hermez_db"
+	"github.com/gateway-fm/zkevm-data-streamer/datastreamer"
+	dslog "github.com/gateway-fm/zkevm-data-streamer/log"
 )
 
 //go:generate mockgen -typed=true -destination=../mocks/stream_server_mock.go -package=mocks . StreamServer

--- a/zk/debug_tools/datastream-client/README.md
+++ b/zk/debug_tools/datastream-client/README.md
@@ -1,0 +1,40 @@
+# Datastream Client Debug Tool
+
+A simple tool for debugging and inspecting datastream entries from a datastream server.
+
+## Usage
+
+```bash
+go run main.go -server localhost:6900
+```
+
+### Options
+- `-server`: Address of the datastream server (default: "localhost:6900")
+
+## Features
+- Connects to a datastream server
+- Prints basic information about each entry type received:
+  - Batch Start entries (number and fork ID)
+  - Batch End entries (number and state root)
+  - L2 Blocks (number, hash, and batch number)
+  - GER Updates (batch number and global exit root)
+- Graceful shutdown on Ctrl+C
+
+## Example Output
+```
+Batch Start: Number=123, ForkId=7
+Block: Number=456, Hash=0x..., Batch=123
+GER Update: Batch=123, GER=0x...
+Batch End: Number=123, StateRoot=0x...
+```
+
+## Testing
+1. Start the datastream server:
+```bash
+go run ../datastream-host/main.go -file /path/to/datastream
+```
+
+2. In another terminal, run the relay:
+```bash
+go run main.go -server localhost:6900
+``` 

--- a/zk/debug_tools/datastream-client/main.go
+++ b/zk/debug_tools/datastream-client/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/zk/datastream/client"
+	"github.com/erigontech/erigon/zk/datastream/types"
+)
+
+func main() {
+	// Parse command line flags
+	serverAddr := flag.String("server", "localhost:6900", "datastream server address")
+	flag.Parse()
+
+	// Create context with cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create stream client (using same configuration as stage_batches.go)
+	dsClient := client.NewClient(ctx, *serverAddr, false, 5*time.Second, 0, client.DefaultEntryChannelSize)
+
+	// Start the client
+	if err := dsClient.Start(); err != nil {
+		log.Error("Failed to start datastream client", "err", err)
+		return
+	}
+	defer dsClient.Stop()
+
+	// Get entry channel
+	entryChan := dsClient.GetEntryChan()
+
+	// Start reading entries in a goroutine
+	go func() {
+		// Start reading entries from the datastream
+		if err := dsClient.ReadAllEntriesToChannel(); err != nil {
+			log.Error("Failed to read entries from datastream", "err", err)
+			return
+		}
+	}()
+
+	// Start processing entries in a goroutine
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case entry := <-*entryChan:
+				processEntry(entry)
+			}
+		}
+	}()
+
+	// Wait for interrupt signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	<-sigChan
+
+}
+
+func processEntry(entry interface{}) {
+	switch e := entry.(type) {
+	case *types.BatchStart:
+		fmt.Printf("Batch Start: Number=%d, ForkId=%d\n", e.Number, e.ForkId)
+	case *types.BatchEnd:
+		fmt.Printf("Batch End: Number=%d, StateRoot=%x\n", e.Number, e.StateRoot)
+	case *types.FullL2Block:
+		fmt.Printf("Block: Number=%d, Hash=%x, Batch=%d\n",
+			e.L2BlockNumber, e.L2Blockhash, e.BatchNumber)
+	case *types.GerUpdate:
+		fmt.Printf("GER Update: Batch=%d, GER=%x\n",
+			e.BatchNumber, e.GlobalExitRoot)
+	default:
+		fmt.Printf("Unknown entry type: %T\n", entry)
+	}
+}

--- a/zk/debug_tools/datastream-host/main.go
+++ b/zk/debug_tools/datastream-host/main.go
@@ -7,9 +7,9 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
-	log2 "github.com/0xPolygonHermez/zkevm-data-streamer/log"
 	"github.com/erigontech/erigon/zk/datastream/server"
+	"github.com/gateway-fm/zkevm-data-streamer/datastreamer"
+	log2 "github.com/gateway-fm/zkevm-data-streamer/log"
 )
 
 var (

--- a/zk/stages/stage_data_stream_catch_up_test.go
+++ b/zk/stages/stage_data_stream_catch_up_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/0xPolygonHermez/zkevm-data-streamer/datastreamer"
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/kv/memdb"
 	"github.com/erigontech/erigon/core/rawdb"
@@ -16,6 +15,7 @@ import (
 	"github.com/erigontech/erigon/smt/pkg/db"
 	"github.com/erigontech/erigon/zk/datastream/mocks"
 	"github.com/erigontech/erigon/zk/hermez_db"
+	"github.com/gateway-fm/zkevm-data-streamer/datastreamer"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"


### PR DESCRIPTION
This pull request introduces a new relay service for zkEVM data streaming, along with necessary updates to Docker configurations and dependencies. The most important changes include adding the relay service, updating Docker files, and modifying import paths for the data streamer package.

### New Relay Service:
* [`cmd/relay/main.go`](diffhunk://#diff-6262051bf1c1cff09f48ba8f666100d53f54c2bba2ddf39c881ba56b50f22e61R1-R89): Added the main implementation for the relay service which connects to a data stream server and forwards data to multiple clients.
* [`cmd/relay/README.md`](diffhunk://#diff-1b9adabe06987250eb28cf0beaf99c6c258506d407160c0b9ea24644d5a57155R1-R69): Added documentation for the relay service, including usage, command-line flags, and architecture details.

### Docker Configuration Updates:
* `Dockerfile`, `Dockerfile.debian`, `debug.Dockerfile`: Added the relay binary to the Docker images and exposed port 7900 for the relay service. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R88) [[2]](diffhunk://#diff-49a95235edddaf12f383a8f467d25b6ae8422204561d88fdaadfc9c1c6a9afe2R79) [[3]](diffhunk://#diff-784378547d3f8322a2e74a673dcf9203c2a39123b9851b4bacb3205aaccb1a80R67)
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L71-R81): Added a new service definition for the relay in Docker Compose, including relevant environment variables and ports.

### Dependency Updates:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R46): Updated import paths to use the `gateway-fm/zkevm-data-streamer` package instead of the old `0xPolygonHermez/zkevm-data-streamer` package. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R46) [[2]](diffhunk://#diff-9cc7046826ce92d9cc5432cf41ed4fc14bb6907da44f771e3932302c40e8dbc2L39-R41)

### Debug Tools:
* [`zk/debug_tools/datastream-client/main.go`](diffhunk://#diff-3757234ad3ec3beffe67808eb490ecbf94289e223f14d790022e6fcd4afd3c20R1-R81): Added a new debug tool for inspecting datastream entries from a server.
* [`zk/debug_tools/datastream-client/README.md`](diffhunk://#diff-45822cee2317552fea6bdc58f797474956afd8925adc2680b84efc228c301b6dR1-R40): Added documentation for the new datastream client debug tool.

These changes collectively introduce a new relay service, update Docker configurations to support the relay, and ensure all dependencies are correctly aligned with the new data streamer package.

Adds a simple tool for debugging and inspecting datastream entries from a datastream server. The tool connects to a datastream server and prints basic information about each entry type received (Batch Start/End, L2 Blocks, GER Updates). Includes graceful shutdown handling.