### PR TITLE
feat(txpool): add Timsort support for pending subpool

### DIFF
--- a/cmd/txpool/main.go
+++ b/cmd/txpool/main.go
@@ -57,7 +57,8 @@ var (
 	priceBump          uint64
 	blobPriceBump      uint64
 
-	noTxGossip bool
+	noTxGossip    bool
+	enableTimsort bool
 
 	commitEvery   time.Duration
 	purgeEvery    time.Duration
@@ -90,6 +91,7 @@ func init() {
 	rootCmd.PersistentFlags().DurationVar(&purgeEvery, utils.TxpoolPurgeEveryFlag.Name, utils.TxpoolPurgeEveryFlag.Value, utils.TxpoolPurgeEveryFlag.Usage)
 	rootCmd.PersistentFlags().DurationVar(&purgeDistance, utils.TxpoolPurgeDistanceFlag.Name, utils.TxpoolPurgeDistanceFlag.Value, utils.TxpoolPurgeDistanceFlag.Usage)
 	rootCmd.PersistentFlags().BoolVar(&noTxGossip, utils.TxPoolGossipDisableFlag.Name, utils.TxPoolGossipDisableFlag.Value, utils.TxPoolGossipDisableFlag.Usage)
+	rootCmd.PersistentFlags().BoolVar(&enableTimsort, utils.TxPoolEnableTimsort.Name, utils.TxPoolEnableTimsort.Value, utils.TxPoolEnableTimsort.Usage)
 	rootCmd.Flags().StringSliceVar(&traceSenders, utils.TxPoolTraceSendersFlag.Name, []string{}, utils.TxPoolTraceSendersFlag.Usage)
 }
 
@@ -160,6 +162,7 @@ func doTxpool(ctx context.Context, logger log.Logger) error {
 	cfg.PriceBump = priceBump
 	cfg.BlobPriceBump = blobPriceBump
 	cfg.NoGossip = noTxGossip
+	cfg.EnableTimsort = enableTimsort
 
 	cacheConfig := kvcache.DefaultCoherentConfig
 	cacheConfig.MetricsLabel = "txpool"

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -247,6 +247,10 @@ var (
 		Usage: "Transactions older than this distance will be purged",
 		Value: txpoolcfg.DefaultConfig.PurgeDistance,
 	}
+	TxPoolEnableTimsort = cli.BoolFlag{
+		Name:  "txpool.enabletimsort",
+		Usage: "Enable Timsort sorting for the 'best' slice in the pending TxPool subpool",
+	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{
 		Name:  "mine",
@@ -2029,6 +2033,9 @@ func setTxPool(ctx *cli.Context, fullCfg *ethconfig.Config) {
 	cfg := &fullCfg.DeprecatedTxPool
 	if ctx.IsSet(TxPoolDisableFlag.Name) {
 		cfg.Disable = ctx.Bool(TxPoolDisableFlag.Name)
+	}
+	if ctx.IsSet(TxPoolEnableTimsort.Name) {
+		cfg.EnableTimsort = ctx.Bool(TxPoolEnableTimsort.Name)
 	}
 	if ctx.IsSet(TxPoolLocalsFlag.Name) {
 		locals := libcommon.CliString2Array(ctx.String(TxPoolLocalsFlag.Name))

--- a/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
+++ b/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
@@ -59,7 +59,8 @@ type Config struct {
 	MdbxDBSizeLimit datasize.ByteSize
 	MdbxGrowthStep  datasize.ByteSize
 
-	NoGossip bool // this mode doesn't broadcast any txs, and if receive remote-txn - skip it
+	NoGossip      bool // this mode doesn't broadcast any txs, and if receive remote-txn - skip it
+	EnableTimsort bool
 
 	PurgeDistance time.Duration
 }
@@ -83,7 +84,8 @@ var DefaultConfig = Config{
 	PriceBump:          10,  // Price bump percentage to replace an already existing transaction
 	BlobPriceBump:      100,
 
-	NoGossip: true, // centralised sequencing for [zkevm] doesn't need tx gossiping
+	NoGossip:      true, // centralised sequencing for [zkevm] doesn't need tx gossiping
+	EnableTimsort: false,
 
 	OverrideShanghaiTime: nil,
 }

--- a/eth/ethconfig/tx_pool.go
+++ b/eth/ethconfig/tx_pool.go
@@ -43,6 +43,7 @@ type DeprecatedTxPoolConfig struct {
 	StartOnInit   bool
 	TracedSenders []string // List of senders for which tx pool should print out debugging info
 	CommitEvery   time.Duration
+	EnableTimsort bool // EnableTimsort determines whether Timsort is used to sort the 'best' slice of the pending subpool.
 }
 
 // DeprecatedDefaultTxPoolConfig contains the default configurations for the transaction

--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,7 @@ require (
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pion/transport/v3 v3.0.7 // indirect
+	github.com/psilva261/timsort/v2 v2.0.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -853,6 +853,8 @@ github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7 h1:0tVE4
 github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7/go.mod h1:wmuf/mdK4VMD+jA9ThwcUKjg3a2XWM9cVfFYjDyY4j4=
 github.com/prysmaticlabs/gohashtree v0.0.3-alpha.0.20230502123415-aafd8b3ca202 h1:ZsFouPKy81vvQo/Zup5gASVdOm6aiuwUhp7GxvQmjIA=
 github.com/prysmaticlabs/gohashtree v0.0.3-alpha.0.20230502123415-aafd8b3ca202/go.mod h1:4pWaT30XoEx1j8KNJf3TV+E3mQkaufn7mf+jRNb/Fuk=
+github.com/psilva261/timsort/v2 v2.0.1 h1:yXOIbHYTmcLweKP8WM77UVpMlsySgvBT/9WJbKOs3Os=
+github.com/psilva261/timsort/v2 v2.0.1/go.mod h1:YBxAWUUK+z+XD9PrMgBQXquJ+ZBeiJ5SGtdwcdhsUtQ=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -31,6 +31,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.TxPoolCommitEveryFlag,
 	&utils.TxpoolPurgeEveryFlag,
 	&utils.TxpoolPurgeDistanceFlag,
+	&utils.TxPoolEnableTimsort,
 	&PruneFlag,
 	&PruneHistoryFlag,
 	&PruneReceiptFlag,

--- a/zk/txpool/metrics_test.go
+++ b/zk/txpool/metrics_test.go
@@ -228,7 +228,7 @@ func TestMedianTimeMetrics(t *testing.T) {
 			search:           &metaTx{Tx: &types.TxSlot{}},
 			senderIDTxnCount: map[uint64]int{},
 		},
-		pending: NewPendingSubPool(PendingSubPool, 100),
+		pending: NewPendingSubPool(PendingSubPool, 100, false),
 		baseFee: NewSubPool(BaseFeeSubPool, 100),
 		queued:  NewSubPool(QueuedSubPool, 100),
 		metrics: &Metrics{},

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -37,6 +37,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/hexutility"
 	"github.com/erigontech/erigon-lib/txpool/txpoolcfg"
 	"github.com/erigontech/erigon/zk/acl"
+	"github.com/psilva261/timsort/v2"
 
 	"github.com/VictoriaMetrics/metrics"
 	mapset "github.com/deckarep/golang-set/v2"
@@ -402,7 +403,7 @@ func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, 
 		discardReasonsLRU:       discardHistory,
 		all:                     byNonce,
 		recentlyConnectedPeers:  &recentlyConnectedPeers{},
-		pending:                 NewPendingSubPool(PendingSubPool, cfg.PendingSubPoolLimit),
+		pending:                 NewPendingSubPool(PendingSubPool, cfg.PendingSubPoolLimit, cfg.EnableTimsort),
 		baseFee:                 NewSubPool(BaseFeeSubPool, cfg.BaseFeeSubPoolLimit),
 		queued:                  NewSubPool(QueuedSubPool, cfg.QueuedSubPoolLimit),
 		newPendingTxs:           newTxs,
@@ -2630,15 +2631,16 @@ func (b *BySenderAndNonce) replaceOrInsert(mt *metaTx) *metaTx {
 // It's more expensive to maintain "slice sort" invariant, but it allow do cheap copy of
 // pending.best slice for mining (because we consider txs and metaTx are immutable)
 type PendingPool struct {
-	sorted bool // means `PendingPool.best` is sorted or not
-	best   *bestSlice
-	worst  *WorstQueue
-	limit  int
-	t      SubPoolType
+	sorted        bool // means `PendingPool.best` is sorted or not
+	best          *bestSlice
+	worst         *WorstQueue
+	limit         int
+	t             SubPoolType
+	enableTimsort bool
 }
 
-func NewPendingSubPool(t SubPoolType, limit int) *PendingPool {
-	return &PendingPool{limit: limit, t: t, best: &bestSlice{ms: []*metaTx{}}, worst: &WorstQueue{ms: []*metaTx{}}}
+func NewPendingSubPool(t SubPoolType, limit int, enableTimsort bool) *PendingPool {
+	return &PendingPool{limit: limit, t: t, best: &bestSlice{ms: []*metaTx{}}, worst: &WorstQueue{ms: []*metaTx{}}, enableTimsort: enableTimsort}
 }
 
 // bestSlice - is similar to best queue, but with O(n log n) complexity and
@@ -2672,7 +2674,11 @@ func (p *PendingPool) EnforceWorstInvariants() {
 }
 func (p *PendingPool) EnforceBestInvariants() {
 	if !p.sorted {
-		sort.Sort(p.best)
+		if p.enableTimsort {
+			timsort.TimSort(p.best)
+		} else {
+			sort.Sort(p.best)
+		}
 		p.sorted = true
 	}
 }

--- a/zk/txpool/pool_test.go
+++ b/zk/txpool/pool_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/exp/rand"
 	"google.golang.org/grpc"
 )
 
@@ -243,4 +244,204 @@ func TestOnNewBlock(t *testing.T) {
 	err := fetch.handleStateChanges(ctx, stateChanges)
 	assert.ErrorIs(t, io.EOF, err)
 	assert.Equal(t, 3, len(minedTxs.Txs))
+}
+
+func generateRandomMetaTx(id int, senderNonceMap map[uint64]uint64) *metaTx {
+	senderID := uint64(rand.Intn(1000))
+	nonce, exists := senderNonceMap[senderID]
+	if !exists {
+		nonce = 0
+	}
+	senderNonceMap[senderID] = nonce + 1
+
+	var idHash [32]byte
+	_, err := rand.Read(idHash[:])
+	if err != nil {
+		panic(fmt.Sprintf("Failed to generate random IDHash: %v", err))
+	}
+
+	minFeeCap := uint64(rand.Intn(1000000)) // [0, 999999]
+
+	var minTip uint64
+	if minFeeCap > 0 {
+		minTip = uint64(rand.Intn(int(minFeeCap))) // [0, minFeeCap-1]
+	} else {
+		minTip = 0
+	}
+
+	return &metaTx{
+		Tx: &types.TxSlot{
+			IDHash:   idHash,
+			SenderID: senderID,
+			Nonce:    nonce,
+		},
+		minFeeCap:                 *uint256.NewInt(minFeeCap),
+		nonceDistance:             0,
+		cumulativeBalanceDistance: 0,
+		minTip:                    minTip,
+		bestIndex:                 -1,
+		worstIndex:                -1,
+		timestamp:                 uint64(time.Now().UnixNano()),
+		created:                   uint64(time.Now().Unix()),
+		subPool:                   0,
+		currentSubPool:            PendingSubPool,
+	}
+}
+
+func isSorted(slice *bestSlice) bool {
+	for i := 1; i < slice.Len(); i++ {
+		if slice.Less(i, i-1) {
+			fmt.Printf("Unsorted at %d: %+v < %+v\n", i, slice.ms[i-1], slice.ms[i])
+			return false
+		}
+	}
+	return true
+}
+
+func TestEnforceBestInvariantsAfterBestChanged(t *testing.T) {
+	const txCount = 1_000_000
+	rand.Seed(uint64(time.Now().UnixNano()))
+
+	poolSort := NewPendingSubPool(PendingSubPool, txCount+1, false)
+	poolTimSort := NewPendingSubPool(PendingSubPool, txCount+1, true)
+
+	senderNonceMap := make(map[uint64]uint64)
+	for i := 0; i < txCount; i++ {
+		tx := generateRandomMetaTx(i, senderNonceMap)
+		txCopy := *tx
+		txCopy.Tx = &types.TxSlot{
+			IDHash:   tx.Tx.IDHash,
+			SenderID: tx.Tx.SenderID,
+			Nonce:    tx.Tx.Nonce,
+		}
+		poolSort.Add(tx)
+		poolTimSort.Add(&txCopy)
+	}
+
+	poolTimSort.EnforceBestInvariants()
+	assert.True(t, isSorted(poolTimSort.best), "timsort.TimSort failed to sort bestSlice")
+
+	poolSort.EnforceBestInvariants()
+	assert.True(t, isSorted(poolSort.best), "sort.Sort failed to sort bestSlice")
+
+	assert.Equal(t, poolSort.best.ms[0].Tx.IDHash, poolTimSort.best.ms[0].Tx.IDHash, "Best tx IDHash differs before removing best txs")
+
+	// remove top 1000 transactions
+	for i := 0; i < 1000; i++ {
+		poolSort.Remove(poolSort.Best())
+		poolTimSort.Remove(poolTimSort.Best())
+	}
+
+	// add 500 new transacions
+	for i := 0; i < 500; i++ {
+		tx := generateRandomMetaTx(i, senderNonceMap)
+		txCopy := *tx
+		txCopy.Tx = &types.TxSlot{
+			IDHash:   tx.Tx.IDHash,
+			SenderID: tx.Tx.SenderID,
+			Nonce:    tx.Tx.Nonce,
+		}
+		poolSort.Add(tx)
+		poolTimSort.Add(&txCopy)
+	}
+
+	start := time.Now()
+	poolTimSort.EnforceBestInvariants()
+	timSortDuration := time.Since(start)
+
+	start = time.Now()
+	poolSort.EnforceBestInvariants()
+	sortDuration := time.Since(start)
+
+	assert.True(t, isSorted(poolTimSort.best), "timsort.TimSort failed to sort bestSlice")
+	assert.True(t, isSorted(poolSort.best), "sort.Sort failed to sort bestSlice")
+	assert.Equal(t, poolSort.best.ms[0].Tx.IDHash, poolTimSort.best.ms[0].Tx.IDHash, "Best tx IDHash differs after removing best txs")
+	assert.Greaterf(t, sortDuration, timSortDuration, "sort.Sort cost less time than timsort.TimSort")
+
+	t.Logf("sort.Sort duration(After BestRead): %v", sortDuration)
+	t.Logf("timsort.TimSort duration(After BestRead): %v", timSortDuration)
+}
+
+func BenchmarkSortingPerformance(b *testing.B) {
+	const (
+		txCount     = 100_000 // Reduced for benchmark speed; adjust as needed
+		removeCount = 1_000   // Number of transactions to remove
+		addCount    = 500     // Number of transactions to add back
+	)
+
+	// Seed random generator
+	rand.Seed(uint64(time.Now().UnixNano()))
+
+	// Run benchmark for both sorting methods
+	b.Run("sort.Sort", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// Initialize pool
+			pool := NewPendingSubPool(PendingSubPool, txCount+addCount, false)
+			senderNonceMap := make(map[uint64]uint64)
+
+			// Add initial transactions
+			for j := 0; j < txCount; j++ {
+				tx := generateRandomMetaTx(j, senderNonceMap)
+				pool.Add(tx)
+			}
+
+			// First sort
+			pool.EnforceBestInvariants()
+			assert.True(b, isSorted(pool.best), "Initial sort.Sort failed")
+
+			// Remove some transactions
+			for j := 0; j < removeCount && pool.best.Len() > 0; j++ {
+				pool.Remove(pool.Best())
+			}
+
+			// Add new transactions
+			for j := 0; j < addCount; j++ {
+				tx := generateRandomMetaTx(txCount+j, senderNonceMap)
+				pool.Add(tx)
+			}
+
+			// Second sort (benchmark this)
+			b.StartTimer()
+			pool.EnforceBestInvariants()
+			b.StopTimer()
+
+			assert.True(b, isSorted(pool.best), "Second sort.Sort failed")
+		}
+	})
+
+	b.Run("timsort.TimSort", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// Initialize pool
+			pool := NewPendingSubPool(PendingSubPool, txCount+addCount, true)
+			senderNonceMap := make(map[uint64]uint64)
+
+			// Add initial transactions
+			for j := 0; j < txCount; j++ {
+				tx := generateRandomMetaTx(j, senderNonceMap)
+				pool.Add(tx)
+			}
+
+			// First sort
+			pool.EnforceBestInvariants()
+			assert.True(b, isSorted(pool.best), "Initial timsort.TimSort failed")
+
+			// Remove some transactions
+			for j := 0; j < removeCount && pool.best.Len() > 0; j++ {
+				pool.Remove(pool.Best())
+			}
+
+			// Add new transactions
+			for j := 0; j < addCount; j++ {
+				tx := generateRandomMetaTx(txCount+j, senderNonceMap)
+				pool.Add(tx)
+			}
+
+			// Second sort (benchmark this)
+			b.StartTimer()
+			pool.EnforceBestInvariants()
+			b.StopTimer()
+
+			assert.True(b, isSorted(pool.best), "Second timsort.TimSort failed")
+		}
+	})
 }


### PR DESCRIPTION
Currently, pending.best is sorted using the built-in sorting algorithm, which exhibits poor performance when the pending.best slice contains a large number of accumulated transactions. In the existing workflow, each time the optimal transactions are retrieved from pending.best, the slice must be sorted to identify the best transaction from the resulting ordered list. When transactions accumulate, pending.best is often already mostly sorted. In such cases, the built-in sorting algorithm underperforms compared to Timsort, which is optimized for partially ordered data. Below are the benchmark results comparing the two sorting methods in a scenario where the pending pool has accumulated 100,000 transactions.
![image](https://github.com/user-attachments/assets/ca42c71f-f3b5-479e-b899-01903555af27)
