### PR TITLE
fix(witness-gen): add nil check for info tree update

### DIFF
--- a/zk/witness/witness.go
+++ b/zk/witness/witness.go
@@ -315,6 +315,10 @@ func CheckForForcedInfoTreeUpdate(reader *hermez_db.HermezDbReader, blockNum uin
 		if err != nil {
 			return nil, fmt.Errorf("failed to get info tree index: %w", err)
 		}
+		if infoTreeIndex == nil {
+			log.Warn("Info tree index not found when generating witness", "index", index, "blockNum", blockNum)
+			return result, nil
+		}
 		d1 := common.LeftPadBytes(infoTreeIndex.GER.Bytes(), 32)
 		d2 := common.LeftPadBytes(state.GLOBAL_EXIT_ROOT_STORAGE_POS.Bytes(), 32)
 		mapKey := keccak256.Hash(d1, d2)


### PR DESCRIPTION
Generate witness by batch is causing a panic on this line under certain conditions and making the method handler crash. This is due too info tree update being nil and we are not nil checking it. If it is nil we should return with an error avoiding the panic.