### PR TITLE
fix(sr): dont change block gas limit rpc execution

### DIFF
--- a/core/blockchain_zkevm.go
+++ b/core/blockchain_zkevm.go
@@ -37,7 +37,6 @@ import (
 	"github.com/erigontech/erigon/core/vm"
 	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/zk/hermez_db"
-	"github.com/erigontech/erigon/zk/utils"
 )
 
 type EphemeralExecResultZk struct {
@@ -67,10 +66,6 @@ func ExecuteBlockEphemerallyZk(
 	header := block.Header()
 	blockTransactions := block.Transactions()
 	blockGasLimit := block.GasLimit()
-
-	if !chainConfig.IsForkID8Elderberry(block.NumberU64()) {
-		blockGasLimit = utils.ForkId7BlockGasLimit
-	}
 
 	gp := new(GasPool).AddGas(blockGasLimit)
 

--- a/zk/utils/utils.go
+++ b/zk/utils/utils.go
@@ -69,6 +69,10 @@ func ShouldShortCircuitExecution(tx kv.RwTx, logPrefix string, l2ShortCircuitToV
 		if err != nil {
 			return false, 0, err
 		}
+
+		if shortCircuitBlock == 0 {
+			break
+		}
 	}
 
 	log.Info(fmt.Sprintf("[%s] Short circuit", logPrefix), "batch", shortCircuitBatch, "block", shortCircuitBlock)


### PR DESCRIPTION
Modifying the block gas limit in RPC execution will cause a state root mismatch. The DS is the source of truth.

Break out of the short circuit if no blocks found. Needed for `zkevm.sync-limit: 1`