### PR TITLE
Support ds block range download

### DIFF
--- a/zk/datastream/client/commands.go
+++ b/zk/datastream/client/commands.go
@@ -9,6 +9,7 @@ const (
 	CmdStartBookmark // CmdStartBookmark for the start from bookmark TCP client command
 	CmdEntry         // CmdEntry for the get entry TCP client command
 	CmdBookmark      // CmdBookmark for the get bookmark TCP client command
+	CmdRangeBookmark // CmdRangeBookmark for the start and end bookmarks TCP client command
 )
 
 // sendHeaderCmd sends the header command to the server.
@@ -37,6 +38,33 @@ func (c *StreamClient) sendBookmarkCmd(bookmark []byte, streaming bool) error {
 
 	// Send the bookmark to retrieve
 	return c.writeToConn(bookmark)
+}
+
+// sendRangeBookmarkCmd sends the CmdRangeBookmark with the start and end bookmark value.
+func (c *StreamClient) sendRangeBookmarkCmd(startBookmark []byte, endBookmark []byte) error {
+	command := CmdRangeBookmark
+	// Send the command
+	if err := c.sendCommand(command); err != nil {
+		return err
+	}
+
+	// Send start bookmark
+	if err := c.writeToConn(uint32(len(startBookmark))); err != nil {
+		return err
+	}
+	if err := c.writeToConn(startBookmark); err != nil {
+		return err
+	}
+
+	// Send end bookmark
+	if err := c.writeToConn(uint32(len(endBookmark))); err != nil {
+		return err
+	}
+	if err := c.writeToConn(endBookmark); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // sendStartCmd sends a start command to the server, indicating

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -496,6 +496,46 @@ func (c *StreamClient) readAllEntriesToChannel() (err error) {
 	return
 }
 
+// Get all entries from the DS server from the current stage progress until to block number,
+// and sends the data into FllL2Blocks with transactions into the channel.
+func (c *StreamClient) ReadRangeEntriesToChannel(to uint64) (err error) {
+	defer func() {
+		if err != nil {
+			c.lastError = err
+		}
+	}()
+	select {
+	case <-c.ctx.Done():
+		return fmt.Errorf("context done - stopping")
+	default:
+	}
+
+	if err = c.readRangeEntriesToChannel(to); err != nil {
+		return fmt.Errorf("readRangeEntriesToChannel: %w", err)
+	}
+
+	return
+}
+
+func (c *StreamClient) readRangeEntriesToChannel(to uint64) error {
+	c.stopReadingToChannel.Store(false)
+
+	// Send start command
+	toEntry, err := c.initiateRangeDownload(to)
+	if err != nil {
+		return err
+	}
+
+	err = c.readRangeFullL2BlocksToChannel(toEntry)
+	c.setStreaming(false)
+
+	if err != nil {
+		return fmt.Errorf("readRangeFullL2BlocksToChannel: %w", err)
+	}
+
+	return nil
+}
+
 // runs the prerequisites for entries download
 func (c *StreamClient) initiateDownloadBookmark(bookmark []byte) (*types.ResultEntry, error) {
 	if err := c.stopStreaming(); err != nil {
@@ -505,6 +545,27 @@ func (c *StreamClient) initiateDownloadBookmark(bookmark []byte) (*types.ResultE
 	// send CmdStartBookmark command
 	if err := c.sendBookmarkCmd(bookmark, true); err != nil {
 		return nil, fmt.Errorf("sendBookmarkCmd: %w", err)
+	}
+
+	c.setStreaming(true)
+
+	re, err := c.afterStartCommand()
+	if err != nil {
+		return re, fmt.Errorf("afterStartCommand: %w", err)
+	}
+
+	return re, nil
+}
+
+// Runs the prerequisites for range entries download (excluding end)
+func (c *StreamClient) initiateRangeDownloadBookmark(startBookmark []byte, endBookmark []byte) (*types.ResultEntry, error) {
+	if err := c.stopStreaming(); err != nil {
+		return nil, fmt.Errorf("stopStreaming: %w", err)
+	}
+
+	// send CmdStartBookmark command
+	if err := c.sendRangeBookmarkCmd(startBookmark, endBookmark); err != nil {
+		return nil, fmt.Errorf("sendRangeBookmarkCmd: %w", err)
 	}
 
 	c.setStreaming(true)
@@ -547,7 +608,7 @@ LOOP:
 		if readNewProto {
 			if parsedProto, entryNum, err = ReadParsedProto(c); err != nil {
 				if err == ErrReachedEntryNumberLimit {
-					return c.trySendStopSignal()
+					return c.TrySendStopSignal()
 				}
 				return err
 			}
@@ -579,7 +640,7 @@ LOOP:
 		if c.header.TotalEntries == entryNum+1 {
 			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
 
-			if err := c.trySendStopSignal(); err != nil {
+			if err := c.TrySendStopSignal(); err != nil {
 				return err
 			}
 			break LOOP
@@ -589,7 +650,106 @@ LOOP:
 	return nil
 }
 
-func (c *StreamClient) trySendStopSignal() error {
+// Read all entries from the server until the end of the range toBlock.
+// Parses the data into FullL2Blocks with transactions and sends them to a channel
+func (c *StreamClient) readRangeFullL2BlocksToChannel(toEntry uint64) (err error) {
+	readNewProto := true
+	entryNum := uint64(0)
+	parsedProto := interface{}(nil)
+LOOP:
+	for {
+		select {
+		default:
+		case <-c.ctx.Done():
+			return fmt.Errorf("context done - stopping")
+		}
+
+		if c.stopReadingToChannel.Load() {
+			break LOOP
+		}
+
+		if err := c.resetReadTimeout(); err != nil {
+			return err
+		}
+
+		if readNewProto {
+			if parsedProto, entryNum, err = ReadParsedProto(c); err != nil {
+				if err == ErrReachedEntryNumberLimit {
+					return c.TrySendStopSignal()
+				}
+				return err
+			}
+			readNewProto = false
+		}
+		c.lastWrittenTime.Store(time.Now().UnixNano())
+
+		switch parsedProto := parsedProto.(type) {
+		case *types.BookmarkProto:
+			readNewProto = true
+			continue
+		case *types.BatchStart:
+			c.currentFork = parsedProto.ForkId
+		case *types.GerUpdate:
+		case *types.BatchEnd:
+		case *types.FullL2Block:
+			parsedProto.ForkId = c.currentFork
+			log.Trace("[Datastream client] writing block to channel", "blockNumber", parsedProto.L2BlockNumber, "batchNumber", parsedProto.BatchNumber)
+		default:
+			return fmt.Errorf("unexpected entry type: %v", parsedProto)
+		}
+		select {
+		case c.entryChan <- parsedProto:
+			readNewProto = true
+		default:
+			time.Sleep(10 * time.Microsecond)
+		}
+
+		// Reach the end of range
+		if entryNum == toEntry || c.header.TotalEntries == entryNum+1 {
+			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
+
+			if err := c.TrySendStopSignal(); err != nil {
+				return err
+			}
+			break LOOP
+		}
+	}
+
+	return nil
+}
+
+func (c *StreamClient) initiateRangeDownload(to uint64) (uint64, error) {
+	var start *types.BookmarkProto
+	progress := c.progress.Load()
+	if progress == 0 {
+		start = types.NewBookmarkProto(0, datastream.BookmarkType_BOOKMARK_TYPE_BATCH)
+	} else {
+		start = types.NewBookmarkProto(progress+1, datastream.BookmarkType_BOOKMARK_TYPE_L2_BLOCK)
+	}
+
+	sb, err := start.Marshal()
+	if err != nil {
+		return 0, err
+	}
+
+	end := types.NewBookmarkProto(to, datastream.BookmarkType_BOOKMARK_TYPE_L2_BLOCK)
+	eb, err := end.Marshal()
+	if err != nil {
+		return 0, err
+	}
+
+	if _, err := c.initiateRangeDownloadBookmark(sb, eb); err != nil {
+		return 0, fmt.Errorf("initiateRangeDownloadBookmark: %w", err)
+	}
+
+	packet, err := c.readBuffer(8)
+	if err != nil {
+		return 0, err
+	}
+	return types.UnmarshalToEntryNumber(packet)
+}
+
+func (c *StreamClient) TrySendStopSignal() error {
 	retries := 0
 	for {
 		select {
@@ -626,6 +786,10 @@ func (c *StreamClient) HandleStart() error {
 	}
 
 	return nil
+}
+
+func (c *StreamClient) HandleRestart() error {
+	return c.tryReConnect()
 }
 
 func (c *StreamClient) tryReConnect() (err error) {

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -242,9 +242,9 @@ func (c *StreamClient) stopStreaming() error {
 }
 
 func (c *StreamClient) getLatestL2Block() (l2Block *types.FullL2Block, err error) {
-	h, err := c.GetHeader()
+	h, err := c.getHeader()
 	if err != nil {
-		return nil, fmt.Errorf("GetHeader: %w", err)
+		return nil, fmt.Errorf("getHeader: %w", err)
 	}
 
 	latestEntryNum := h.TotalEntries - 1
@@ -309,10 +309,26 @@ func (c *StreamClient) Stop() error {
 	return nil
 }
 
+func (c *StreamClient) GetHeader() (*types.HeaderEntry, error) {
+	select {
+	case <-c.ctx.Done():
+		return nil, errors.New("context done - stopping")
+	default:
+	}
+
+	header, err := c.getHeader()
+	if err != nil {
+		c.lastError = err
+		return nil, err
+	}
+
+	return header, nil
+}
+
 // Command header: Get status
 // Returns the current status of the header.
 // If started, terminate the connection.
-func (c *StreamClient) GetHeader() (*types.HeaderEntry, error) {
+func (c *StreamClient) getHeader() (*types.HeaderEntry, error) {
 	log.Debug("[Datastream client] Getting header")
 	if err := c.stopStreaming(); err != nil {
 		return nil, fmt.Errorf("stopStreaming: %w", err)
@@ -365,9 +381,9 @@ func (c *StreamClient) sendEntryCmdWrapper(entryNum uint64) error {
 
 func (c *StreamClient) ExecutePerFile(bookmark *types.BookmarkProto, function func(file *types.FileEntry) error) error {
 	// Get header from server
-	header, err := c.GetHeader()
+	header, err := c.getHeader()
 	if err != nil {
-		return fmt.Errorf("GetHeader: %w", err)
+		return fmt.Errorf("getHeader: %w", err)
 	}
 
 	protoBookmark, err := bookmark.Marshal()
@@ -454,8 +470,8 @@ func (c *StreamClient) ReadAllEntriesToChannel() (err error) {
 	}
 
 	// first load up the header of the stream
-	if _, err = c.GetHeader(); err != nil {
-		err = fmt.Errorf("GetHeader: %w", err)
+	if _, err = c.getHeader(); err != nil {
+		err = fmt.Errorf("getHeader: %w", err)
 		return err
 	}
 

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -674,9 +674,6 @@ LOOP:
 
 		if readNewProto {
 			if parsedProto, entryNum, err = ReadParsedProto(c); err != nil {
-				if err == ErrReachedEntryNumberLimit {
-					return c.TrySendStopSignal()
-				}
 				return err
 			}
 			readNewProto = false
@@ -704,13 +701,9 @@ LOOP:
 			time.Sleep(10 * time.Microsecond)
 		}
 
-		// Reach the end of range
+		// Reach the end of range. Do not send stop signal here as range read may continue
 		if entryNum == toEntry || c.header.TotalEntries == entryNum+1 {
-			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
-
-			if err := c.TrySendStopSignal(); err != nil {
-				return err
-			}
+			log.Trace("[Datastream client] reached the current end of the range read", "toEntry", toEntry, "entryNum", entryNum, "header_totalEntries", c.header.TotalEntries)
 			break LOOP
 		}
 	}
@@ -786,10 +779,6 @@ func (c *StreamClient) HandleStart() error {
 	}
 
 	return nil
-}
-
-func (c *StreamClient) HandleRestart() error {
-	return c.tryReConnect()
 }
 
 func (c *StreamClient) tryReConnect() (err error) {

--- a/zk/datastream/types/file.go
+++ b/zk/datastream/types/file.go
@@ -97,3 +97,7 @@ func DecodeFileEntry(b []byte) (*FileEntry, error) {
 		Data:       data,
 	}, nil
 }
+
+func UnmarshalToEntryNumber(data []byte) (uint64, error) {
+	return binary.BigEndian.Uint64(data[:8]), nil
+}

--- a/zk/stages/stage_batches.go
+++ b/zk/stages/stage_batches.go
@@ -62,14 +62,18 @@ type DatastreamClient interface {
 	RenewEntryChannel()
 	RenewMaxEntryChannel()
 	ReadAllEntriesToChannel() error
+	ReadRangeEntriesToChannel(to uint64) error
 	StopReadingToChannel()
 	GetEntryChan() *chan interface{}
+	GetHeader() (*types.HeaderEntry, error)
 	GetL2BlockByNumber(blockNum uint64) (*types.FullL2Block, error)
 	GetLatestL2Block() (*types.FullL2Block, error)
 	GetProgressAtomic() *atomic.Uint64
 	Start() error
 	Stop() error
 	HandleStart() error
+	HandleRestart() error
+	TrySendStopSignal() error
 }
 
 type dsClientCreatorHandler func(context.Context, *ethconfig.Zk, uint64) (DatastreamClient, error)
@@ -291,16 +295,21 @@ func SpawnStageBatches(
 		return fmt.Errorf("NewBatchesProcessor: %w", err)
 	}
 
-	// start routine to download blocks and push them in a channel
+	// Set maximum block range to be 50% of the entry channel capacity
+	diffBlock := highestDSL2Block - stageProgressBlockNo
+	if diffBlock > client.DefaultEntryChannelSize {
+		dsQueryClient.RenewMaxEntryChannel()
+	} else {
+		dsQueryClient.RenewEntryChannel()
+	}
+	entryChan := dsQueryClient.GetEntryChan()
+	blockRange := uint64(cap(*entryChan) / 2)
+
+	// start routine to download blocks and push them to the channel
 	errorChan := make(chan struct{})
 	dsClientRunner := NewDatastreamClientRunner(dsQueryClient, logPrefix)
-	err = dsClientRunner.StartRead(errorChan, highestDSL2Block-stageProgressBlockNo)
-	if err != nil {
-		return fmt.Errorf("StartRead: %w", err)
-	}
+	dsClientRunner.StartRangeRead(errorChan, highestDSL2Block, blockRange)
 	defer dsClientRunner.StopRead()
-
-	entryChan := dsQueryClient.GetEntryChan()
 
 	prevAmountBlocksWritten := uint64(0)
 	endLoop := false

--- a/zk/stages/stage_batches.go
+++ b/zk/stages/stage_batches.go
@@ -72,7 +72,6 @@ type DatastreamClient interface {
 	Start() error
 	Stop() error
 	HandleStart() error
-	HandleRestart() error
 	TrySendStopSignal() error
 }
 

--- a/zk/stages/stage_batches_datastream.go
+++ b/zk/stages/stage_batches_datastream.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/erigontech/erigon-lib/log/v3"
-	"github.com/erigontech/erigon/zk/datastream/client"
 )
 
 type DatastreamClientRunner struct {
@@ -24,13 +23,7 @@ func NewDatastreamClientRunner(dsClient DatastreamClient, logPrefix string) *Dat
 	}
 }
 
-func (r *DatastreamClientRunner) StartRead(errorChan chan struct{}, diffBlock uint64) error {
-	if diffBlock > client.DefaultEntryChannelSize {
-		r.dsClient.RenewMaxEntryChannel()
-	} else {
-		r.dsClient.RenewEntryChannel()
-	}
-
+func (r *DatastreamClientRunner) StartRead(errorChan chan struct{}) error {
 	if r.isReading.Load() {
 		return fmt.Errorf("tried starting datastream client runner thread while another is running")
 	}
@@ -53,6 +46,72 @@ func (r *DatastreamClientRunner) StartRead(errorChan chan struct{}, diffBlock ui
 			}
 			errorChan <- struct{}{}
 			log.Warn(fmt.Sprintf("[%s] Error downloading blocks from datastream", r.logPrefix), "error", err)
+		}
+	}()
+
+	return nil
+}
+
+func (r *DatastreamClientRunner) StartRangeRead(
+	errorChan chan struct{},
+	highestDSL2Block uint64,
+	blockRange uint64,
+) error {
+	if r.isReading.Load() {
+		return fmt.Errorf("tried starting datastream client runner thread while another is running")
+	}
+
+	r.stopRunner.Store(false)
+
+	entryChan := r.dsClient.GetEntryChan()
+
+	go func() {
+		routineId := rand.Intn(1000000)
+
+		log.Info(fmt.Sprintf("[%s] Started downloading L2Blocks routine ID: %d", r.logPrefix, routineId))
+		defer log.Info(fmt.Sprintf("[%s] Ended downloading L2Blocks routine ID: %d", r.logPrefix, routineId))
+
+		r.isReading.Store(true)
+		defer r.isReading.Store(false)
+
+		// first load up the header of the stream
+		if _, err := r.dsClient.GetHeader(); err != nil {
+			errorChan <- struct{}{}
+			log.Warn(fmt.Sprintf("[%s] Error getting block header from datastream", r.logPrefix), "error", err)
+			return
+		}
+
+		progress := r.dsClient.GetProgressAtomic()
+		for !r.stopRunner.Load() {
+			// Wait until all entries in entryChan is consumed
+			for len(*entryChan) > 0 {
+				time.Sleep(100 * time.Millisecond)
+				if r.stopRunner.Load() {
+					return
+				}
+			}
+
+			from := progress.Load()
+			if from >= highestDSL2Block {
+				return
+			}
+
+			to := min(from+blockRange, highestDSL2Block)
+			r.dsClient.HandleRestart()
+			if err := r.dsClient.ReadRangeEntriesToChannel(to); err != nil {
+				time.Sleep(1 * time.Second)
+				errorChan <- struct{}{}
+				log.Warn(fmt.Sprintf("[%s] Error downloading blocks from datastream", r.logPrefix), "error", err)
+				return
+			}
+		}
+
+		// Send stop signal
+		if err := r.dsClient.TrySendStopSignal(); err != nil {
+			time.Sleep(1 * time.Second)
+			errorChan <- struct{}{}
+			log.Warn(fmt.Sprintf("[%s] Error sending stop signal", r.logPrefix), "error", err)
+			return
 		}
 	}()
 

--- a/zk/stages/stage_batches_datastream.go
+++ b/zk/stages/stage_batches_datastream.go
@@ -81,6 +81,7 @@ func (r *DatastreamClientRunner) StartRangeRead(
 			return
 		}
 
+		errorFlag := false
 		progress := r.dsClient.GetProgressAtomic()
 		for !r.stopRunner.Load() {
 			// Wait until all entries in entryChan is consumed
@@ -91,18 +92,33 @@ func (r *DatastreamClientRunner) StartRangeRead(
 				}
 			}
 
+			// Check for conn health
+			if err := r.dsClient.HandleStart(); err != nil {
+				time.Sleep(1 * time.Second)
+				errorChan <- struct{}{}
+				log.Warn(fmt.Sprintf("[%s] Error on handle start datastream connection", r.logPrefix), "error", err)
+				return
+			}
+
 			from := progress.Load()
 			if from >= highestDSL2Block {
 				return
 			}
 
 			to := min(from+blockRange, highestDSL2Block)
-			r.dsClient.HandleRestart()
 			if err := r.dsClient.ReadRangeEntriesToChannel(to); err != nil {
-				time.Sleep(1 * time.Second)
-				errorChan <- struct{}{}
-				log.Warn(fmt.Sprintf("[%s] Error downloading blocks from datastream", r.logPrefix), "error", err)
-				return
+				if !errorFlag {
+					// Try to reconnect and get range again
+					errorFlag = true
+					continue
+				} else {
+					time.Sleep(1 * time.Second)
+					errorChan <- struct{}{}
+					log.Warn(fmt.Sprintf("[%s] Error downloading blocks from datastream", r.logPrefix), "error", err)
+					return
+				}
+			} else {
+				errorFlag = false
 			}
 		}
 

--- a/zk/stages/stage_batches_datastream.go
+++ b/zk/stages/stage_batches_datastream.go
@@ -102,7 +102,7 @@ func (r *DatastreamClientRunner) StartRangeRead(
 
 			from := progress.Load()
 			if from >= highestDSL2Block {
-				return
+				break
 			}
 
 			to := min(from+blockRange, highestDSL2Block)

--- a/zk/stages/test_utils.go
+++ b/zk/stages/test_utils.go
@@ -51,6 +51,10 @@ func (c *TestDatastreamClient) ReadAllEntriesToChannel() error {
 	return nil
 }
 
+func (c *TestDatastreamClient) ReadRangeEntriesToChannel(from uint64, to uint64) error {
+	return nil
+}
+
 func (c *TestDatastreamClient) RenewEntryChannel() {
 }
 
@@ -63,6 +67,10 @@ func (c *TestDatastreamClient) StopReadingToChannel() {
 
 func (c *TestDatastreamClient) GetEntryChan() *chan interface{} {
 	return &c.entriesChan
+}
+
+func (c *TestDatastreamClient) GetHeader() (*types.HeaderEntry, error) {
+	return nil, nil
 }
 
 func (c *TestDatastreamClient) GetErrChan() chan error {
@@ -113,5 +121,13 @@ func (c *TestDatastreamClient) PrepUnwind() {
 }
 
 func (c *TestDatastreamClient) HandleStart() error {
+	return nil
+}
+
+func (c *TestDatastreamClient) HandleRestart() error {
+	return nil
+}
+
+func (c *TestDatastreamClient) TrySendStopSignal() error {
 	return nil
 }

--- a/zk/stages/test_utils.go
+++ b/zk/stages/test_utils.go
@@ -51,7 +51,7 @@ func (c *TestDatastreamClient) ReadAllEntriesToChannel() error {
 	return nil
 }
 
-func (c *TestDatastreamClient) ReadRangeEntriesToChannel(from uint64, to uint64) error {
+func (c *TestDatastreamClient) ReadRangeEntriesToChannel(to uint64) error {
 	return nil
 }
 

--- a/zk/stages/test_utils.go
+++ b/zk/stages/test_utils.go
@@ -124,10 +124,6 @@ func (c *TestDatastreamClient) HandleStart() error {
 	return nil
 }
 
-func (c *TestDatastreamClient) HandleRestart() error {
-	return nil
-}
-
 func (c *TestDatastreamClient) TrySendStopSignal() error {
 	return nil
 }


### PR DESCRIPTION
## Summary

### Context
- https://github.com/0xPolygonHermez/cdk-erigon/issues/1847
- Although PR #1851 resolved the error propagation issue of the data stream, it still does not resolve the issue completely because the underlying unreliable TCP stream may still break midway
- Due to L2 block data being stored in multipled nested file entries (such as transaction data, etc), when the stream is broken midway, we cannot deterministically confirm at which point the stream is broken and cause issues with de-serializing file data into L2 block data
- 

### Changes
- Combined with the changes on the data-streamer server: https://github.com/0xPolygon/zkevm-data-streamer/pull/158
- This PR supports batch downloading of the L2 block data from the datastreamer using the new range DS block download, with the CmdStartEndBookmark request
- Adds the range download into the sync logic - when the requested download block range is very large (such as syncing from genesis, etc), we will use block ranges to resolve the bottleneck issue of consuming file entries from the entryChan (which causes I/O timeouts)
- This PR (and the DS PR) changes has been tested to work with xlayer-erigon