### PR TITLE
chore: docker alpine dependency updated to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.2
-FROM docker.io/library/golang:1.23-alpine3.20 AS builder
+FROM docker.io/library/golang:1.23-alpine AS builder
 
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache \
     make BUILD_TAGS=nosqlite,noboltdb,nosilkworm all
 
 
-FROM docker.io/library/golang:1.23-alpine3.20 AS tools-builder
+FROM docker.io/library/golang:1.23-alpine AS tools-builder
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 WORKDIR /app
 
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod \
     make db-tools
 
-FROM docker.io/library/alpine:3.20
+FROM docker.io/library/alpine:latest
 
 # install required runtime libs, along with some helpers for debugging
 RUN apk add --no-cache ca-certificates libstdc++ tzdata

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache \
     make all
 
 
-FROM docker.io/library/golang:1.23-alpine3.20 AS tools-builder
+FROM docker.io/library/golang:1.23-alpine AS tools-builder
 
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 WORKDIR /app

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.2
-FROM docker.io/library/golang:1.23-alpine3.20 AS builder
+FROM docker.io/library/golang:1.23-alpine AS builder
 
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod \
     make BUILD_TAGS=nosqlite,noboltdb,nosilkworm cdk-erigon
 
-FROM docker.io/library/alpine:3.20
+FROM docker.io/library/alpine:latest
 
 # install required runtime libs, along with some helpers for debugging
 RUN apk add --no-cache ca-certificates libstdc++ tzdata

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,6 +1,6 @@
-ARG RELEASE_DOCKER_BASE_IMAGE="alpine:3.20.6" \
+ARG RELEASE_DOCKER_BASE_IMAGE="alpine:latest" \
     CI_CD_MAIN_BUILDER_IMAGE="golang:1.23-bookworm" \
-    CI_CD_MAIN_TARGET_BASE_IMAGE="alpine:3.20.6" \
+    CI_CD_MAIN_TARGET_BASE_IMAGE="alpine:latest" \
     UID_ERIGON=1000 \
     GID_ERIGON=1000 \
     EXPOSED_PORTS="8545 \
@@ -55,7 +55,7 @@ RUN --mount=type=bind,from=temporary,source=/tmp/${APPLICATION},target=/tmp/${AP
         echo "Installing libsilkworm_capi.so library to /lib/x86_64-linux-gnu/ in case amd64 architecture:"; \
         find /tmp/${APPLICATION} -name libsilkworm_capi.so -type f | xargs -I % install -m a=r -v % /lib/x86_64-linux-gnu/; \
         echo "Done." ; \
-    fi && \    
+    fi && \
     install -d -o ${USER} -g ${GROUP} /home/${USER}/.local /home/${USER}/.local/share /home/${USER}/.local/share/erigon && \
     install -o root -g root /tmp/${APPLICATION}/cdk-erigon /usr/local/bin/ && \
     install -o root -g root /tmp/${APPLICATION}/integration /usr/local/bin/ && \

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.2
-FROM docker.io/library/golang:1.23-alpine3.20 AS builder
+FROM docker.io/library/golang:1.23-alpine AS builder
 
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache \
     make all
 
 
-FROM docker.io/library/golang:1.23-alpine3.20 AS tools-builder
+FROM docker.io/library/golang:1.23-alpine AS tools-builder
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 WORKDIR /app
 
@@ -27,7 +27,7 @@ ADD go.sum go.sum
 
 RUN mkdir -p /app/build/bin
 
-FROM docker.io/library/alpine:3.20
+FROM docker.io/library/alpine:latest
 
 # install required runtime libs, along with some helpers for debugging
 RUN apk add --no-cache ca-certificates libstdc++ tzdata


### PR DESCRIPTION
More information about the security vulnerability can be found here:
https://security.alpinelinux.org/vuln/CVE-2025-31498

We've updated the Dockerfiles to use alpine:latest instead of a specific version (e.g., alpine:3.20) to simplify maintenance and ensure that our base image always receives the latest security updates and patches by default. This approach reduces the need for manual updates to the base image tag whenever new Alpine releases come out, which in turn minimizes the risk of running containers on outdated or vulnerable OS layers.

While pinning to a specific version offers more deterministic builds, in this context we’ve opted for latest because:
- Security: Automatically benefits from the latest CVE patches without manual intervention.
- Operational Overhead: Reduces the need to track and upgrade Alpine versions across multiple Dockerfiles.
- Compatibility: Our application and dependencies are already tested and resilient across minor Alpine version changes.

We’ll continue to monitor for breaking changes, but overall, this change helps us stay current and secure with less effort.