### PR TITLE
fix: block stuck on nonce too high if the only tx in the pool

### DIFF
--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -502,6 +502,13 @@ func sequencingBatchStep(
 						continue
 					}
 
+					// if we have an error at this point something has gone wrong, either in the pool or otherwise
+					// to stop the pool growing and hampering further processing of good transactions here
+					// we mark it for being discarded
+					log.Warn(fmt.Sprintf("[%s] error adding transaction to batch, discarding from pool", logPrefix), "hash", txHash, "err", err)
+					badTxHashes = append(badTxHashes, txHash)
+					batchState.blockState.transactionsToDiscard = append(batchState.blockState.transactionsToDiscard, batchState.blockState.transactionHashesToSlots[txHash])
+
 					if errors.Is(err, core.ErrNonceTooHigh) || errors.Is(err, core.ErrNonceTooLow) {
 						// here we have a case where some situation has caused a nonce issue to find its way into the pending pool
 						// we want to skip transactions for this sender in this batch for now and ask the pool to trigger a sender
@@ -512,13 +519,6 @@ func sequencingBatchStep(
 						sendersToTriggerStatechanges[txSender] = struct{}{}
 						continue
 					}
-
-					// if we have an error at this point something has gone wrong, either in the pool or otherwise
-					// to stop the pool growing and hampering further processing of good transactions here
-					// we mark it for being discarded
-					log.Warn(fmt.Sprintf("[%s] error adding transaction to batch, discarding from pool", logPrefix), "hash", txHash, "err", err)
-					badTxHashes = append(badTxHashes, txHash)
-					batchState.blockState.transactionsToDiscard = append(batchState.blockState.transactionsToDiscard, batchState.blockState.transactionHashesToSlots[txHash])
 				}
 
 				switch anyOverflow {

--- a/zk/stages/stage_sequence_execute_state.go
+++ b/zk/stages/stage_sequence_execute_state.go
@@ -310,6 +310,7 @@ func (bbe *BuiltBlockElements) resetBlockBuildingArrays() {
 	bbe.receipts = types.Receipts{}
 	bbe.effectiveGases = []uint8{}
 	bbe.executionResults = []*evmtypes.ExecutionResult{}
+	bbe.txSlots = []common.Hash{}
 }
 
 func (bbe *BuiltBlockElements) onFinishAddingTransaction(transaction types.Transaction, receipt *types.Receipt, execResult *evmtypes.ExecutionResult, effectiveGas uint8, slotId common.Hash) {


### PR DESCRIPTION
Fixes #1877 by adding the NonceTooHigh tx into badTxs that are disarded and removed from txs for inclusion, and the block is closed OK.

The fix verified manually with code changes that add tx to pending pool instead of queued and disable promotion/demotion of txs from the pools.

Ran anansi to stress test the pool and verified that it was cleared OK (no pending txs in the pool) after load testing stops.

Side fix: clear txSlots on blockState reset