### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # .github/CODEOWNERS
-* @revitteth @hexoscott @mandrigin @eduadiez
+* @revitteth @hexoscott @mandrigin @eduadiez @ppttf


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to include a new code owner.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L2-R2): Added `@ppttf` to the list of code owners.
[Copilot is generating a summary...]