### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # .github/CODEOWNERS
 * @revitteth @hexoscott @mandrigin @eduadiez
+zk/datastream @ppttf
+zk/stages @ppttf


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to assign ownership of specific directories to a new team.

Ownership updates:

* Assigned the `zk/datastream` and `zk/stages` directories to the `@ppttf` team in the `.github/CODEOWNERS` file.