### PR TITLE
Fix StageLoopIteration

### DIFF
--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -108,7 +108,7 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 	}() // avoid crash because Erigon's core does many things
 
 	externalTx := txc.Tx != nil
-	finishProgressBefore, borProgressBefore, headersProgressBefore, err := stagesHeadersAndFinish(db, txc.Tx)
+	headersProgressBefore, borProgressBefore, finishProgressBefore, err := stagesHeadersAndFinish(db, txc.Tx)
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 	// - Prune(limited time)+Commit(sync). Write to disk happening here.
 
 	if hook != nil {
-		if err = hook.BeforeRun(txc.Tx, isSynced); err != nil {
+		if err = hook.BeforeRun(txc.Tx, !isSynced); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This Pr fixes two issues with StageLoopIteration:
1. The order of the return values ​​of `stagesHeadersAndFinish` is incorrect;
2. [This line](https://github.com/okx/xlayer-erigon/blob/0937a7b6354058c51e272d17450e07b2e1bf86f9/turbo/stages/stageloop.go#L137) passes `isSynced` as a parameter of `hook.BeforeRun`, but `BeforeRun` requires `inSync`, so I think `!isSynced` should be passed here. This problem may cause the unwindTxs to fail to be added to the txpool when the Sequencer is unwinded, because `notifications.Accumulator `will directly call `Reset` instead of `SendAndReset`;