### PR TITLE
fix block stuck

### DIFF
--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -256,6 +256,8 @@ func sequencingBatchStep(
 	// until the next batch starts
 	sendersToSkip := make(map[common.Address]struct{})
 
+	breakBatchLoop := false
+BatchLoop:
 	for blockNumber := executionAt + 1; runLoopBlocks; blockNumber++ {
 		if batchTimedOut {
 			log.Debug(fmt.Sprintf("[%s] Closing batch due to timeout", logPrefix))
@@ -675,8 +677,8 @@ func sequencingBatchStep(
 		// this could happen if there were lots of nonce issues from transaction in the pool due to a failed tx processing or similar and
 		// there wasn't much time left in the batch to mine any transactions
 		if len(batchState.blockState.transactionsForInclusion) > 0 && len(batchState.blockState.builtBlockElements.transactions) == 0 {
-			log.Info(fmt.Sprintf("[%s] Skipping block: no transactions mined in block %d, skipping block for now", logPrefix, blockNumber))
-			break
+			log.Warn(fmt.Sprintf("[%s] Closing batch to keep liveness when encountering empty block %d", logPrefix, blockNumber))
+			breakBatchLoop = true
 		}
 
 		if block, err = doFinishBlockAndUpdateState(batchContext, ibs, header, parentBlock, batchState, ger, l1BlockHash, l1TreeUpdateIndex, infoTreeIndexProgress, batchCounters); err != nil {
@@ -763,6 +765,10 @@ func sequencingBatchStep(
 		// was the previous block created
 		if err := cfg.doneHook.AfterRun(batchContext.sdb.tx, block.NumberU64()-1, s.PrevUnwindPoint()); err != nil {
 			return err
+		}
+
+		if breakBatchLoop {
+			break BatchLoop
 		}
 	}
 

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -2825,6 +2825,11 @@ func (mt *metaTx) better(than *metaTx, pendingBaseFee uint256.Int) bool {
 	if than.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
 		thanSubPool |= EnoughFeeCapBlock
 	}
+
+	if mt.Tx.SenderID == than.Tx.SenderID && mt.Tx.Nonce != than.Tx.Nonce {
+		return mt.Tx.Nonce < than.Tx.Nonce
+	}
+
 	if subPool != thanSubPool {
 		return subPool > thanSubPool
 	}

--- a/zk/txpool/pool_zk.go
+++ b/zk/txpool/pool_zk.go
@@ -53,6 +53,7 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 		if mt.Tx.Traced {
 			log.Info(fmt.Sprintf("TX TRACING: onSenderStateChange loop iteration idHash=%x senderID=%d, senderNonce=%d, txn.nonce=%d, currentSubPool=%s", mt.Tx.IDHash, senderID, senderNonce, mt.Tx.Nonce, mt.currentSubPool))
 		}
+		mt.subPool |= IsLocal
 		if senderNonce > mt.Tx.Nonce {
 			if mt.Tx.Traced {
 				log.Info(fmt.Sprintf("TX TRACING: removing due to low nonce for idHash=%x senderID=%d, senderNonce=%d, txn.nonce=%d, currentSubPool=%s", mt.Tx.IDHash, senderID, senderNonce, mt.Tx.Nonce, mt.currentSubPool))


### PR DESCRIPTION
Fix issue #1877 and be an alternative to #1890 

1. Close the batch to let `addTxsOnNewBlock` to promote the txpool txs if `nonce too high` issue occurs.
2. We met some txs' subPool value is 111100 (not IsLocal), which we think is not normal for L2 architecture, so we enforce them to be 1 during `onSenderStateChange`
3. We put higher priority on the nonce for the same sender, which should make sense.

p.s. Even we did the 2nd and 3th modifications on XLayer, we still may run into occasional `nonce too high` issue. But with the 1st modification, no block stuck and all txs can be executed normally while stress testing with arbitaray nonces.