### PR TITLE
Zkevm info tree fixes

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -75,6 +75,8 @@ var (
 	output      = flag.String("output", "", "output path")
 	cfglocation = flag.String("cfglocation", "", "where the dynamic config files are located")
 	chain       = flag.String("chain", "", "name of chain used for zkcfgmerge")
+	key         = flag.Int("key", 1, "key to use from a table")
+	offset      = flag.Int("offset", 0, "offset to apply")
 )
 
 func dbSlice(chaindata string, bucket string, prefix []byte) {
@@ -1610,6 +1612,8 @@ func main() {
 		err = dumpAll(*chaindata, *output)
 	case "zkCfgMerge":
 		err = mergeZkConfig(*cfglocation, *chain, *output)
+	case "infoTreeChange":
+		err = infoTreeChange(*chaindata, key, offset)
 	}
 
 	if err != nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -610,10 +610,16 @@ var (
 		Name:  "zkevm.sequencer-decoded-tx-cache-ttl",
 		Usage: "Sequencer decoded transaction cache time-to-live",
 		Value: 600 * time.Second,
+	}
 	SequencerResequenceInfoTreeOffset = cli.StringFlag{
 		Name:  "zkevm.sequencer-resequence-info-tree-offset",
 		Usage: "A tuple describing an info tree offset to use during resequencing.  Designed to recover from a skipped leaf in the info tree.  Format <index>:<offset>:<expected_ger_hash>",
 		Value: "",
+	}
+	AlwaysGenerateBatchL2Data = cli.BoolFlag{
+		Name:  "zkevm.always-generate-batch-l2-data",
+		Usage: "Always generate the batch L2 data",
+		Value: true,
 	}
 	ExecutorUrls = cli.StringFlag{
 		Name:  "zkevm.executor-urls",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -610,6 +610,10 @@ var (
 		Name:  "zkevm.sequencer-decoded-tx-cache-ttl",
 		Usage: "Sequencer decoded transaction cache time-to-live",
 		Value: 600 * time.Second,
+	SequencerResequenceInfoTreeOffset = cli.StringFlag{
+		Name:  "zkevm.sequencer-resequence-info-tree-offset",
+		Usage: "A tuple describing an info tree offset to use during resequencing.  Designed to recover from a skipped leaf in the info tree.  Format <index>:<offset>:<expected_ger_hash>",
+		Value: "",
 	}
 	ExecutorUrls = cli.StringFlag{
 		Name:  "zkevm.executor-urls",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -51,6 +51,7 @@ type Zk struct {
 	SequencerResequenceReuseL1InfoIndex    bool
 	SequencerDecodedTxCacheSize            int
 	SequencerDecodedTxCacheTTL             time.Duration
+	SequencerResequenceInfoTreeOffset      *L1InfoTreeOffset
 	ExecutorUrls                           []string
 	ExecutorStrictMode                     bool
 	ExecutorRequestTimeout                 time.Duration
@@ -205,4 +206,10 @@ func (c *Zk) UsingHermezHardfork() bool {
 
 func (c *Zk) UsingEthereumHardfork() bool {
 	return c.Hardfork == HardforkTypeEthereum
+}
+
+type L1InfoTreeOffset struct {
+	Index           uint64
+	Offset          int64
+	ExpectedGerHash common.Hash
 }

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -117,6 +117,7 @@ type Zk struct {
 	WitnessCacheBatchAheadOffset   uint64
 	WitnessCacheBatchBehindOffset  uint64
 	WitnessContractInclusion       []common.Address
+	AlwaysGenerateBatchL2Data      bool
 	RejectLowGasPriceTransactions  bool
 	RejectLowGasPriceTolerance     float64
 	LogLevel                       log.Lvl

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -224,6 +224,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.SequencerResequenceReuseL1InfoIndex,
 	&utils.SequencerDecodedTxCacheSize,
 	&utils.SequencerDecodedTxCacheTTL,
+	&utils.SequencerResequenceInfoTreeOffset,
 	&utils.ExecutorUrls,
 	&utils.ExecutorStrictMode,
 	&utils.ExecutorRequestTimeout,

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -225,6 +225,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.SequencerDecodedTxCacheSize,
 	&utils.SequencerDecodedTxCacheTTL,
 	&utils.SequencerResequenceInfoTreeOffset,
+	&utils.AlwaysGenerateBatchL2Data,
 	&utils.ExecutorUrls,
 	&utils.ExecutorStrictMode,
 	&utils.ExecutorRequestTimeout,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -317,6 +317,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		WitnessCacheBatchAheadOffset:           ctx.Uint64(utils.WitnessCacheBatchAheadOffset.Name),
 		WitnessCacheBatchBehindOffset:          ctx.Uint64(utils.WitnessCacheBatchBehindOffset.Name),
 		WitnessContractInclusion:               witnessInclusion,
+		AlwaysGenerateBatchL2Data:              ctx.Bool(utils.AlwaysGenerateBatchL2Data.Name),
 		GasPriceCheckFrequency:                 ctx.Duration(utils.GasPriceCheckFrequency.Name),
 		GasPriceHistoryCount:                   ctx.Uint64(utils.GasPriceHistoryCount.Name),
 		RejectLowGasPriceTransactions:          ctx.Bool(utils.RejectLowGasPriceTransactions.Name),

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"net"
@@ -187,6 +188,39 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		panic(fmt.Sprintf("Invalid commitment: %s. Must be one of: %s", ctx.String(utils.Commitment.Name), commitment.ValidCommitments()))
 	}
 
+	var l1InfoTreeOffset *ethconfig.L1InfoTreeOffset
+	infoTreeOffsetStr := ctx.String(utils.SequencerResequenceInfoTreeOffset.Name)
+	if infoTreeOffsetStr != "" {
+		parts := strings.Split(infoTreeOffsetStr, ":")
+		if len(parts) != 3 {
+			panic(fmt.Sprintf("Invalid info tree offset format: %s, should be <index>:<offset>:<expected_ger_hash>", infoTreeOffsetStr))
+		}
+		index, err := strconv.ParseUint(parts[0], 10, 64)
+		if err != nil {
+			panic(fmt.Sprintf("Invalid info tree offset format: %s", infoTreeOffsetStr))
+		}
+		offset, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			panic(fmt.Sprintf("Invalid info tree offset format: %s", infoTreeOffsetStr))
+		}
+		hashStr := parts[2]
+		if !strings.HasPrefix(hashStr, "0x") {
+			panic(fmt.Sprintf("Invalid info tree offset format: %s, expected_ger_hash should start with 0x", infoTreeOffsetStr))
+		}
+		if _, err := hex.DecodeString(hashStr[2:]); err != nil {
+			panic(fmt.Sprintf("Invalid info tree offset format: %s, expected_ger_hash should be a valid hex string", infoTreeOffsetStr))
+		}
+		if len(hashStr) != 66 {
+			panic(fmt.Sprintf("Invalid info tree offset format: %s, expected_ger_hash should be 66 characters long", infoTreeOffsetStr))
+		}
+		expectedGerHash := libcommon.HexToHash(hashStr)
+		l1InfoTreeOffset = &ethconfig.L1InfoTreeOffset{
+			Index:           index,
+			Offset:          offset,
+			ExpectedGerHash: expectedGerHash,
+		}
+	}
+
 	cfg.Zk = &ethconfig.Zk{
 		L2ChainId:                              ctx.Uint64(utils.L2ChainIdFlag.Name),
 		L2RpcUrl:                               ctx.String(utils.L2RpcUrlFlag.Name),
@@ -231,6 +265,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		SequencerResequenceReuseL1InfoIndex:    ctx.Bool(utils.SequencerResequenceReuseL1InfoIndex.Name),
 		SequencerDecodedTxCacheSize:            ctx.Int(utils.SequencerDecodedTxCacheSize.Name),
 		SequencerDecodedTxCacheTTL:             ctx.Duration(utils.SequencerDecodedTxCacheTTL.Name),
+		SequencerResequenceInfoTreeOffset:      l1InfoTreeOffset,
 		ExecutorUrls:                           strings.Split(strings.ReplaceAll(ctx.String(utils.ExecutorUrls.Name), " ", ""), ","),
 		ExecutorStrictMode:                     ctx.Bool(utils.ExecutorStrictMode.Name),
 		ExecutorRequestTimeout:                 ctx.Duration(utils.ExecutorRequestTimeout.Name),

--- a/turbo/jsonrpc/zkevm_api.go
+++ b/turbo/jsonrpc/zkevm_api.go
@@ -367,9 +367,14 @@ func (api *ZkEvmAPIImpl) GetBatchDataByNumbers(ctx context.Context, batchNumbers
 }
 
 func (api *ZkEvmAPIImpl) getOrCalcBatchData(ctx context.Context, tx kv.Tx, dbReader state.ReadOnlyHermezDb, batchNo uint64) ([]byte, error) {
-	batchData, err := dbReader.GetL1BatchData(batchNo)
-	if err != nil {
-		return nil, err
+	var batchData []byte
+	var err error
+
+	if !api.config.Zk.AlwaysGenerateBatchL2Data {
+		batchData, err = dbReader.GetL1BatchData(batchNo)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	//found in db, do not calculate

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -311,7 +311,7 @@ func sequencingBatchStep(
 		// timer: evm + smt
 		t := utils.StartTimer("stage_sequence_execute", "evm", "smt")
 
-		infoTreeIndexProgress, l1TreeUpdate, l1TreeUpdateIndex, l1BlockHash, ger, shouldWriteGerToContract, err := prepareL1AndInfoTreeRelatedStuff(sdb, batchState, header.Time, cfg.zk.SequencerResequenceReuseL1InfoIndex)
+		infoTreeIndexProgress, l1TreeUpdate, l1TreeUpdateIndex, l1BlockHash, ger, shouldWriteGerToContract, err := prepareL1AndInfoTreeRelatedStuff(logPrefix, sdb, batchState, header.Time, cfg.zk.SequencerResequenceReuseL1InfoIndex, cfg.zk.SequencerResequenceInfoTreeOffset)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Allows us to use the hack tool to apply an info tree offset.  This is useful if we detect that the sequencer has missed a leaf on the info tree and we need to retrospectively apply an offset after correcting the tree in the DB (replacing the sequencer datadir with a synced healthy RPC node).  This approach will keep the state exactly as it was but will alter the batchL2Data being sent to the L1 after a call to fork12 `rollbackBatches` has been called.

There is also additional config / code to allow this offset to be applied during a full re-sequence of the sequencer, although this method will take considerably longer and _could_ case an L2 re-org, SO USE THIS OPTION WITH ABSOLUTE CAUTION!