### PR TITLE
feat: return 1 for BLOBBASEFEE opcode to match the min per EIP4844 

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -222,20 +222,21 @@ func (st *StateTransition) buyGas(gasBailout bool) error {
 	}
 
 	// compute blob fee for eip-4844 data blobs if any
+	// Blob txs are not supported for L2
 	blobGasVal := new(uint256.Int)
-	if st.evm.ChainRules().IsCancun {
-		blobGasPrice := st.evm.Context.BlobBaseFee
-		if blobGasPrice == nil {
-			return fmt.Errorf("%w: Cancun is active but ExcessBlobGas is nil", ErrInternalFailure)
-		}
-		blobGasVal, overflow = blobGasVal.MulOverflow(blobGasPrice, new(uint256.Int).SetUint64(st.msg.BlobGas()))
-		if overflow {
-			return fmt.Errorf("%w: overflow converting blob gas: %v", ErrInsufficientFunds, blobGasVal)
-		}
-		if err := st.gp.SubBlobGas(st.msg.BlobGas()); err != nil {
-			return err
-		}
-	}
+	// if st.evm.ChainRules().IsCancun {
+	// 	blobGasPrice := st.evm.Context.BlobBaseFee
+	// 	if blobGasPrice == nil {
+	// 		return fmt.Errorf("%w: Cancun is active but ExcessBlobGas is nil", ErrInternalFailure)
+	// 	}
+	// 	blobGasVal, overflow = blobGasVal.MulOverflow(blobGasPrice, new(uint256.Int).SetUint64(st.msg.BlobGas()))
+	// 	if overflow {
+	// 		return fmt.Errorf("%w: overflow converting blob gas: %v", ErrInsufficientFunds, blobGasVal)
+	// 	}
+	// 	if err := st.gp.SubBlobGas(st.msg.BlobGas()); err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	if !gasBailout {
 		balanceCheck := gasVal
@@ -249,23 +250,23 @@ func (st *StateTransition) buyGas(gasBailout bool) error {
 			if overflow {
 				return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From().Hex())
 			}
-			if st.evm.ChainRules().IsCancun {
-				maxBlobFee, overflow := new(uint256.Int).MulOverflow(st.msg.MaxFeePerBlobGas(), new(uint256.Int).SetUint64(st.msg.BlobGas()))
-				if overflow {
-					return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From().Hex())
-				}
-				balanceCheck, overflow = balanceCheck.AddOverflow(balanceCheck, maxBlobFee)
-				if overflow {
-					return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From().Hex())
-				}
-			}
+			// if st.evm.ChainRules().IsCancun {
+			// 	maxBlobFee, overflow := new(uint256.Int).MulOverflow(st.msg.MaxFeePerBlobGas(), new(uint256.Int).SetUint64(st.msg.BlobGas()))
+			// 	if overflow {
+			// 		return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From().Hex())
+			// 	}
+			// 	balanceCheck, overflow = balanceCheck.AddOverflow(balanceCheck, maxBlobFee)
+			// 	if overflow {
+			// 		return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From().Hex())
+			// 	}
+			// }
 		}
 		balance := st.state.GetBalance(st.msg.From())
 		if have, want := balance, balanceCheck; have.Cmp(want) < 0 {
 			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From().Hex(), have, want)
 		}
 		st.state.SubBalance(st.msg.From(), gasVal)
-		st.state.SubBalance(st.msg.From(), blobGasVal)
+		// st.state.SubBalance(st.msg.From(), blobGasVal) // Blob txs are not supported for L2
 	}
 
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {
@@ -329,17 +330,23 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 			}
 		}
 	}
-	if st.msg.BlobGas() > 0 && st.evm.ChainRules().IsCancun {
-		blobGasPrice := st.evm.Context.BlobBaseFee
-		if blobGasPrice == nil {
-			return fmt.Errorf("%w: Cancun is active but ExcessBlobGas is nil", ErrInternalFailure)
-		}
-		maxFeePerBlobGas := st.msg.MaxFeePerBlobGas()
-		if !st.evm.Config().NoBaseFee && blobGasPrice.Cmp(maxFeePerBlobGas) > 0 {
-			return fmt.Errorf("%w: address %v, maxFeePerBlobGas: %v < blobGasPrice: %v",
-				ErrMaxFeePerBlobGas, st.msg.From().Hex(), st.msg.MaxFeePerBlobGas(), blobGasPrice)
-		}
+
+	// Blob txs are not supported for L2
+	if st.msg.BlobHashes() != nil {
+		return fmt.Errorf("%w: address %v, blob txs are not supported for L2", ErrTxTypeNotSupported, st.msg.From().Hex())
 	}
+
+	// if st.msg.BlobGas() > 0 && st.evm.ChainRules().IsCancun {
+	// 	blobGasPrice := st.evm.Context.BlobBaseFee
+	// 	if blobGasPrice == nil {
+	// 		return fmt.Errorf("%w: Cancun is active but ExcessBlobGas is nil", ErrInternalFailure)
+	// 	}
+	// 	maxFeePerBlobGas := st.msg.MaxFeePerBlobGas()
+	// 	if !st.evm.Config().NoBaseFee && blobGasPrice.Cmp(maxFeePerBlobGas) > 0 {
+	// 		return fmt.Errorf("%w: address %v, maxFeePerBlobGas: %v < blobGasPrice: %v",
+	// 			ErrMaxFeePerBlobGas, st.msg.From().Hex(), st.msg.MaxFeePerBlobGas(), blobGasPrice)
+	// 	}
+	// }
 
 	return st.buyGas(gasBailout)
 }

--- a/core/vm/eips_zkevm.go
+++ b/core/vm/eips_zkevm.go
@@ -50,3 +50,12 @@ func enable3529_zkevm(jt *JumpTable) {
 	jt[SSTORE].dynamicGas = gasSStoreEIP3529
 	jt[SELFDESTRUCT].dynamicGas = gasSelfdestructEIP3529_zkevm
 }
+
+func enable7516_zkevm(jt *JumpTable) {
+	jt[BLOBBASEFEE] = &operation{
+		execute:     opBlobBaseFee_zkevm,
+		constantGas: GasQuickStep,
+		numPop:      0,
+		numPush:     1,
+	}
+}

--- a/core/vm/instructions_zkevm.go
+++ b/core/vm/instructions_zkevm.go
@@ -82,6 +82,12 @@ func opDifficulty_zkevm(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCon
 	return nil, nil
 }
 
+func opBlobBaseFee_zkevm(pc *uint64, interpreter *EVMInterpreter, callContext *ScopeContext) ([]byte, error) {
+	// We don't support blob base fee in the ZK-EVM, so we return 1 as minimum per EIP.
+	callContext.Stack.Push(uint256.NewInt(1))
+	return nil, nil
+}
+
 func opStaticCall_zkevm(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	// Pop gas. The actual gas is in interpreter.evm.callGasTemp.
 	stack := scope.Stack

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -62,8 +62,8 @@ var (
 	londonInstructionSet           = newLondonInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
 	napoliInstructionSet           = newNapoliInstructionSetZk()
-	cancunInstructionSet           = newCancunInstructionSet()
-	pragueInstructionSet           = newPragueInstructionSet()
+	cancunInstructionSet           = newCancunInstructionSetZk()
+	pragueInstructionSet           = newPragueInstructionSetZk()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -101,7 +101,7 @@ func newPragueInstructionSet() JumpTable {
 // constantinople, istanbul, petersburg, berlin, london, paris, shanghai,
 // and cancun instructions.
 func newCancunInstructionSet() JumpTable {
-	instructionSet := newNapoliInstructionSetZk()
+	instructionSet := newNapoliInstructionSet()
 	// Disable BLOBHASH and BLOBBASEFEE opcodes for L2
 	// enable4844(&instructionSet) // BLOBHASH opcode
 	// enable7516(&instructionSet) // BLOBBASEFEE opcode

--- a/core/vm/jump_table_zkevm.go
+++ b/core/vm/jump_table_zkevm.go
@@ -118,3 +118,19 @@ func newFrontierInstructionSetZk() JumpTable {
 	}
 	return is
 }
+
+func newCancunInstructionSetZk() JumpTable {
+	instructionSet := newNapoliInstructionSetZk()
+	// Disable BLOBHASH and BLOBBASEFEE opcodes for L2
+	// enable4844(&instructionSet) // BLOBHASH opcode
+	enable7516(&instructionSet) // BLOBBASEFEE opcode
+	validateAndFillMaxStack(&instructionSet)
+	return instructionSet
+}
+
+func newPragueInstructionSetZk() JumpTable {
+	instructionSet := newCancunInstructionSetZk()
+	enable7702(&instructionSet) // EIP-7702: set code tx
+	validateAndFillMaxStack(&instructionSet)
+	return instructionSet
+}


### PR DESCRIPTION
if called from contracts.
Return error if BlobHashes are set in state transition.
We do not allow blob txs on L2, but the opcode still can be used in deployed contracts, so we dont revert, just return 1.

Tested with this contract deployed:
```
pragma solidity ^0.8.18;

contract BlobBasefeeTest {
    /// @notice Read the blob base-fee via the new opcode (0x4a) and return it
    function getBlobBaseFee() public view returns (uint256) {
        return block.blobbasefee;  // in older compilers you can also use `block.blobGasPrice`
    }
}
```

```
cast call 0xFA85Ab2B363610CfE03A5BCD90066937C618b129 "getBlobBaseFee()(uint256)" -r http://localhost:8123
1
```