### PR TITLE
Enable EIP-7623 calldata cost increase only for normalcy mode

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -462,8 +462,9 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*evmtype
 		}
 	}
 
+	isPragueNormalcy := rules.IsPrague && rules.IsNormalcy
 	// Check clauses 4-5, subtract intrinsic gas if everything is correct
-	gas, floorGas7623, err := IntrinsicGas(st.data, accessTuples, contractCreation, rules.IsHomestead, rules.IsIstanbul, isEIP3860, rules.IsPrague, uint64(len(auths)))
+	gas, floorGas7623, err := IntrinsicGas(st.data, accessTuples, contractCreation, rules.IsHomestead, rules.IsIstanbul, isEIP3860, isPragueNormalcy, uint64(len(auths)))
 	if err != nil {
 		return nil, err
 	}
@@ -513,12 +514,12 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*evmtype
 		gasUsed := st.gasUsed()
 		refund := min(gasUsed/refundQuotient, st.state.GetRefund())
 		gasUsed = gasUsed - refund
-		if rules.IsPrague {
+		if isPragueNormalcy {
 			gasUsed = max(floorGas7623, gasUsed)
 		}
 		st.gasRemaining = st.initialGas - gasUsed
 		st.refundGas()
-	} else if rules.IsPrague {
+	} else if isPragueNormalcy {
 		st.gasRemaining = st.initialGas - max(floorGas7623, st.gasUsed())
 	}
 

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -595,7 +595,7 @@ func (c *Config) checkCompatible(newcfg *Config, head uint64) *ConfigCompatError
 		return newCompatError("Merge netsplit block", c.MergeNetsplitBlock, newcfg.MergeNetsplitBlock)
 	}
 	if incompatible(c.NormalcyBlock, newcfg.NormalcyBlock, head) {
-		return newCompatError("London fork block", c.NormalcyBlock, newcfg.NormalcyBlock)
+		return newCompatError("Normalcy fork block", c.NormalcyBlock, newcfg.NormalcyBlock)
 	}
 
 	return nil

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -323,6 +323,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		if mock.ChainConfig.Bor != nil {
 			agraBlock = mock.ChainConfig.Bor.GetAgraBlock()
 		}
+		normalcyBlock := mock.ChainConfig.NormalcyBlock
 
 		// we want to enable gossip testing for the majority of tests even though in a zk context we don't want it enabled - having it disabled stops the
 		// p2p sentry pickup on events from the txpool
@@ -331,7 +332,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		pragueTime := mock.ChainConfig.PragueTime
 		blobSchedule := mock.ChainConfig.BlobSchedule
 
-		mock.TxPool, err = txpool.New(newTxs, mock.DB, poolCfg, kvcache.NewDummy(), *chainID, shanghaiTime, agraBlock, cancunTime, pragueTime, blobSchedule, londonBlock, &ethconfig.Defaults, mock.DB)
+		mock.TxPool, err = txpool.New(newTxs, mock.DB, poolCfg, kvcache.NewDummy(), *chainID, shanghaiTime, agraBlock, cancunTime, pragueTime, blobSchedule, londonBlock, normalcyBlock, &ethconfig.Defaults, mock.DB)
 		if err != nil {
 			tb.Fatal(err)
 		}

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -129,7 +129,7 @@ func TestSpawnSequencingStage(t *testing.T) {
 	cacheMock := cMocks.NewMockCache(mockCtrl)
 	cacheMock.EXPECT().View(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
-	txPool, err := txpool.New(nil, txPoolDb, txpoolcfg.Config{}, cacheMock, chainID, nil, nil, nil, nil, nil, nil, &ethconfig.Config{}, nil)
+	txPool, err := txpool.New(nil, txPoolDb, txpoolcfg.Config{}, cacheMock, chainID, nil, nil, nil, nil, nil, nil, nil, &ethconfig.Config{}, nil)
 	require.NoError(t, err)
 
 	engineMock.EXPECT().

--- a/zk/txpool/fetch_test.go
+++ b/zk/txpool/fetch_test.go
@@ -57,7 +57,7 @@ func TestFetch(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	ethCfg := &ethconfig.Defaults
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, ethCfg, aclsDB)
+	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, ethCfg, aclsDB)
 	assert.NoError(err)
 	require.True(pool != nil)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/zk/txpool/metrics_test.go
+++ b/zk/txpool/metrics_test.go
@@ -99,7 +99,7 @@ func TestCalculateMetrics(t *testing.T) {
 			require.NotNil(t, txPoolDB)
 			require.NotNil(t, aclsDB)
 
-			pool, err := New(ch, coreDB, txpoolcfg.DefaultConfig, kvcache.New(kvcache.DefaultCoherentConfig), uint256.Int(*u256.N1), nil, nil, nil, nil, nil, nil, &ethconfig.Defaults, aclsDB)
+			pool, err := New(ch, coreDB, txpoolcfg.DefaultConfig, kvcache.New(kvcache.DefaultCoherentConfig), uint256.Int(*u256.N1), nil, nil, nil, nil, nil, nil, nil, &ethconfig.Defaults, aclsDB)
 			assert.NoError(err)
 			require.True(pool != nil)
 

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -317,6 +317,8 @@ type TxPool struct {
 	isPostCancun            atomic.Bool
 	pragueTime              *uint64
 	isPostPrague            atomic.Bool
+	normalcyBlock           *big.Int
+	isPostNormalcy          atomic.Bool
 	blobSchedule            *chain.BlobSchedule
 	feeCalculator           FeeCalculator
 	// log          log.Logger
@@ -353,7 +355,7 @@ type FeeCalculator interface {
 
 func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, cache kvcache.Cache,
 	chainID uint256.Int, shanghaiTime, agraBlock, cancunTime, pragueTime *big.Int, blobSchedule *chain.BlobSchedule,
-	londonBlock *big.Int, ethCfg *ethconfig.Config, aclDB kv.RwDB) (*TxPool, error) {
+	londonBlock *big.Int, normalcyBlock *big.Int, ethCfg *ethconfig.Config, aclDB kv.RwDB) (*TxPool, error) {
 	var err error
 	localsHistory, err := simplelru.NewLRU[string, struct{}](10_000, nil)
 	if err != nil {
@@ -425,6 +427,7 @@ func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, 
 		agraBlock:               blockTimeOrNil(agraBlock),
 		cancunTime:              blockTimeOrNil(cancunTime),
 		pragueTime:              blockTimeOrNil(pragueTime),
+		normalcyBlock:           normalcyBlock,
 		auths:                   map[common.Address]*metaTx{},
 	}
 
@@ -1082,7 +1085,23 @@ func (p *TxPool) isCancun() bool {
 }
 
 func (p *TxPool) isPrague() bool {
-	return isTimeBasedForkActivated(&p.isPostPrague, p.pragueTime)
+	return isTimeBasedForkActivated(&p.isPostPrague, p.pragueTime) && p.isNormalcy()
+}
+
+func (p *TxPool) isNormalcy() bool {
+	set := p.isPostNormalcy.Load()
+	if set {
+		return true
+	}
+	if p.normalcyBlock == nil {
+		return false
+	}
+	lsbBig := big.NewInt(0).SetUint64(p.lastSeenBlock.Load())
+	if p.normalcyBlock.Cmp(lsbBig) <= 0 {
+		p.isPostNormalcy.Swap(true)
+		return true
+	}
+	return false
 }
 
 func (p *TxPool) GetMaxBlobsPerBlock() uint64 {

--- a/zk/txpool/pool_test.go
+++ b/zk/txpool/pool_test.go
@@ -47,7 +47,7 @@ func TestNonceFromAddress(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	ethCfg := &ethconfig.Defaults
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, ethCfg, aclsDB)
+	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, ethCfg, aclsDB)
 	assert.NoError(err)
 	require.True(pool != nil)
 	ctx := context.Background()

--- a/zk/txpool/pool_zk.go
+++ b/zk/txpool/pool_zk.go
@@ -173,7 +173,7 @@ func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 
 	isShanghai := p.isShanghai()
 	isLondon := p.isLondon()
-	_ = isLondon
+	isPrague := p.isPrague()
 	best := p.pending.best
 
 	txs.Resize(uint(cmp.Min(int(n), len(best.ms))))
@@ -232,8 +232,8 @@ func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 		// make sure we have enough gas in the caller to add this transaction.
 		// not an exact science using intrinsic gas but as close as we could hope for at
 		// this stage
-		intrinsicGas, floorGas, _ := txpoolcfg.CalcIntrinsicGas(uint64(mt.Tx.DataLen), uint64(mt.Tx.DataNonZeroLen), uint64(len(mt.Tx.Authorizations)), uint64(mt.Tx.AlAddrCount), uint64(mt.Tx.AlStorCount), mt.Tx.Creation, true, true, isShanghai, p.isPrague())
-		if p.isPrague() && floorGas > intrinsicGas {
+		intrinsicGas, floorGas, _ := txpoolcfg.CalcIntrinsicGas(uint64(mt.Tx.DataLen), uint64(mt.Tx.DataNonZeroLen), uint64(len(mt.Tx.Authorizations)), uint64(mt.Tx.AlAddrCount), uint64(mt.Tx.AlStorCount), mt.Tx.Creation, true, true, isShanghai, isPrague)
+		if isPrague && floorGas > intrinsicGas {
 			intrinsicGas = floorGas
 		}
 

--- a/zk/txpool/pool_zk_limbo_persistent_test.go
+++ b/zk/txpool/pool_zk_limbo_persistent_test.go
@@ -44,7 +44,7 @@ func store(t *testing.T, dbPath string) *TxPool {
 	ethCfg := &ethconfig.Defaults
 	ethCfg.Zk.Limbo = true
 
-	pSource, err := New(make(chan types.Announcements), db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), ethCfg, aclDb)
+	pSource, err := New(make(chan types.Announcements), db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, ethCfg, aclDb)
 	assert.NilError(t, err)
 
 	parseCtx := types.NewTxParseContext(pSource.chainID)
@@ -147,7 +147,7 @@ func store(t *testing.T, dbPath string) *TxPool {
 	assert.NilError(t, err)
 
 	// restore
-	pTarget, err := New(make(chan types.Announcements), db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), ethCfg, aclDb)
+	pTarget, err := New(make(chan types.Announcements), db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, ethCfg, aclDb)
 	assert.NilError(t, err)
 
 	cacheView, err := pTarget._stateCache.View(context.Background(), tx)
@@ -184,7 +184,7 @@ func restoreRo(t *testing.T, dbPath string, pSource *TxPool) {
 	newTxs := make(chan types.Announcements, 1024)
 	defer close(newTxs)
 
-	pTarget, err := New(newTxs, db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), &ethconfig.Defaults, aclDb)
+	pTarget, err := New(newTxs, db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, &ethconfig.Defaults, aclDb)
 	assert.NilError(t, err)
 
 	err = db.View(context.Background(), func(tx kv.Tx) error {

--- a/zk/txpool/txpooluitl/all_components.go
+++ b/zk/txpool/txpooluitl/all_components.go
@@ -149,7 +149,7 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, ethCfg *ethconfig.
 		shanghaiTime = cfg.OverrideShanghaiTime
 	}
 
-	txPool, err := txpool.New(newTxs, chainDB, cfg, cache, *chainID, shanghaiTime, agraBlock, cancunTime, pragueTime, chainConfig.BlobSchedule, chainConfig.LondonBlock, ethCfg, aclDB)
+	txPool, err := txpool.New(newTxs, chainDB, cfg, cache, *chainID, shanghaiTime, agraBlock, cancunTime, pragueTime, chainConfig.BlobSchedule, chainConfig.LondonBlock, chainConfig.NormalcyBlock, ethCfg, aclDB)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
Confirmed with:
```
ZEROS=$(printf '00%.0s' {1..2048})
ONES=$(printf 'ff%.0s' {1..2048})
```
pre-pectra:
```
cast estimate --from 0xe859276098f208D003ca6904C6cC26629Ee364Ce 0x0000000000000000000000000000000000000000 0x$ZEROS --rpc-url http://localhost:8123
29192
cast estimate --from 0xe859276098f208D003ca6904C6cC26629Ee364Ce 0x0000000000000000000000000000000000000000 0x$ONES --rpc-url http://localhost:8123
53768
```
post-pectra:
```
cast estimate --from 0xe859276098f208D003ca6904C6cC26629Ee364Ce 0x0000000000000000000000000000000000000000 0x$ZEROS --rpc-url http://localhost:8123                                             
41480
cast estimate --from 0xe859276098f208D003ca6904C6cC26629Ee364Ce 0x0000000000000000000000000000000000000000 0x$ONES --rpc-url http://localhost:8123
102920
```
Expected:
```
Pre-Pectra Gas Used (4 gas/zero byte; 16 gas/non-zero byte):
2048 zero bytes: 21 000 + 4 × 2048 = 29 192 gas
2048 non-zero bytes: 21 000 + 16 × 2048 = 53 768 gas

Post-Pectra Gas Used (10 gas per “token” where a zero byte = 1 token, non-zero = 4 tokens):
2048 zero bytes: Tokens = 2048 → 10 × 2048 = 20 480 → 21 000+20 480 = 41 480 gas
2048 non-zero bytes: Tokens = 4 × 2048 = 8192 → 10 × 8192 = 81 920 → 21 000+81 920 = 102 920 gas
```


