### PR TITLE
Feat/info tree correctness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ vendor
 
 datadir
 zk/tests/unwinds/datastream/hermez-dynamic-integration8-datastream
+zk/debug_tools/rpc-cache/cache.db
+zk/debug_tools/rpc-cache/rpc-cache

--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -549,6 +549,8 @@ const (
 	BATCH_ENDS                        = "batch_ends"
 	WITNESS_CACHE                     = "witness_cache"
 	BAD_TX_HASHES                     = "bad_tx_hashes"
+	CONFIRMED_L1_INFO_TREE_UPDATE     = "confirmed_l1_info_tree_update"
+
 	//Diagnostics tables
 	DiagSystemInfo = "DiagSystemInfo"
 	DiagSyncStages = "DiagSyncStages"
@@ -795,6 +797,7 @@ var ChaindataTables = []string{
 	BATCH_ENDS,
 	WITNESS_CACHE,
 	BAD_TX_HASHES,
+	CONFIRMED_L1_INFO_TREE_UPDATE,
 }
 
 const (

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1123,7 +1123,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			ctx,
 			ethermanClients,
 			[]libcommon.Address{cfg.AddressGerManager},
-			[][]libcommon.Hash{{contracts.UpdateL1InfoTreeTopic}},
+			[][]libcommon.Hash{{contracts.UpdateL1InfoTreeTopic, contracts.UpdateL1InfoTreeV2Topic}},
 			cfg.L1BlockRange,
 			cfg.L1QueryDelay,
 			cfg.L1HighestBlockType,

--- a/zk/contracts/l1_contracts.go
+++ b/zk/contracts/l1_contracts.go
@@ -11,6 +11,7 @@ var (
 	VerificationTopicPreEtrog      = common.HexToHash("0xcb339b570a7f0b25afa7333371ff11192092a0aeace12b671f4c212f2815c6fe")
 	VerificationTopicEtrog         = common.HexToHash("0xd1ec3a1216f08b6eff72e169ceb548b782db18a6614852618d86bb19f3f9b0d3")
 	UpdateL1InfoTreeTopic          = common.HexToHash("0xda61aa7823fcd807e37b95aabcbe17f03a6f3efd514176444dae191d27fd66b3")
+	UpdateL1InfoTreeV2Topic        = common.HexToHash("0xaf6c6cd7790e0180a4d22eb8ed846e55846f54ed10e5946db19972b5a0813a59")
 	InitialSequenceBatchesTopic    = common.HexToHash("0x060116213bcbf54ca19fd649dc84b59ab2bbd200ab199770e4d923e222a28e7f")
 	AddNewRollupTypeTopic          = common.HexToHash("0xa2970448b3bd66ba7e524e7b2a5b9cf94fa29e32488fb942afdfe70dd4b77b52")
 	AddNewRollupTypeTopicBanana    = common.HexToHash("0x9eaf2ecbddb14889c9e141a63175c55ac25e0cd7cdea312cdfbd0397976b383a")

--- a/zk/contracts/l1_contracts_test.go
+++ b/zk/contracts/l1_contracts_test.go
@@ -47,6 +47,11 @@ func TestZkContractsEventsHash(t *testing.T) {
 			expectedHash: UpdateL1InfoTreeTopic,
 		},
 		{
+			name:         "UpdateL1InfoTreeV2",
+			eventSig:     "UpdateL1InfoTreeV2(bytes32,uint32,uint256,uint64)",
+			expectedHash: UpdateL1InfoTreeV2Topic,
+		},
+		{
 			name:         "InitialSequenceBatches",
 			eventSig:     "InitialSequenceBatches(bytes,bytes32,address)",
 			expectedHash: InitialSequenceBatchesTopic,

--- a/zk/debug_tools/rpc-cache/Readme.md
+++ b/zk/debug_tools/rpc-cache/Readme.md
@@ -1,0 +1,31 @@
+# Debug rpc cache
+
+A handy tool for caching responses from the L1 and for chaos testing events that
+rely on L1 interactions
+
+## Normal cache
+
+To run the cache in the standard way you can just use `go run main.go` and 
+the service will run on port 6969.
+
+To use the cache ensure that your node is calling in the following format
+`http://localhost:6969?chainid=<chainid>&endpoint=<endpoint>`
+
+Where endpoint is the upstream endpoint that you want to cache responses from.
+
+The tool can be used across multiple networks which are differentiated by the `chainid`
+in the URL.
+
+The application stores everything in a bolt db that will be created local to wherever
+the code is run from
+
+## Chaos mode
+
+To add a little chaos you can use the flags below which will alter resposnes sent 
+from the tool.  There is configurable randomness and you can specifiy specific addresses
+or individual topics or combinations of the two
+
+`-chaos=5` - this will apply chaos 1 in 5 times
+`-chaos-after=1000000` - this will apply chaos after the specified block number for eth_getLogs by inspecting the `fromBlock` argument
+`-chaos-topics=0x1234567890abcdef1234567890abcdef12345678,0x1234567890abcdef1234567890abcdef12345678` - this will remove any log events that contain these topics
+`-chaos-addresses=0x1234567890abcdef1234567890abcdef12345678,0x1234567890abcdef1234567890abcdef12345678` - this will remove any log events that contain these addresses

--- a/zk/debug_tools/rpc-cache/go.mod
+++ b/zk/debug_tools/rpc-cache/go.mod
@@ -1,0 +1,7 @@
+module rpc-cache
+
+go 1.20
+
+require github.com/boltdb/bolt v1.3.1
+
+require golang.org/x/sys v0.20.0 // indirect

--- a/zk/debug_tools/rpc-cache/go.sum
+++ b/zk/debug_tools/rpc-cache/go.sum
@@ -1,0 +1,4 @@
+github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
+github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/zk/debug_tools/rpc-cache/main.go
+++ b/zk/debug_tools/rpc-cache/main.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	url2 "net/url"
+	"time"
+
+	"github.com/boltdb/bolt"
+)
+
+var db *bolt.DB
+
+const (
+	bucketName   = "Cache"
+	expiryBucket = "Expiry"
+)
+
+// methods we don't cache
+var methodsToIgnore = map[string]struct{}{}
+
+// methods we configure expiry for
+var methodsToExpire = map[string]time.Duration{
+	"eth_getBlockByNumber": 1 * time.Minute,
+}
+
+// params that trigger expiration
+var paramsToExpire = map[string]struct{}{
+	"latest":    {},
+	"finalized": {},
+}
+
+func initDB() {
+	var err error
+	db, err = bolt.Open("cache.db", 0600, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(bucketName))
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists([]byte(expiryBucket))
+		return err
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func fetchFromCache(key string) ([]byte, bool) {
+	var data []byte
+	var expiry []byte
+	err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketName))
+		e := tx.Bucket([]byte(expiryBucket))
+		data = b.Get([]byte(key))
+		expiry = e.Get([]byte(key))
+		return nil
+	})
+	if err != nil || data == nil {
+		return nil, false
+	}
+
+	if expiry != nil {
+		expiryTime, err := time.Parse(time.RFC3339, string(expiry))
+		if err == nil && time.Now().After(expiryTime) {
+			// Cache entry has expired
+			return nil, false
+		}
+	}
+
+	return data, true
+}
+
+func saveToCache(key string, response []byte, duration time.Duration) {
+	err := db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketName))
+		e := tx.Bucket([]byte(expiryBucket))
+		err := b.Put([]byte(key), response)
+		if err != nil {
+			return err
+		}
+		// Only set expiry if duration is not zero (indicating that it should expire)
+		if duration > 0 {
+			expiryTime := time.Now().Add(duration).Format(time.RFC3339)
+			return e.Put([]byte(key), []byte(expiryTime))
+		}
+		return nil
+	})
+	if err != nil {
+		log.Println("Failed to save to cache:", err)
+	}
+}
+
+func generateCacheKey(chainID string, body []byte) (string, error) {
+	var request map[string]interface{}
+	err := json.Unmarshal(body, &request)
+	if err != nil {
+		return "", err
+	}
+	delete(request, "id")
+	modifiedBody, err := json.Marshal(request)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s_%s", chainID, modifiedBody), nil
+}
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+	endpoint := r.URL.Query().Get("endpoint")
+	chainID := r.URL.Query().Get("chainid")
+	if endpoint == "" || chainID == "" {
+		http.Error(w, "Missing endpoint or chainid parameter", http.StatusBadRequest)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+
+	var request map[string]interface{}
+	if err := json.Unmarshal(body, &request); err != nil {
+		http.Error(w, "Invalid JSON-RPC request", http.StatusBadRequest)
+		return
+	}
+
+	method, ok := request["method"].(string)
+	if !ok {
+		http.Error(w, "Invalid JSON-RPC method", http.StatusBadRequest)
+		return
+	}
+
+	cacheKey, err := generateCacheKey(chainID, body)
+	if err != nil {
+		http.Error(w, "Failed to generate cache key", http.StatusInternalServerError)
+		return
+	}
+
+	if _, ignore := methodsToIgnore[method]; !ignore {
+		if cachedResponse, found := fetchFromCache(cacheKey); found {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cachedResponse)
+			return
+		}
+	}
+
+	url, _ := url2.Parse(endpoint)
+	fmt.Printf("%s Fetching from upstream %s\n", time.Now().Format(time.RFC3339), url.Host)
+
+	resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		http.Error(w, "Failed to fetch from upstream", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, "Failed to read upstream response", http.StatusInternalServerError)
+		return
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		// Check if the response contains a JSON-RPC error
+		var jsonResponse map[string]interface{}
+		if err := json.Unmarshal(responseBody, &jsonResponse); err == nil {
+			if _, hasError := jsonResponse["error"]; hasError {
+				fmt.Println("Received error response from upstream, not caching", url.Host)
+			} else {
+				if _, ignore := methodsToIgnore[method]; !ignore {
+					cacheDuration := time.Duration(0)
+					if duration, found := methodsToExpire[method]; found {
+						if method == "eth_getBlockByNumber" {
+							params, ok := request["params"].([]interface{})
+							if ok && len(params) > 0 {
+								param, ok := params[0].(string)
+								if ok {
+									if _, shouldExpire := paramsToExpire[param]; shouldExpire {
+										cacheDuration = duration
+									}
+								}
+							}
+						} else {
+							cacheDuration = duration
+						}
+					}
+					saveToCache(cacheKey, responseBody, cacheDuration)
+				}
+			}
+		} else {
+			fmt.Println("Failed to parse upstream response, not caching")
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(responseBody)
+}
+
+func handleCacheLookup(w http.ResponseWriter, r *http.Request) {
+	cacheKey := r.URL.Query().Get("key")
+	if cacheKey == "" {
+		http.Error(w, "Missing key parameter", http.StatusBadRequest)
+		return
+	}
+
+	cachedResponse, found := fetchFromCache(cacheKey)
+	if !found {
+		http.Error(w, "Cache miss", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(cachedResponse)
+}
+
+func main() {
+	initDB()
+	defer db.Close()
+
+	http.HandleFunc("/", handleRequest)
+	http.HandleFunc("/lookup", handleCacheLookup)
+	server := &http.Server{
+		Addr:           ":6969",
+		Handler:        nil,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+	log.Println("Starting proxy server on port 6969")
+	log.Fatal(server.ListenAndServe())
+}

--- a/zk/l1infotree/updater.go
+++ b/zk/l1infotree/updater.go
@@ -229,7 +229,9 @@ LOOP:
 
 	// save the progress - we add one here so that we don't cause overlap on the next run.  We don't want to duplicate an info tree update in the db
 	if len(allLogs) > 0 {
-		u.progress = allLogs[len(allLogs)-1].BlockNumber + 1
+		// here we save progress at the exact block number of the last log.  The syncer will automatically add 1 to this value
+		// when the node / syncing process is restarted.
+		u.progress = allLogs[len(allLogs)-1].BlockNumber
 	}
 	if err = stages.SaveStageProgress(tx, stages.L1InfoTree, u.progress); err != nil {
 		return 0, fmt.Errorf("SaveStageProgress: %w", err)

--- a/zk/l1infotree/updater.go
+++ b/zk/l1infotree/updater.go
@@ -103,7 +103,7 @@ func (u *Updater) WarmUp(tx kv.RwTx) (err error) {
 	return nil
 }
 
-func (u *Updater) CheckForInfoTreeUpdates(logPrefix string, tx kv.RwTx) (allLogs []types.Log, err error) {
+func (u *Updater) CheckForInfoTreeUpdates(logPrefix string, tx kv.RwTx) (processed uint64, err error) {
 	defer func() {
 		if err != nil {
 			u.syncer.StopQueryBlocks()
@@ -117,6 +117,7 @@ func (u *Updater) CheckForInfoTreeUpdates(logPrefix string, tx kv.RwTx) (allLogs
 	progressChan := u.syncer.GetProgressMessageChan()
 
 	// first get all the logs we need to process
+	allLogs := make([]types.Log, 0)
 LOOP:
 	for {
 		select {
@@ -133,6 +134,7 @@ LOOP:
 	}
 
 	// sort the logs by block number - it is important that we process them in order to get the index correct
+	// the v2 topic always appears after the v1 topic so we can rely on this ordering to process the logs correctly.
 	sort.Slice(allLogs, func(i, j int) bool {
 		l1 := allLogs[i]
 		l2 := allLogs[j]
@@ -151,14 +153,14 @@ LOOP:
 
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
-	processed := 0
+	processed = 0
 
 	var tree *L1InfoTree
 	if len(allLogs) > 0 {
 		log.Info(fmt.Sprintf("[%s] Checking for L1 info tree updates, logs count:%v", logPrefix, len(allLogs)))
 		tree, err = InitialiseL1InfoTree(hermezDb)
 		if err != nil {
-			return nil, fmt.Errorf("InitialiseL1InfoTree: %w", err)
+			return 0, fmt.Errorf("InitialiseL1InfoTree: %w", err)
 		}
 	}
 
@@ -166,65 +168,52 @@ LOOP:
 	for _, chunk := range chunks {
 		select {
 		case <-ticker.C:
-			log.Info(fmt.Sprintf("[%s] Processed %d/%d logs, %d%% complete", logPrefix, processed, len(allLogs), processed*100/len(allLogs)))
+			log.Info(fmt.Sprintf("[%s] Processed %d/%d logs, %d%% complete", logPrefix, processed, len(allLogs), int(processed)*100/len(allLogs)))
 		default:
 		}
 
 		headersMap, err := u.syncer.L1QueryHeaders(chunk)
 		if err != nil {
-			return nil, fmt.Errorf("L1QueryHeaders: %w", err)
+			return 0, fmt.Errorf("L1QueryHeaders: %w", err)
 		}
 
 		for _, l := range chunk {
 			switch l.Topics[0] {
 			case contracts.UpdateL1InfoTreeTopic:
-				header := headersMap[l.BlockNumber]
-				if header == nil {
-					header, err = u.syncer.GetHeader(l.BlockNumber)
-					if err != nil {
-						return nil, fmt.Errorf("GetHeader: %w", err)
+				// calculate and store the info tree leaf / index
+				if err := u.HandleL1InfoTreeUpdate(hermezDb, l, tree, headersMap); err != nil {
+					return 0, fmt.Errorf("HandleL1InfoTreeUpdate: %w", err)
+				}
+				processed++
+			case contracts.UpdateL1InfoTreeV2Topic:
+				// here we can verify that the information we have stored about the info tree is indeed correct
+				leafCount := l.Topics[1].Big().Uint64()
+				root := l.Data[:32]
+				expectedIndex, found, err := hermezDb.GetL1InfoTreeIndexByRoot(common.BytesToHash(root))
+				if err != nil {
+					return 0, fmt.Errorf("GetL1InfoTreeIndexByRoot: %w", err)
+				}
+				if !found {
+					return 0, fmt.Errorf("could not find index for root %s", common.BytesToHash(root).String())
+				}
+				if expectedIndex == leafCount-1 {
+					if err = hermezDb.WriteConfirmedL1InfoTreeUpdate(expectedIndex, l.BlockNumber); err != nil {
+						return 0, fmt.Errorf("WriteConfirmedL1InfoTreeUpdate: %w", err)
 					}
-				}
+				} else {
+					log.Info(fmt.Sprintf("[%s] Unexpected index for L1 info tree root", logPrefix), "expected", expectedIndex, "found", leafCount-1)
 
-				tmpUpdate, err := createL1InfoTreeUpdate(l, header)
-				if err != nil {
-					return nil, fmt.Errorf("createL1InfoTreeUpdate: %w", err)
-				}
+					if err := u.RollbackL1InfoTree(hermezDb, tx); err != nil {
+						return 0, fmt.Errorf("RollbackL1InfoTree: %w", err)
+					}
 
-				leafHash := HashLeafData(tmpUpdate.GER, tmpUpdate.ParentHash, tmpUpdate.Timestamp)
-				if tree.LeafExists(leafHash) {
-					log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", leafHash)
-					continue
-				}
+					// now reset the syncer to start from the last confirmed block
+					u.syncer.RunQueryBlocks(u.progress)
 
-				if u.latestUpdate != nil {
-					tmpUpdate.Index = u.latestUpdate.Index + 1
-				} // if latestUpdate is nil then Index = 0 which is the default value so no need to set it
-				u.latestUpdate = tmpUpdate
-
-				newRoot, err := tree.AddLeaf(uint32(u.latestUpdate.Index), leafHash)
-				if err != nil {
-					return nil, fmt.Errorf("tree.AddLeaf: %w", err)
+					// early return as we need to re-start the syncing process here to get new
+					// leaves from scratch
+					return processed, nil
 				}
-				log.Debug("New L1 Index",
-					"index", u.latestUpdate.Index,
-					"root", newRoot.String(),
-					"mainnet", u.latestUpdate.MainnetExitRoot.String(),
-					"rollup", u.latestUpdate.RollupExitRoot.String(),
-					"ger", u.latestUpdate.GER.String(),
-					"parent", u.latestUpdate.ParentHash.String(),
-				)
-
-				if err = handleL1InfoTreeUpdate(hermezDb, u.latestUpdate); err != nil {
-					return nil, fmt.Errorf("handleL1InfoTreeUpdate: %w", err)
-				}
-				if err = hermezDb.WriteL1InfoTreeLeaf(u.latestUpdate.Index, leafHash); err != nil {
-					return nil, fmt.Errorf("WriteL1InfoTreeLeaf: %w", err)
-				}
-				if err = hermezDb.WriteL1InfoTreeRoot(common.BytesToHash(newRoot[:]), u.latestUpdate.Index); err != nil {
-					return nil, fmt.Errorf("WriteL1InfoTreeRoot: %w", err)
-				}
-
 				processed++
 			default:
 				log.Warn("received unexpected topic from l1 info tree stage", "topic", l.Topics[0])
@@ -237,10 +226,91 @@ LOOP:
 		u.progress = allLogs[len(allLogs)-1].BlockNumber + 1
 	}
 	if err = stages.SaveStageProgress(tx, stages.L1InfoTree, u.progress); err != nil {
-		return nil, fmt.Errorf("SaveStageProgress: %w", err)
+		return 0, fmt.Errorf("SaveStageProgress: %w", err)
 	}
 
-	return allLogs, nil
+	return processed, nil
+}
+
+func (u *Updater) HandleL1InfoTreeUpdate(hermezDb *hermez_db.HermezDb, l types.Log, tree *L1InfoTree, headersMap map[uint64]*types.Header) error {
+	var err error
+	header := headersMap[l.BlockNumber]
+	if header == nil {
+		header, err = u.syncer.GetHeader(l.BlockNumber)
+		if err != nil {
+			return fmt.Errorf("GetHeader: %w", err)
+		}
+	}
+
+	tmpUpdate, err := createL1InfoTreeUpdate(l, header)
+	if err != nil {
+		return fmt.Errorf("createL1InfoTreeUpdate: %w", err)
+	}
+
+	leafHash := HashLeafData(tmpUpdate.GER, tmpUpdate.ParentHash, tmpUpdate.Timestamp)
+	if tree.LeafExists(leafHash) {
+		log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", leafHash)
+		return nil
+	}
+
+	if u.latestUpdate != nil {
+		tmpUpdate.Index = u.latestUpdate.Index + 1
+	}
+	// if latestUpdate is nil then Index = 0 which is the default value so no need to set it
+	u.latestUpdate = tmpUpdate
+
+	newRoot, err := tree.AddLeaf(uint32(u.latestUpdate.Index), leafHash)
+	if err != nil {
+		return fmt.Errorf("tree.AddLeaf: %w", err)
+	}
+
+	log.Debug("New L1 Index",
+		"index", u.latestUpdate.Index,
+		"root", newRoot.String(),
+		"mainnet", u.latestUpdate.MainnetExitRoot.String(),
+		"rollup", u.latestUpdate.RollupExitRoot.String(),
+		"ger", u.latestUpdate.GER.String(),
+		"parent", u.latestUpdate.ParentHash.String(),
+	)
+
+	if err = writeL1InfoTreeUpdate(hermezDb, u.latestUpdate, leafHash, newRoot); err != nil {
+		return fmt.Errorf("writeL1InfoTreeUpdate: %w", err)
+	}
+
+	return nil
+}
+
+func (u *Updater) RollbackL1InfoTree(hermezDb *hermez_db.HermezDb, tx kv.RwTx) error {
+	// unexpected index means we missed a leaf somewhere so we need to rollback our data and start re-syncing
+	index, l1BlockNumber, err := hermezDb.GetConfirmedL1InfoTreeUpdate()
+	if err != nil {
+		return fmt.Errorf("GetConfirmedL1InfoTreeUpdate: %w", err)
+	}
+
+	if err = truncateL1InfoTreeData(hermezDb, index+1); err != nil {
+		return fmt.Errorf("truncateL1InfoTreeData: %w", err)
+	}
+
+	// now read the latest confirmed update and set the latest update to this value
+	latestUpdate, err := hermezDb.GetL1InfoTreeUpdate(index)
+	if err != nil {
+		return fmt.Errorf("GetL1InfoTreeUpdate: %w", err)
+	}
+	u.latestUpdate = latestUpdate
+
+	// stop the syncer
+	u.syncer.StopQueryBlocks()
+	u.syncer.ConsumeQueryBlocks()
+	u.syncer.WaitQueryBlocksToFinish()
+
+	// reset progress for the next iteration
+	u.progress = l1BlockNumber - 1
+
+	if err = stages.SaveStageProgress(tx, stages.L1InfoTree, u.progress); err != nil {
+		return fmt.Errorf("SaveStageProgress: %w", err)
+	}
+
+	return nil
 }
 
 func (u *Updater) CheckL2RpcForInfoTreeUpdates(logPrefix string, tx kv.RwTx) (infoTrees []zkTypes.L1InfoTreeUpdate, err error) {
@@ -319,16 +389,8 @@ LOOP:
 					return nil, fmt.Errorf("tree.AddLeaf: %w", err)
 				}
 
-				if err = handleL1InfoTreeUpdate(hermezDb, tmpUpdate); err != nil {
-					return nil, fmt.Errorf("handleL1InfoTreeUpdate: %w", err)
-				}
-
-				if err = hermezDb.WriteL1InfoTreeLeaf(tmpUpdate.Index, leafHash); err != nil {
-					return nil, fmt.Errorf("WriteL1InfoTreeLeaf: %w", err)
-				}
-
-				if err = hermezDb.WriteL1InfoTreeRoot(common.BytesToHash(newRoot[:]), tmpUpdate.Index); err != nil {
-					return nil, fmt.Errorf("WriteL1InfoTreeRoot: %w", err)
+				if err = writeL1InfoTreeUpdate(hermezDb, tmpUpdate, leafHash, newRoot); err != nil {
+					return nil, fmt.Errorf("writeL1InfoTreeUpdate: %w", err)
 				}
 
 				processed++
@@ -348,16 +410,8 @@ LOOP:
 			return nil, fmt.Errorf("tree.AddLeaf: %w", err)
 		}
 
-		if err = handleL1InfoTreeUpdate(hermezDb, u.latestUpdate); err != nil {
-			return nil, fmt.Errorf("handleL1InfoTreeUpdate: %w", err)
-		}
-
-		if err = hermezDb.WriteL1InfoTreeLeaf(u.latestUpdate.Index, leafHash); err != nil {
-			return nil, fmt.Errorf("WriteL1InfoTreeLeaf: %w", err)
-		}
-
-		if err = hermezDb.WriteL1InfoTreeRoot(common.BytesToHash(newRoot[:]), u.latestUpdate.Index); err != nil {
-			return nil, fmt.Errorf("WriteL1InfoTreeRoot: %w", err)
+		if err = writeL1InfoTreeUpdate(hermezDb, u.latestUpdate, leafHash, newRoot); err != nil {
+			return nil, fmt.Errorf("writeL1InfoTreeUpdate: %w", err)
 		}
 
 		processed++
@@ -433,16 +487,41 @@ func createL1InfoTreeUpdate(l types.Log, header *types.Header) (*zkTypes.L1InfoT
 	return update, nil
 }
 
-func handleL1InfoTreeUpdate(
+func writeL1InfoTreeUpdate(
 	hermezDb *hermez_db.HermezDb,
 	update *zkTypes.L1InfoTreeUpdate,
+	leafHash [32]byte,
+	newRoot [32]byte,
 ) error {
 	var err error
+
 	if err = hermezDb.WriteL1InfoTreeUpdate(update); err != nil {
 		return fmt.Errorf("WriteL1InfoTreeUpdate: %w", err)
 	}
 	if err = hermezDb.WriteL1InfoTreeUpdateToGer(update); err != nil {
 		return fmt.Errorf("WriteL1InfoTreeUpdateToGer: %w", err)
+	}
+	if err = hermezDb.WriteL1InfoTreeLeaf(update.Index, leafHash); err != nil {
+		return fmt.Errorf("WriteL1InfoTreeLeaf: %w", err)
+	}
+	if err = hermezDb.WriteL1InfoTreeRoot(common.BytesToHash(newRoot[:]), update.Index); err != nil {
+		return fmt.Errorf("WriteL1InfoTreeRoot: %w", err)
+	}
+	return nil
+}
+
+func truncateL1InfoTreeData(hermezDb *hermez_db.HermezDb, fromIndex uint64) error {
+	if err := hermezDb.TruncateL1InfoTreeUpdates(fromIndex); err != nil {
+		return fmt.Errorf("TruncateL1InfoTreeUpdates: %w", err)
+	}
+	if err := hermezDb.TruncateL1InfoTreeUpdatesByGer(fromIndex); err != nil {
+		return fmt.Errorf("TruncateL1InfoTreeUpdatesByGer: %w", err)
+	}
+	if err := hermezDb.TruncateL1InfoTreeLeaves(fromIndex); err != nil {
+		return fmt.Errorf("TruncateL1InfoTreeLeaves: %w", err)
+	}
+	if err := hermezDb.TruncateL1InfoTreeRoots(fromIndex); err != nil {
+		return fmt.Errorf("TruncateL1InfoTreeRoots: %w", err)
 	}
 	return nil
 }

--- a/zk/l1infotree/updater.go
+++ b/zk/l1infotree/updater.go
@@ -194,20 +194,26 @@ LOOP:
 					return 0, fmt.Errorf("GetL1InfoTreeIndexByRoot: %w", err)
 				}
 				if !found {
-					return 0, fmt.Errorf("could not find index for root %s", common.BytesToHash(root).String())
+					// some leaf must have been missed in this case as the v2 event from the info tree suggests
+					// there is a root that we haven't calculated so we need to unwind the info tree locally
+					// and try syncing again
+					log.Error(fmt.Sprintf("[%s] Could not find an l1 info tree update by root", logPrefix), "root", common.BytesToHash(root).String())
+					if err := u.RollbackL1InfoTree(hermezDb, tx); err != nil {
+						return 0, fmt.Errorf("RollbackL1InfoTree: %w", err)
+					}
+					u.syncer.RunQueryBlocks(u.progress)
+
+					return processed, nil
 				}
 				if expectedIndex == leafCount-1 {
 					if err = hermezDb.WriteConfirmedL1InfoTreeUpdate(expectedIndex, l.BlockNumber); err != nil {
 						return 0, fmt.Errorf("WriteConfirmedL1InfoTreeUpdate: %w", err)
 					}
 				} else {
-					log.Info(fmt.Sprintf("[%s] Unexpected index for L1 info tree root", logPrefix), "expected", expectedIndex, "found", leafCount-1)
-
+					log.Error(fmt.Sprintf("[%s] Unexpected index for L1 info tree root", logPrefix), "expected", expectedIndex, "found", leafCount-1)
 					if err := u.RollbackL1InfoTree(hermezDb, tx); err != nil {
 						return 0, fmt.Errorf("RollbackL1InfoTree: %w", err)
 					}
-
-					// now reset the syncer to start from the last confirmed block
 					u.syncer.RunQueryBlocks(u.progress)
 
 					// early return as we need to re-start the syncing process here to get new
@@ -249,7 +255,7 @@ func (u *Updater) HandleL1InfoTreeUpdate(hermezDb *hermez_db.HermezDb, l types.L
 
 	leafHash := HashLeafData(tmpUpdate.GER, tmpUpdate.ParentHash, tmpUpdate.Timestamp)
 	if tree.LeafExists(leafHash) {
-		log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", leafHash)
+		log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", common.BytesToHash(leafHash[:]).String())
 		return nil
 	}
 
@@ -281,22 +287,43 @@ func (u *Updater) HandleL1InfoTreeUpdate(hermezDb *hermez_db.HermezDb, l types.L
 }
 
 func (u *Updater) RollbackL1InfoTree(hermezDb *hermez_db.HermezDb, tx kv.RwTx) error {
-	// unexpected index means we missed a leaf somewhere so we need to rollback our data and start re-syncing
-	index, l1BlockNumber, err := hermezDb.GetConfirmedL1InfoTreeUpdate()
+	// unexpected confirmedIndex means we missed a leaf somewhere so we need to rollback our data and start re-syncing
+	confirmedIndex, confirmedL1BlockNumber, err := hermezDb.GetConfirmedL1InfoTreeUpdate()
 	if err != nil {
 		return fmt.Errorf("GetConfirmedL1InfoTreeUpdate: %w", err)
 	}
 
-	if err = truncateL1InfoTreeData(hermezDb, index+1); err != nil {
-		return fmt.Errorf("truncateL1InfoTreeData: %w", err)
-	}
+	if confirmedIndex == 0 && confirmedL1BlockNumber == 0 {
+		// so we know there are no confirmed leaves on the tree at this point
+		// now we check if we have an index in the DB or not.  If we do then we
+		// are in a state where we've detected fork 12 events but our previously
+		// synced info tree is invalid with no way of knowing where / how it became
+		// invalid.  Not good, this needs intervention so we just return an error
+		// to stop further indexes being used in the network
+		latestUpdate, err := hermezDb.GetLatestL1InfoTreeUpdate()
+		if err != nil {
+			return fmt.Errorf("GetLatestL1InfoTreeUpdate: %w", err)
+		}
+		if latestUpdate.Index > 0 {
+			// oh dear
+			return errors.New("first fork12 info tree update v2 transaction shows our info tree cannot be verified")
+		}
 
-	// now read the latest confirmed update and set the latest update to this value
-	latestUpdate, err := hermezDb.GetL1InfoTreeUpdate(index)
-	if err != nil {
-		return fmt.Errorf("GetL1InfoTreeUpdate: %w", err)
+		confirmedL1BlockNumber = u.cfg.L1FirstBlock - 1
+	} else {
+		// we have some data already so we need to truncate the tables down
+		// and reset the latest update data
+		if err = truncateL1InfoTreeData(hermezDb, confirmedIndex+1); err != nil {
+			return fmt.Errorf("truncateL1InfoTreeData: %w", err)
+		}
+
+		// now read the latest confirmed update and set the latest update to this value
+		latestUpdate, err := hermezDb.GetL1InfoTreeUpdate(confirmedIndex)
+		if err != nil {
+			return fmt.Errorf("GetL1InfoTreeUpdate: %w", err)
+		}
+		u.latestUpdate = latestUpdate
 	}
-	u.latestUpdate = latestUpdate
 
 	// stop the syncer
 	u.syncer.StopQueryBlocks()
@@ -304,7 +331,7 @@ func (u *Updater) RollbackL1InfoTree(hermezDb *hermez_db.HermezDb, tx kv.RwTx) e
 	u.syncer.WaitQueryBlocksToFinish()
 
 	// reset progress for the next iteration
-	u.progress = l1BlockNumber - 1
+	u.progress = confirmedL1BlockNumber - 1
 
 	if err = stages.SaveStageProgress(tx, stages.L1InfoTree, u.progress); err != nil {
 		return fmt.Errorf("SaveStageProgress: %w", err)
@@ -380,7 +407,7 @@ LOOP:
 
 				leafHash := HashLeafData(tmpUpdate.GER, tmpUpdate.ParentHash, tmpUpdate.Timestamp)
 				if tree.LeafExists(leafHash) {
-					log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", leafHash)
+					log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", common.BytesToHash(leafHash[:]).String())
 					continue
 				}
 
@@ -401,7 +428,7 @@ LOOP:
 
 		leafHash := HashLeafData(u.latestUpdate.GER, u.latestUpdate.ParentHash, u.latestUpdate.Timestamp)
 		if tree.LeafExists(leafHash) {
-			log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", leafHash)
+			log.Warn("Skipping log as L1 Info Tree leaf already exists", "hash", common.BytesToHash(leafHash[:]).String())
 			continue
 		}
 

--- a/zk/stages/stage_l1_info_tree.go
+++ b/zk/stages/stage_l1_info_tree.go
@@ -86,7 +86,7 @@ func SpawnL1InfoTreeStage(
 		return fmt.Errorf("cfg.updater.WarmUp: %w", err)
 	}
 
-	allLogs, err := cfg.updater.CheckForInfoTreeUpdates(logPrefix, tx)
+	processedLogs, err := cfg.updater.CheckForInfoTreeUpdates(logPrefix, tx)
 	if err != nil {
 		return fmt.Errorf("CheckForInfoTreeUpdates: %w", err)
 	}
@@ -97,7 +97,7 @@ func SpawnL1InfoTreeStage(
 		latestIndex = latestUpdate.Index
 	}
 
-	log.Info(fmt.Sprintf("[%s] Info tree updates", logPrefix), "count", len(allLogs), "latestIndex", latestIndex)
+	log.Info(fmt.Sprintf("[%s] Info tree updates", logPrefix), "count", processedLogs, "latestIndex", latestIndex)
 
 	if freshTx {
 		if funcErr = tx.Commit(); funcErr != nil {

--- a/zk/stages/stage_l1_info_tree_test.go
+++ b/zk/stages/stage_l1_info_tree_test.go
@@ -86,7 +86,9 @@ func TestSpawnL1InfoTreeStage(t *testing.T) {
 	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
 
 	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest")
-	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{}))
+	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{
+		L2RpcUrl: "http://127.0.0.1:8545",
+	}))
 	cfg := StageL1InfoTreeCfg(db1, &ethconfig.Zk{}, updater)
 
 	// act
@@ -147,5 +149,5 @@ func TestSpawnL1InfoTreeStage(t *testing.T) {
 	// check SaveStageProgress
 	progress, err := stages.GetStageProgress(tx, stages.L1InfoTree)
 	require.NoError(t, err)
-	assert.Equal(t, latestBlockNumber.Uint64()+1, progress)
+	assert.Equal(t, latestBlockNumber.Uint64(), progress)
 }

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -384,7 +384,7 @@ func sequencingBatchStep(
 
 			select {
 			case <-infoTreeTicker.C:
-				newLogs, err := cfg.infoTreeUpdater.CheckForInfoTreeUpdates(logPrefix, sdb.tx)
+				processedLogs, err := cfg.infoTreeUpdater.CheckForInfoTreeUpdates(logPrefix, sdb.tx)
 				if err != nil {
 					return err
 				}
@@ -393,7 +393,7 @@ func sequencingBatchStep(
 				if latest != nil {
 					latestIndex = latest.Index
 				}
-				log.Info(fmt.Sprintf("[%s] Info tree updates", logPrefix), "count", len(newLogs), "latestIndex", latestIndex)
+				log.Info(fmt.Sprintf("[%s] Info tree updates", logPrefix), "count", processedLogs, "latestIndex", latestIndex)
 			default:
 			}
 


### PR DESCRIPTION
consume fork 12 events from the GER manager contract to verify correctness of the info tree state.  On detecting an issue, unwind the info tree and re-sync to capture missed events.

rpc-cache tool with chaos mode to simulate logs going missing from the L1 service.