### PR TITLE
fix(panic): stop panic on eth_createAccessList when invalid account

### DIFF
--- a/turbo/jsonrpc/eth_call.go
+++ b/turbo/jsonrpc/eth_call.go
@@ -507,6 +507,9 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 				if err != nil {
 					return nil, err
 				}
+				if a == nil {
+					return nil, fmt.Errorf("account %s not found", args.From)
+				}
 				nonce = a.Nonce + 1
 			}
 


### PR DESCRIPTION
When you pass an invalid account the method handler will crash because of a panic. This is because it tries to read nil as the account because it was never found.