### PR TITLE
Fix DS client when block time is reduced

### DIFF
--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -345,6 +345,7 @@ func (c *StreamClient) GetHeader() (*types.HeaderEntry, error) {
 	}
 
 	c.header = h
+	log.Info("[Datastream client] getHeader", "header", c.header)
 
 	return h, nil
 }
@@ -524,6 +525,8 @@ func (c *StreamClient) afterStartCommand() (*types.ResultEntry, error) {
 // reads all entries from the server and sends them to a channel
 // sends the parsed FullL2Blocks with transactions to a channel
 func (c *StreamClient) readAllFullL2BlocksToChannel() (err error) {
+	log.Info("[Datastream client] reading full L2 blocks to channel", "header_totalEntries", c.header.TotalEntries)
+
 	readNewProto := true
 	entryNum := uint64(0)
 	parsedProto := interface{}(nil)
@@ -831,6 +834,10 @@ func (c *StreamClient) readHeaderEntry() (h *types.HeaderEntry, err error) {
 	}
 
 	headLength := binary.BigEndian.Uint32(binaryHeader[1:5])
+	if headLength != types.HeaderSize && headLength != types.HeaderSizePreEtrog {
+		return h, fmt.Errorf("read header bytes error, unexpected header size: %d", headLength)
+	}
+
 	if headLength == types.HeaderSize {
 		// Read the rest of fixed size fields
 		buffer, err := c.readBuffer(types.HeaderSize - types.HeaderSizePreEtrog)

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -576,7 +576,7 @@ LOOP:
 			time.Sleep(10 * time.Microsecond)
 		}
 
-		if c.header.TotalEntries == entryNum+1 {
+		if c.header.TotalEntries <= entryNum+1 {
 			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
 
 			if err := c.trySendStopSignal(); err != nil {


### PR DESCRIPTION
## Summary

- Fixes issues found on X Layer side, when we decreased block time
- Due to the increased speed of blocks inflow in the DS, there were some issues found on the DS side which resulted in the RPC sync to get stuck. Context of the issues:
   - https://github.com/okx/xlayer-erigon/issues/464
   - https://github.com/okx/xlayer-erigon/issues/487
- Issue 1: the atomicity of the blocks download is not consistent from the getHeader step and while downloading all block file entries to channel
- Issue 2: when block time is decreased, we cannot ensure certain assumptions will occur (such as flushes to the TCP connection), causing the decoding function to occasionally incorrect decode incorrect bytes
