### PR TITLE
fix(counters): return 0 counters on unlimited counters rpc call

### DIFF
--- a/turbo/jsonrpc/zkevm_counters.go
+++ b/turbo/jsonrpc/zkevm_counters.go
@@ -409,8 +409,7 @@ func (api *ZkEvmAPIImpl) GetBatchCountersByNumber(ctx context.Context, batchNumR
 		return nil, err
 	}
 
-	lastBlockNum := batchBlockNumbers[len(batchBlockNumbers)-1]
-	unlimitedCounters := chainConfig.IsNormalcy(lastBlockNum) || api.config.Zk.ShouldCountersBeUnlimited(api.config.Zk.IsL1Recovery())
+	unlimitedCounters := chainConfig.IsNormalcy(latestBlockNum) || api.config.Zk.ShouldCountersBeUnlimited(api.config.Zk.IsL1Recovery())
 
 	batchCounters := vm.NewBatchCounterCollector(smtDepth, uint16(forkId), api.config.Zk.VirtualCountersSmtReduction, unlimitedCounters, nil)
 
@@ -534,7 +533,7 @@ type batchCountersResponse struct {
 	BlockFrom      uint64           `json:"blockFrom"`
 	BlockTo        uint64           `json:"blockTo"`
 	CountersUsed   combinecCounters `json:"countersUsed"`
-	CoutnersLimits combinecCounters `json:"countersLimits"`
+	CountersLimits combinecCounters `json:"countersLimits"`
 }
 
 func populateBatchCounters(collected *vm.Counters, smtDepth int, batchNum, blockFrom, blockTo, totalGasUsed uint64) (jsonRes json.RawMessage, err error) {
@@ -592,7 +591,7 @@ func populateBatchCounters(collected *vm.Counters, smtDepth int, batchNum, block
 		BlockFrom:      blockFrom,
 		BlockTo:        blockTo,
 		CountersUsed:   countersUsed,
-		CoutnersLimits: countersLimits,
+		CountersLimits: countersLimits,
 	}
 
 	return json.Marshal(res)

--- a/turbo/jsonrpc/zkevm_counters.go
+++ b/turbo/jsonrpc/zkevm_counters.go
@@ -410,7 +410,7 @@ func (api *ZkEvmAPIImpl) GetBatchCountersByNumber(ctx context.Context, batchNumR
 	}
 
 	lastBlockNum := batchBlockNumbers[len(batchBlockNumbers)-1]
-	unlimitedCounters := chainConfig.IsNormalcy(lastBlockNum)
+	unlimitedCounters := chainConfig.IsNormalcy(lastBlockNum) || api.config.Zk.ShouldCountersBeUnlimited(api.config.Zk.IsL1Recovery())
 
 	batchCounters := vm.NewBatchCounterCollector(smtDepth, uint16(forkId), api.config.Zk.VirtualCountersSmtReduction, unlimitedCounters, nil)
 

--- a/turbo/jsonrpc/zkevm_counters.go
+++ b/turbo/jsonrpc/zkevm_counters.go
@@ -409,7 +409,10 @@ func (api *ZkEvmAPIImpl) GetBatchCountersByNumber(ctx context.Context, batchNumR
 		return nil, err
 	}
 
-	batchCounters := vm.NewBatchCounterCollector(smtDepth, uint16(forkId), api.config.Zk.VirtualCountersSmtReduction, false, nil)
+	lastBlockNum := batchBlockNumbers[len(batchBlockNumbers)-1]
+	unlimitedCounters := chainConfig.IsNormalcy(lastBlockNum)
+
+	batchCounters := vm.NewBatchCounterCollector(smtDepth, uint16(forkId), api.config.Zk.VirtualCountersSmtReduction, unlimitedCounters, nil)
 
 	var (
 		block                                   *types.Block
@@ -535,13 +538,32 @@ type batchCountersResponse struct {
 }
 
 func populateBatchCounters(collected *vm.Counters, smtDepth int, batchNum, blockFrom, blockTo, totalGasUsed uint64) (jsonRes json.RawMessage, err error) {
-
-	res := batchCountersResponse{
-		SmtDepth:    smtDepth,
-		BatchNumber: batchNum,
-		BlockFrom:   blockFrom,
-		BlockTo:     blockTo,
-		CountersUsed: combinecCounters{
+	var countersUsed combinecCounters
+	var countersLimits combinecCounters
+	if len(*collected) == 0 {
+		countersLimits = combinecCounters{
+			KeccakHashes:     0,
+			Poseidonhashes:   0,
+			PoseidonPaddings: 0,
+			MemAligns:        0,
+			Arithmetics:      0,
+			Binaries:         0,
+			Steps:            0,
+			SHA256hashes:     0,
+		}
+		countersUsed = combinecCounters{
+			Gas:              0,
+			KeccakHashes:     0,
+			Poseidonhashes:   0,
+			PoseidonPaddings: 0,
+			MemAligns:        0,
+			Arithmetics:      0,
+			Binaries:         0,
+			Steps:            0,
+			SHA256hashes:     0,
+		}
+	} else {
+		countersUsed = combinecCounters{
 			Gas:              totalGasUsed,
 			KeccakHashes:     collected.GetKeccakHashes().Used(),
 			Poseidonhashes:   collected.GetPoseidonHashes().Used(),
@@ -551,8 +573,8 @@ func populateBatchCounters(collected *vm.Counters, smtDepth int, batchNum, block
 			Binaries:         collected.GetBinaries().Used(),
 			Steps:            collected.GetSteps().Used(),
 			SHA256hashes:     collected.GetSHA256Hashes().Used(),
-		},
-		CoutnersLimits: combinecCounters{
+		}
+		countersLimits = combinecCounters{
 			KeccakHashes:     collected.GetKeccakHashes().Limit(),
 			Poseidonhashes:   collected.GetPoseidonHashes().Limit(),
 			PoseidonPaddings: collected.GetPoseidonPaddings().Limit(),
@@ -561,7 +583,16 @@ func populateBatchCounters(collected *vm.Counters, smtDepth int, batchNum, block
 			Binaries:         collected.GetBinaries().Limit(),
 			Steps:            collected.GetSteps().Limit(),
 			SHA256hashes:     collected.GetSHA256Hashes().Limit(),
-		},
+		}
+	}
+
+	res := batchCountersResponse{
+		SmtDepth:       smtDepth,
+		BatchNumber:    batchNum,
+		BlockFrom:      blockFrom,
+		BlockTo:        blockTo,
+		CountersUsed:   countersUsed,
+		CoutnersLimits: countersLimits,
 	}
 
 	return json.Marshal(res)


### PR DESCRIPTION
When the batch has unlimited counters the RPC call still counts counters. This is changed to represent the fact the batch has unlimited counters.