### PR TITLE
Feat/transaction yield async

### DIFF
--- a/cmd/integration/commands/stages_zkevm.go
+++ b/cmd/integration/commands/stages_zkevm.go
@@ -129,6 +129,7 @@ func newSyncZk(ctx context.Context, db kv.RwDB) (consensus.Engine, *vm.Config, *
 			nil,
 			nil,
 			nil,
+			nil,
 		)
 	} else {
 		stages = stages2.NewDefaultZkStages(

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -578,7 +578,7 @@ var (
 	}
 	SequencerTimeoutOnEmptyTxPool = cli.StringFlag{
 		Name:  "zkevm.sequencer-timeout-on-empty-tx-pool",
-		Usage: "Timeout before requesting txs from the txpool if none were found before. Defaults to 250ms",
+		Usage: "Timeout before requesting txs from the txpool if none were found before. Defaults to 5ms",
 		Value: "5ms",
 	}
 	SequencerHaltOnBatchNumber = cli.Uint64Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -579,7 +579,7 @@ var (
 	SequencerTimeoutOnEmptyTxPool = cli.StringFlag{
 		Name:  "zkevm.sequencer-timeout-on-empty-tx-pool",
 		Usage: "Timeout before requesting txs from the txpool if none were found before. Defaults to 250ms",
-		Value: "250ms",
+		Value: "5ms",
 	}
 	SequencerHaltOnBatchNumber = cli.Uint64Flag{
 		Name:  "zkevm.sequencer-halt-on-batch-number",

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -116,7 +116,6 @@ func SpawnMiningExecStage(s *StageState, tx kv.RwTx, cfg MiningExecCfg, quit <-c
 			NotifyPendingLogs(logPrefix, cfg.notifier, logs, logger)
 		} else {
 
-			yielded := mapset.NewSet[[32]byte]()
 			var simulationTx kv.StatelessRwTx
 			m := membatch.NewHashBatch(tx, quit, cfg.tmpdir, logger)
 			defer m.Close()
@@ -128,7 +127,7 @@ func SpawnMiningExecStage(s *StageState, tx kv.RwTx, cfg MiningExecCfg, quit <-c
 			}
 
 			for {
-				txs, y, err := getNextTransactions(cfg, chainID, current.Header, 50, executionAt, stateReader, simulationTx, yielded, logger)
+				txs, y, err := getNextTransactions(cfg, chainID, current.Header, 50, executionAt, stateReader, simulationTx, logger)
 				if err != nil {
 					return err
 				}
@@ -190,7 +189,6 @@ func getNextTransactions(
 	executionAt uint64,
 	stateReader state.StateReader,
 	simulationTx kv.StatelessRwTx,
-	alreadyYielded mapset.Set[[32]byte],
 	logger log.Logger,
 ) (types.TransactionsStream, int, error) {
 	txSlots := types2.TxsRlp{}
@@ -204,7 +202,7 @@ func getNextTransactions(
 			remainingBlobGas = cfg.chainConfig.GetMaxBlobGasPerBlock(header.Time) - *header.BlobGasUsed
 		}
 
-		if _, count, err = cfg.txPool2.YieldBest(amount, &txSlots, poolTx, executionAt, remainingGas, remainingBlobGas, alreadyYielded); err != nil {
+		if _, count, err = cfg.txPool2.YieldBest(amount, &txSlots, poolTx, executionAt, remainingGas, remainingBlobGas); err != nil {
 			return err
 		}
 

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -127,6 +127,9 @@ func SpawnMiningExecStage(s *StageState, tx kv.RwTx, cfg MiningExecCfg, quit <-c
 			}
 
 			for {
+				// [zkevm] - warning here!  we no longer send an already yielded map here so if this code is
+				// ever required again then there needs to be a manual check for the yielded transactions already in a
+				// block.  see transaction_yielder.go for more details on how zkevm sequencer handles this
 				txs, y, err := getNextTransactions(cfg, chainID, current.Header, 50, executionAt, stateReader, simulationTx, logger)
 				if err != nil {
 					return err

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -21,6 +21,7 @@ import (
 	zkStages "github.com/erigontech/erigon/zk/stages"
 	"github.com/erigontech/erigon/zk/syncer"
 	"github.com/erigontech/erigon/zk/txpool"
+	"github.com/erigontech/erigon/zk/sequencer"
 )
 
 // NewDefaultZkStages creates stages for zk syncer (RPC mode)
@@ -109,6 +110,7 @@ func NewSequencerZkStages(ctx context.Context,
 	verifier *legacy_executor_verifier.LegacyExecutorVerifier,
 	infoTreeUpdater *l1infotree.Updater,
 	hook *Hook,
+	txYielder *sequencer.PoolTransactionYielder,
 ) []*stagedsync.Stage {
 	dirs := cfg.Dirs
 	blockReader := freezeblocks.NewBlockReader(snapshots, nil)
@@ -149,6 +151,7 @@ func NewSequencerZkStages(ctx context.Context,
 			uint16(cfg.YieldSize),
 			infoTreeUpdater,
 			hook,
+			txYielder,
 		),
 		stagedsync.StageHashStateCfg(db, dirs, cfg.HistoryV3, agg),
 		zkStages.StageZkInterHashesCfg(db, !cfg.DebugDisableStateRootCheck, true, false, dirs.Tmp, blockReader, controlServer.Hd, cfg.HistoryV3, agg, cfg.Zk),

--- a/zk/sequencer/effective_gas.go
+++ b/zk/sequencer/effective_gas.go
@@ -1,0 +1,30 @@
+package sequencer
+
+import (
+	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/eth/ethconfig"
+)
+
+func deriveEffectiveGasPrice(cfg ethconfig.Zk, tx types.Transaction) uint8 {
+	if tx.GetTo() == nil {
+		return cfg.EffectiveGasPriceForContractDeployment
+	}
+
+	data := tx.GetData()
+	dataLen := len(data)
+	if dataLen != 0 {
+		if dataLen >= 8 {
+			// transfer's method id 0xa9059cbb
+			isTransfer := data[0] == 169 && data[1] == 5 && data[2] == 156 && data[3] == 187
+			// transfer's method id 0x23b872dd
+			isTransferFrom := data[0] == 35 && data[1] == 184 && data[2] == 114 && data[3] == 221
+			if isTransfer || isTransferFrom {
+				return cfg.EffectiveGasPriceForErc20Transfer
+			}
+		}
+
+		return cfg.EffectiveGasPriceForContractInvocation
+	}
+
+	return cfg.EffectiveGasPriceForEthTransfer
+}

--- a/zk/sequencer/effective_gas.go
+++ b/zk/sequencer/effective_gas.go
@@ -1,11 +1,11 @@
 package sequencer
 
 import (
-	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/eth/ethconfig"
+	"github.com/erigontech/erigon/core/types"
 )
 
-func deriveEffectiveGasPrice(cfg ethconfig.Zk, tx types.Transaction) uint8 {
+func DeriveEffectiveGasPrice(cfg ethconfig.Zk, tx types.Transaction) uint8 {
 	if tx.GetTo() == nil {
 		return cfg.EffectiveGasPriceForContractDeployment
 	}

--- a/zk/sequencer/transaction_yielder.go
+++ b/zk/sequencer/transaction_yielder.go
@@ -1,0 +1,313 @@
+package sequencer
+
+import (
+	"github.com/erigontech/erigon/core/types"
+	"golang.org/x/net/context"
+	"github.com/erigontech/erigon/zk/txpool"
+	"github.com/erigontech/erigon-lib/kv"
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon/zk/utils"
+	types2 "github.com/erigontech/erigon-lib/types"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/eth/ethconfig"
+	"time"
+	"sync"
+)
+
+type PoolTransactionYielder struct {
+	ctx context.Context
+	cfg ethconfig.Zk
+
+	readyMtx              sync.Mutex
+	readyTransactions     []common.Hash
+	readyTransactionBytes map[common.Hash][]byte
+	toSkip                map[common.Hash]struct{}
+
+	pool      *txpool.TxPool
+	yieldSize uint16
+
+	// the pool db which sits separate from the usual erigon db
+	db kv.RwDB
+
+	decodedTxCache *expirable.LRU[common.Hash, *types.Transaction]
+
+	// executionAt and forkId are used during the yielding process and will be
+	// updated by the sequencer every time a new block is being processed.
+	executionAt uint64
+	forkId      uint64
+
+	startedYielding    bool
+	startedYieldingMtx sync.Mutex
+}
+
+func NewPoolTransactionYielder(
+	ctx context.Context,
+	cfg ethconfig.Zk,
+	pool *txpool.TxPool,
+	yieldSize uint16,
+	db kv.RwDB,
+	decodedTxCache *expirable.LRU[common.Hash, *types.Transaction],
+) *PoolTransactionYielder {
+	// Initialize the channel with the specified size
+	readyTransactions := make([]common.Hash, 0)
+
+	return &PoolTransactionYielder{
+		readyTransactions:     readyTransactions,
+		readyTransactionBytes: make(map[common.Hash][]byte),
+		readyMtx:              sync.Mutex{},
+		toSkip:                make(map[common.Hash]struct{}),
+		ctx:                   ctx,
+		cfg:                   cfg,
+		pool:                  pool,
+		yieldSize:             yieldSize,
+		db:                    db,
+		decodedTxCache:        decodedTxCache,
+		startedYielding:       false,
+		startedYieldingMtx:    sync.Mutex{},
+	}
+}
+
+func (y *PoolTransactionYielder) YieldNextTransaction() (types.Transaction, uint8, bool) {
+	var tx types.Transaction
+	var effectiveGas uint8
+	var err error
+	var yieldedIdx int
+
+	y.readyMtx.Lock()
+	defer y.readyMtx.Unlock()
+
+	for idx, hash := range y.readyTransactions {
+		if _, found := y.toSkip[hash]; found {
+			continue
+		}
+		if txBytes, found := y.readyTransactionBytes[hash]; found {
+			txPtr, inCache := y.decodedTxCache.Get(hash)
+			if inCache {
+				tx = *txPtr
+			} else {
+				tx, err = types.DecodeTransaction(txBytes)
+				if err != nil {
+					log.Warn("[extractTransaction] Failed to decode transaction from ready queue, skipping and removing from queue",
+						"error", err,
+						"id", hash.String())
+					y.pool.MarkForDiscardFromPendingBest(hash)
+					y.toSkip[hash] = struct{}{}
+					continue // Skip this transaction if decoding fails
+				}
+				y.decodedTxCache.Add(hash, &tx)
+			}
+			effectiveGas = deriveEffectiveGasPrice(y.cfg, tx)
+			yieldedIdx = idx
+			break
+		}
+	}
+
+	return tx, effectiveGas, tx != nil && yieldedIdx < len(y.readyTransactions)
+}
+
+func (y *PoolTransactionYielder) RemoveMinedTransactions(hashes []common.Hash) {
+	y.readyMtx.Lock()
+	defer y.readyMtx.Unlock()
+
+	for _, hash := range hashes {
+		if _, found := y.decodedTxCache.Get(hash); found {
+			y.decodedTxCache.Remove(hash)
+		}
+	}
+
+	// ensure we take a fresh view on the pool
+	y.toSkip = make(map[common.Hash]struct{})
+}
+
+func (y *PoolTransactionYielder) AddMined(hash common.Hash) {
+	y.readyMtx.Lock()
+	defer y.readyMtx.Unlock()
+	y.toSkip[hash] = struct{}{}
+}
+
+func (y *PoolTransactionYielder) SetExecutionDetails(executionAt, forkId uint64) {
+	y.executionAt = executionAt
+	y.forkId = forkId
+}
+
+func (y *PoolTransactionYielder) BeginYielding() {
+	if y.alreadyYielding() {
+		return // Yielding has already started, no need to start again
+	}
+
+	for {
+		select {
+		case <-y.ctx.Done():
+			log.Info("Transaction yielder context done, stopping yielding")
+			y.startedYieldingMtx.Lock()
+			y.startedYielding = false
+			y.startedYieldingMtx.Unlock()
+			return
+		default:
+		}
+
+		y.performNextRefresh()
+
+		// add in some delay here to avoid spamming the pool too quickly
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func (y *PoolTransactionYielder) performNextRefresh() {
+	txHashes, txBytes, err := y.refreshPoolTransactions(y.executionAt, y.forkId)
+	if err != nil {
+		log.Error("Error while yielding next transactions", "error", err)
+		time.Sleep(500 * time.Millisecond) // could be a transient error, wait before retrying
+	}
+
+	y.readyMtx.Lock()
+	defer y.readyMtx.Unlock()
+
+	y.readyTransactions = y.readyTransactions[:0] // Clear the ready transactions slice
+
+	for idx, hash := range txHashes {
+		y.readyTransactions = append(y.readyTransactions, hash)
+		y.readyTransactionBytes[hash] = txBytes[idx]
+	}
+}
+
+func (y *PoolTransactionYielder) alreadyYielding() bool {
+	y.startedYieldingMtx.Lock()
+	defer y.startedYieldingMtx.Unlock()
+	if y.startedYielding {
+		return true
+	}
+	y.startedYielding = true
+	return false
+}
+
+func (y *PoolTransactionYielder) refreshPoolTransactions(executionAt, forkId uint64) ([]common.Hash, [][]byte, error) {
+	gasLimit := utils.GetBlockGasLimitForFork(forkId)
+
+	ti := utils.StartTimer("txpool", "get-transactions")
+	defer ti.LogTimer()
+
+	y.pool.PreYield()
+	defer y.pool.PostYield()
+
+	var ids []common.Hash
+	var txBytes [][]byte
+
+	err := y.db.View(y.ctx, func(poolTx kv.Tx) error {
+		slots := types2.TxsRlp{}
+		_, _, err := y.pool.YieldBest(y.yieldSize, &slots, poolTx, executionAt, gasLimit, 0)
+		if err != nil {
+			return err
+		}
+		ids, txBytes, err = y.extractTransactionsFromSlot(&slots)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ids, txBytes, nil
+}
+
+func (y *PoolTransactionYielder) extractTransactionsFromSlot(slot *types2.TxsRlp) ([]common.Hash, [][]byte, error) {
+	ids := make([]common.Hash, 0, len(slot.TxIds))
+	txBytes := make([][]byte, 0, len(slot.Txs))
+
+	for idx, bytes := range slot.Txs {
+		// get the id of the transaction and
+		ids = append(ids, slot.TxIds[idx])
+		txBytes = append(txBytes, bytes)
+	}
+
+	return ids, txBytes, nil
+}
+
+type LimboTransactionYielder struct {
+	transactions []types.Transaction
+	cfg          ethconfig.Zk
+}
+
+func NewLimboTransactionYielder(transactions []types.Transaction, cfg ethconfig.Zk) *LimboTransactionYielder {
+	return &LimboTransactionYielder{
+		transactions: transactions,
+		cfg:          cfg,
+	}
+}
+
+func (l *LimboTransactionYielder) YieldNextTransaction() (types.Transaction, uint8, bool) {
+	if len(l.transactions) == 0 {
+		return nil, 0, false
+	}
+
+	tx := l.transactions[0]
+	effectiveGas := deriveEffectiveGasPrice(l.cfg, tx)
+	l.transactions = l.transactions[1:] // Remove the transaction after yielding it
+
+	return tx, effectiveGas, true
+}
+
+func (l *LimboTransactionYielder) AddMined(_ common.Hash) {
+	// no need to maintain this
+}
+
+func (l *LimboTransactionYielder) RemoveMinedTransactions(hashes []common.Hash) {
+	// do nothing as we remove transactions immediately after yielding them
+}
+
+func (l *LimboTransactionYielder) SetExecutionDetails(_, _ uint64) {
+	// LimboTransactionYielder does not use executionAt and forkId, so this method can be empty
+}
+
+func (l *LimboTransactionYielder) BeginYielding() {
+	// do nothing
+}
+
+type RecoveryTransactionYielder struct {
+	transactions         []types.Transaction
+	effectivePercentages []uint8
+}
+
+func NewRecoveryTransactionYielder(transactions []types.Transaction, effectivePercentages []uint8) *RecoveryTransactionYielder {
+	return &RecoveryTransactionYielder{
+		transactions:         transactions,
+		effectivePercentages: effectivePercentages,
+	}
+}
+
+func (d *RecoveryTransactionYielder) YieldNextTransaction() (types.Transaction, uint8, bool) {
+	if len(d.transactions) == 0 {
+		return nil, 0, false
+	}
+
+	tx := d.transactions[0]
+	effectiveGas := d.effectivePercentages[0]
+
+	if len(d.transactions) > 0 {
+		d.transactions = d.transactions[1:] // Remove the transaction after yielding it
+	}
+	if len(d.effectivePercentages) > 0 {
+		d.effectivePercentages = d.effectivePercentages[1:]
+	}
+
+	return tx, effectiveGas, true
+}
+
+func (d *RecoveryTransactionYielder) AddMined(_ common.Hash) {
+	// no need to maintain this
+}
+
+func (d *RecoveryTransactionYielder) RemoveMinedTransactions(hashes []common.Hash) {
+	// do nothing as we remove transactions immediately after yielding them
+}
+
+func (d *RecoveryTransactionYielder) SetExecutionDetails(_, _ uint64) {
+	// RecoveryTransactionYielder does not use executionAt and forkId, so this method can be empty
+}
+
+func (d *RecoveryTransactionYielder) BeginYielding() {
+	// do nothing
+}

--- a/zk/sequencer/transaction_yielder.go
+++ b/zk/sequencer/transaction_yielder.go
@@ -83,12 +83,12 @@ func (y *PoolTransactionYielder) YieldNextTransaction() (types.Transaction, uint
 	var tx types.Transaction
 	var effectiveGas uint8
 	var err error
-	var yieldedIdx int
+	var yieldedSomething bool
 
 	y.readyMtx.Lock()
 	defer y.readyMtx.Unlock()
 
-	for idx, hash := range y.readyTransactions {
+	for _, hash := range y.readyTransactions {
 		if _, found := y.toSkip[hash]; found {
 			continue
 		}
@@ -104,22 +104,26 @@ func (y *PoolTransactionYielder) YieldNextTransaction() (types.Transaction, uint
 						"id", hash.String())
 					y.pool.MarkForDiscardFromPendingBest(hash)
 					y.toSkip[hash] = struct{}{}
-					continue // Skip this transaction if decoding fails
+					continue
 				}
 				y.decodedTxCache.Add(hash, &tx)
 			}
 			effectiveGas = deriveEffectiveGasPrice(y.cfg, tx)
-			yieldedIdx = idx
+			yieldedSomething = true
 			break
 		}
 	}
 
-	return tx, effectiveGas, tx != nil && yieldedIdx < len(y.readyTransactions)
+	return tx, effectiveGas, yieldedSomething
 }
 
 func (y *PoolTransactionYielder) RemoveMinedTransactions(hashes []common.Hash) {
 	y.readyMtx.Lock()
 	defer y.readyMtx.Unlock()
+
+	for _, hash := range hashes {
+		y.decodedTxCache.Remove(hash)
+	}
 
 	// ensure we take a fresh view on the pool
 	y.toSkip = make(map[common.Hash]struct{})
@@ -201,6 +205,9 @@ func (y *PoolTransactionYielder) performNextRefresh() {
 	defer y.readyMtx.Unlock()
 
 	y.readyTransactions = y.readyTransactions[:0] // Clear the ready transactions slice
+	for hash := range y.readyTransactionBytes {
+		delete(y.readyTransactionBytes, hash)
+	}
 
 	for idx, hash := range txHashes {
 		y.readyTransactions = append(y.readyTransactions, hash)

--- a/zk/sequencer/transaction_yielder.go
+++ b/zk/sequencer/transaction_yielder.go
@@ -60,7 +60,6 @@ func NewPoolTransactionYielder(
 	db kv.RwDB,
 	decodedTxCache *expirable.LRU[common.Hash, *types.Transaction],
 ) *PoolTransactionYielder {
-	// Initialize the channel with the specified size
 	readyTransactions := make([]common.Hash, 0)
 
 	return &PoolTransactionYielder{
@@ -108,7 +107,7 @@ func (y *PoolTransactionYielder) YieldNextTransaction() (types.Transaction, uint
 				}
 				y.decodedTxCache.Add(hash, &tx)
 			}
-			effectiveGas = deriveEffectiveGasPrice(y.cfg, tx)
+			effectiveGas = DeriveEffectiveGasPrice(y.cfg, tx)
 			yieldedSomething = true
 			break
 		}
@@ -204,13 +203,16 @@ func (y *PoolTransactionYielder) performNextRefresh() {
 	y.readyMtx.Lock()
 	defer y.readyMtx.Unlock()
 
-	y.readyTransactions = y.readyTransactions[:0] // Clear the ready transactions slice
-	for hash := range y.readyTransactionBytes {
-		delete(y.readyTransactionBytes, hash)
+	// Ensure capacity and copy in one operation and keep allocations down
+	if cap(y.readyTransactions) < len(txHashes) {
+		y.readyTransactions = make([]common.Hash, len(txHashes))
+	} else {
+		y.readyTransactions = y.readyTransactions[:len(txHashes)]
 	}
+	copy(y.readyTransactions, txHashes)
 
+	y.readyTransactionBytes = make(map[common.Hash][]byte)
 	for idx, hash := range txHashes {
-		y.readyTransactions = append(y.readyTransactions, hash)
 		y.readyTransactionBytes[hash] = txBytes[idx]
 	}
 }
@@ -277,7 +279,7 @@ func (l *LimboTransactionYielder) YieldNextTransaction() (types.Transaction, uin
 	}
 
 	tx := l.transactions[0]
-	effectiveGas := deriveEffectiveGasPrice(l.cfg, tx)
+	effectiveGas := DeriveEffectiveGasPrice(l.cfg, tx)
 	l.transactions = l.transactions[1:] // Remove the transaction after yielding it
 
 	return tx, effectiveGas, true

--- a/zk/sequencer/transaction_yielder.go
+++ b/zk/sequencer/transaction_yielder.go
@@ -1,18 +1,19 @@
 package sequencer
 
 import (
-	"github.com/erigontech/erigon/core/types"
-	"golang.org/x/net/context"
-	"github.com/erigontech/erigon/zk/txpool"
-	"github.com/erigontech/erigon-lib/kv"
-	"github.com/erigontech/erigon-lib/common"
-	"github.com/erigontech/erigon/zk/utils"
-	types2 "github.com/erigontech/erigon-lib/types"
-	"github.com/hashicorp/golang-lru/v2/expirable"
-	"github.com/erigontech/erigon-lib/log/v3"
-	"github.com/erigontech/erigon/eth/ethconfig"
-	"time"
 	"sync"
+	"time"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/kv"
+	"github.com/erigontech/erigon-lib/log/v3"
+	types2 "github.com/erigontech/erigon-lib/types"
+	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/eth/ethconfig"
+	"github.com/erigontech/erigon/zk/txpool"
+	"github.com/erigontech/erigon/zk/utils"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"golang.org/x/net/context"
 )
 
 type PoolTransactionYielder struct {

--- a/zk/sequencer/transaction_yielder.go
+++ b/zk/sequencer/transaction_yielder.go
@@ -124,6 +124,18 @@ func (y *PoolTransactionYielder) AddMined(hash common.Hash) {
 	y.readyMtx.Lock()
 	defer y.readyMtx.Unlock()
 	y.toSkip[hash] = struct{}{}
+
+	// remove the transaction from the readyTransactions slice. this will save burning CPU for the next yielding
+	// for a transaction to execute.  we still maintain the hash in the toSkip map to avoid yielding it again
+	// when we refresh the pool best list into the readyTransactions slice. there is a window where we have
+	// executed something, but the pool hasn't removed it yet, so we could yield it again before this has happened
+	for idx, readyHash := range y.readyTransactions {
+		if readyHash == hash {
+			// Remove the transaction from the slice
+			y.readyTransactions = append(y.readyTransactions[:idx], y.readyTransactions[idx+1:]...)
+			break
+		}
+	}
 }
 
 func (y *PoolTransactionYielder) SetExecutionDetails(executionAt, forkId uint64) {

--- a/zk/sequencer/transaction_yielder.go
+++ b/zk/sequencer/transaction_yielder.go
@@ -162,7 +162,7 @@ func (y *PoolTransactionYielder) BeginYielding() {
 		y.performNextRefresh()
 
 		// add in some delay here to avoid spamming the pool too quickly
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/zk/sequencer/transaction_yielder.go
+++ b/zk/sequencer/transaction_yielder.go
@@ -144,26 +144,38 @@ func (y *PoolTransactionYielder) SetExecutionDetails(executionAt, forkId uint64)
 }
 
 func (y *PoolTransactionYielder) BeginYielding() {
-	if y.alreadyYielding() {
-		return // Yielding has already started, no need to start again
+	y.startedYieldingMtx.Lock()
+	defer y.startedYieldingMtx.Unlock()
+
+	if y.startedYielding {
+		return
 	}
+
+	y.startedYielding = true
+
+	go y.startLoop()
+}
+
+func (y *PoolTransactionYielder) startLoop() {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-y.ctx.Done():
 			log.Info("Transaction yielder context done, stopping yielding")
-			y.startedYieldingMtx.Lock()
-			y.startedYielding = false
-			y.startedYieldingMtx.Unlock()
+			y.setYieldingState(false)
 			return
-		default:
+		case <-ticker.C:
+			y.performNextRefresh()
 		}
-
-		y.performNextRefresh()
-
-		// add in some delay here to avoid spamming the pool too quickly
-		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+func (y *PoolTransactionYielder) setYieldingState(state bool) {
+	y.startedYieldingMtx.Lock()
+	defer y.startedYieldingMtx.Unlock()
+	y.startedYielding = state
 }
 
 func (y *PoolTransactionYielder) performNextRefresh() {
@@ -182,16 +194,6 @@ func (y *PoolTransactionYielder) performNextRefresh() {
 		y.readyTransactions = append(y.readyTransactions, hash)
 		y.readyTransactionBytes[hash] = txBytes[idx]
 	}
-}
-
-func (y *PoolTransactionYielder) alreadyYielding() bool {
-	y.startedYieldingMtx.Lock()
-	defer y.startedYieldingMtx.Unlock()
-	if y.startedYielding {
-		return true
-	}
-	y.startedYielding = true
-	return false
 }
 
 func (y *PoolTransactionYielder) refreshPoolTransactions(executionAt, forkId uint64) ([]common.Hash, [][]byte, error) {

--- a/zk/sequencer/transaction_yielder.go
+++ b/zk/sequencer/transaction_yielder.go
@@ -1,6 +1,7 @@
 package sequencer
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -20,10 +21,19 @@ type PoolTransactionYielder struct {
 	ctx context.Context
 	cfg ethconfig.Zk
 
-	readyMtx              sync.Mutex
+	readyMtx sync.Mutex
+
+	// readyTransactions and readyTransactionBytes are used to avoid us eagerly
+	// decoding a transaction that we may never work with. instead we defer this
+	// until we yield that single transaction.
 	readyTransactions     []common.Hash
 	readyTransactionBytes map[common.Hash][]byte
-	toSkip                map[common.Hash]struct{}
+
+	// toSkip is used to hold on to a map of hashes for transactions that have been
+	// yielded and mined.  there is a lag between a block being built and the pool
+	// handling the removal.  because we continuosly yield transactions we need a
+	// way to handle this lag so we don't keep yielding the same transaction over and over.
+	toSkip map[common.Hash]struct{}
 
 	pool      *txpool.TxPool
 	yieldSize uint16
@@ -111,12 +121,6 @@ func (y *PoolTransactionYielder) RemoveMinedTransactions(hashes []common.Hash) {
 	y.readyMtx.Lock()
 	defer y.readyMtx.Unlock()
 
-	for _, hash := range hashes {
-		if _, found := y.decodedTxCache.Get(hash); found {
-			y.decodedTxCache.Remove(hash)
-		}
-	}
-
 	// ensure we take a fresh view on the pool
 	y.toSkip = make(map[common.Hash]struct{})
 }
@@ -130,13 +134,17 @@ func (y *PoolTransactionYielder) AddMined(hash common.Hash) {
 	// for a transaction to execute.  we still maintain the hash in the toSkip map to avoid yielding it again
 	// when we refresh the pool best list into the readyTransactions slice. there is a window where we have
 	// executed something, but the pool hasn't removed it yet, so we could yield it again before this has happened
+	foundIdx := -1
 	for idx, readyHash := range y.readyTransactions {
 		if readyHash == hash {
-			// Remove the transaction from the slice
-			y.readyTransactions = append(y.readyTransactions[:idx], y.readyTransactions[idx+1:]...)
+			foundIdx = idx
 			break
 		}
 	}
+	if foundIdx != -1 {
+		y.readyTransactions = append(y.readyTransactions[:foundIdx], y.readyTransactions[foundIdx+1:]...)
+	}
+	delete(y.readyTransactionBytes, hash)
 }
 
 func (y *PoolTransactionYielder) SetExecutionDetails(executionAt, forkId uint64) {
@@ -184,6 +192,9 @@ func (y *PoolTransactionYielder) performNextRefresh() {
 	if err != nil {
 		log.Error("Error while yielding next transactions", "error", err)
 		time.Sleep(500 * time.Millisecond) // could be a transient error, wait before retrying
+		// return early as there will be nothing to process now - we'll
+		// wait until the next iteration happens to attempt again
+		return
 	}
 
 	y.readyMtx.Lock()
@@ -286,11 +297,15 @@ type RecoveryTransactionYielder struct {
 	effectivePercentages []uint8
 }
 
-func NewRecoveryTransactionYielder(transactions []types.Transaction, effectivePercentages []uint8) *RecoveryTransactionYielder {
+func NewRecoveryTransactionYielder(transactions []types.Transaction, effectivePercentages []uint8) (*RecoveryTransactionYielder, error) {
+	if len(transactions) != len(effectivePercentages) {
+		return nil, errors.New("transactions and effectivePercentages must have the same length")
+	}
+
 	return &RecoveryTransactionYielder{
 		transactions:         transactions,
 		effectivePercentages: effectivePercentages,
-	}
+	}, nil
 }
 
 func (d *RecoveryTransactionYielder) YieldNextTransaction() (types.Transaction, uint8, bool) {

--- a/zk/sequencer/transaction_yielder_test.go
+++ b/zk/sequencer/transaction_yielder_test.go
@@ -456,7 +456,8 @@ func TestRecoveryTransactionYielder(t *testing.T) {
 	transactions := []types.Transaction{tx1, tx2}
 	effectivePercentages := []uint8{15, 25}
 
-	yielder := NewRecoveryTransactionYielder(transactions, effectivePercentages)
+	yielder, err := NewRecoveryTransactionYielder(transactions, effectivePercentages)
+	assert.NoError(t, err)
 
 	// Test yielding first transaction
 	tx, effectiveGas, hasMore := yielder.YieldNextTransaction()

--- a/zk/sequencer/transaction_yielder_test.go
+++ b/zk/sequencer/transaction_yielder_test.go
@@ -1,0 +1,512 @@
+package sequencer
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/kv/memdb"
+	types2 "github.com/erigontech/erigon-lib/types"
+	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/eth/ethconfig"
+	"github.com/erigontech/erigon/zk/txpool"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+// Mock transaction for testing
+func createMockTransaction(nonce uint64, to *common.Address, data []byte) types.Transaction {
+	if to == nil {
+		// Contract creation
+		tx := types.NewContractCreation(nonce, uint256.NewInt(1000), 21000, uint256.NewInt(2000000000), data)
+		return tx
+	}
+	// Regular transaction
+	tx := types.NewTransaction(nonce, *to, uint256.NewInt(1000), 21000, uint256.NewInt(2000000000), data)
+	return tx
+}
+
+// Mock transaction bytes for testing
+func createMockTransactionBytes(tx types.Transaction) []byte {
+	var buf bytes.Buffer
+	tx.MarshalBinary(&buf)
+	return buf.Bytes()
+}
+
+func TestNewPoolTransactionYielder(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{
+		EffectiveGasPriceForEthTransfer:        10,
+		EffectiveGasPriceForErc20Transfer:      20,
+		EffectiveGasPriceForContractInvocation: 30,
+		EffectiveGasPriceForContractDeployment: 40,
+	}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	assert.NotNil(t, yielder)
+	assert.Equal(t, ctx, yielder.ctx)
+	assert.Equal(t, cfg, yielder.cfg)
+	assert.Equal(t, pool, yielder.pool)
+	assert.Equal(t, uint16(10), yielder.yieldSize)
+	assert.Equal(t, mockDB, yielder.db)
+	assert.Equal(t, cache, yielder.decodedTxCache)
+	assert.False(t, yielder.startedYielding)
+	assert.Empty(t, yielder.readyTransactions)
+	assert.Empty(t, yielder.readyTransactionBytes)
+	assert.Empty(t, yielder.toSkip)
+}
+
+func TestPoolTransactionYielder_YieldNextTransaction_EmptyPool(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Test yielding when no transactions are available
+	tx, effectiveGas, hasMore := yielder.YieldNextTransaction()
+
+	assert.Nil(t, tx)
+	assert.Equal(t, uint8(0), effectiveGas)
+	assert.False(t, hasMore)
+}
+
+func TestPoolTransactionYielder_YieldNextTransaction_WithValidTransactions(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{
+		EffectiveGasPriceForEthTransfer:        10,
+		EffectiveGasPriceForErc20Transfer:      20,
+		EffectiveGasPriceForContractInvocation: 30,
+		EffectiveGasPriceForContractDeployment: 40,
+	}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Create test transactions
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tx1 := createMockTransaction(1, &to, []byte{})                                   // ETH transfer
+	tx2 := createMockTransaction(2, &to, []byte{169, 5, 156, 187, 169, 5, 156, 187}) // ERC20 transfer
+
+	tx1Bytes := createMockTransactionBytes(tx1)
+	tx2Bytes := createMockTransactionBytes(tx2)
+
+	// Manually populate the ready transactions
+	yielder.readyMtx.Lock()
+	yielder.readyTransactions = []common.Hash{tx1.Hash(), tx2.Hash()}
+	yielder.readyTransactionBytes[tx1.Hash()] = tx1Bytes
+	yielder.readyTransactionBytes[tx2.Hash()] = tx2Bytes
+	yielder.readyMtx.Unlock()
+
+	// Test yielding first transaction
+	tx, effectiveGas, hasMore := yielder.YieldNextTransaction()
+
+	assert.NotNil(t, tx)
+	assert.Equal(t, uint8(10), effectiveGas)
+	assert.True(t, hasMore)
+
+	// pretend we mined this first transaction
+	yielder.AddMined(tx.Hash())
+
+	// Test yielding second transaction
+	tx, effectiveGas, hasMore = yielder.YieldNextTransaction()
+
+	assert.NotNil(t, tx)
+	assert.Equal(t, uint8(20), effectiveGas) // ERC20 transfer effective gas
+	assert.True(t, hasMore)
+
+	// pretend we mined this second transaction
+	yielder.AddMined(tx.Hash())
+
+	// Test yielding when no more transactions
+	tx, effectiveGas, hasMore = yielder.YieldNextTransaction()
+
+	assert.Nil(t, tx)
+	assert.Equal(t, uint8(0), effectiveGas)
+	assert.False(t, hasMore)
+}
+
+func TestPoolTransactionYielder_YieldNextTransaction_WithCachedTransactions(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{
+		EffectiveGasPriceForEthTransfer: 10,
+	}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Create test transaction
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tx := createMockTransaction(1, &to, []byte{})
+	txBytes := createMockTransactionBytes(tx)
+
+	// Add transaction to cache
+	cache.Add(tx.Hash(), &tx)
+
+	// Manually populate the ready transactions
+	yielder.readyMtx.Lock()
+	yielder.readyTransactions = []common.Hash{tx.Hash()}
+	yielder.readyTransactionBytes[tx.Hash()] = txBytes
+	yielder.readyMtx.Unlock()
+
+	// Test yielding cached transaction
+	resultTx, effectiveGas, hasMore := yielder.YieldNextTransaction()
+
+	assert.NotNil(t, resultTx)
+	assert.Equal(t, tx.Hash(), resultTx.Hash())
+	assert.Equal(t, uint8(10), effectiveGas)
+	assert.True(t, hasMore)
+}
+
+func TestPoolTransactionYielder_YieldNextTransaction_WithSkippedTransactions(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{
+		EffectiveGasPriceForEthTransfer: 10,
+	}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Create test transactions
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tx1 := createMockTransaction(1, &to, []byte{})
+	tx2 := createMockTransaction(2, &to, []byte{})
+
+	tx1Bytes := createMockTransactionBytes(tx1)
+	tx2Bytes := createMockTransactionBytes(tx2)
+
+	// Manually populate the ready transactions
+	yielder.readyMtx.Lock()
+	yielder.readyTransactions = []common.Hash{tx1.Hash(), tx2.Hash()}
+	yielder.readyTransactionBytes[tx1.Hash()] = tx1Bytes
+	yielder.readyTransactionBytes[tx2.Hash()] = tx2Bytes
+	yielder.toSkip[tx1.Hash()] = struct{}{} // Mark first transaction as skipped
+	yielder.readyMtx.Unlock()
+
+	// Test yielding - should skip tx1 and return tx2
+	tx, effectiveGas, hasMore := yielder.YieldNextTransaction()
+
+	assert.NotNil(t, tx)
+	assert.Equal(t, tx2.Hash(), tx.Hash()) // Should return second transaction
+	assert.Equal(t, uint8(10), effectiveGas)
+	assert.True(t, hasMore)
+}
+
+func TestPoolTransactionYielder_AddMined(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Create test transaction
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tx := createMockTransaction(1, &to, []byte{})
+	txHash := tx.Hash()
+
+	// Manually populate the ready transactions
+	yielder.readyMtx.Lock()
+	yielder.readyTransactions = []common.Hash{txHash, common.HexToHash("0x1234")}
+	yielder.readyTransactionBytes[txHash] = createMockTransactionBytes(tx)
+	yielder.readyMtx.Unlock()
+
+	// Add transaction as mined
+	yielder.AddMined(txHash)
+
+	// Verify transaction was removed from ready transactions
+	yielder.readyMtx.Lock()
+	assert.Len(t, yielder.readyTransactions, 1)
+	assert.Equal(t, common.HexToHash("0x1234"), yielder.readyTransactions[0])
+	_, isSkipped := yielder.toSkip[txHash]
+	yielder.readyMtx.Unlock()
+
+	assert.True(t, isSkipped)
+}
+
+func TestPoolTransactionYielder_RemoveMinedTransactions(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Create test transaction
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tx := createMockTransaction(1, &to, []byte{})
+	txHash := tx.Hash()
+
+	// Add transaction to cache
+	cache.Add(txHash, &tx)
+
+	// Add some transactions to skip map
+	yielder.readyMtx.Lock()
+	yielder.toSkip[common.HexToHash("0x1234")] = struct{}{}
+	yielder.toSkip[common.HexToHash("0x5678")] = struct{}{}
+	yielder.readyMtx.Unlock()
+
+	// Remove mined transactions
+	yielder.RemoveMinedTransactions([]common.Hash{txHash})
+
+	// Verify transaction was removed from cache
+	_, found := cache.Get(txHash)
+	assert.False(t, found)
+
+	// Verify skip map was cleared
+	yielder.readyMtx.Lock()
+	assert.Empty(t, yielder.toSkip)
+	yielder.readyMtx.Unlock()
+}
+
+func TestPoolTransactionYielder_SetExecutionDetails(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Set execution details
+	executionAt := uint64(1000)
+	forkId := uint64(5)
+	yielder.SetExecutionDetails(executionAt, forkId)
+
+	assert.Equal(t, executionAt, yielder.executionAt)
+	assert.Equal(t, forkId, yielder.forkId)
+}
+
+func TestPoolTransactionYielder_BeginYielding(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := ethconfig.Zk{}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Test BeginYielding when not started
+	assert.False(t, yielder.startedYielding)
+
+	yielder.BeginYielding()
+
+	// Give some time for the goroutine to start
+	time.Sleep(10 * time.Millisecond)
+
+	assert.True(t, yielder.startedYielding)
+
+	// Test BeginYielding when already started
+	yielder.BeginYielding()
+	assert.True(t, yielder.startedYielding)
+}
+
+func TestPoolTransactionYielder_ExtractTransactionsFromSlot(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Create test slot
+	slot := &types2.TxsRlp{
+		TxIds: []common.Hash{
+			common.HexToHash("0x1234"),
+			common.HexToHash("0x5678"),
+		},
+		Txs: [][]byte{
+			[]byte{0x01, 0x02, 0x03},
+			[]byte{0x04, 0x05, 0x06},
+		},
+	}
+
+	// Extract transactions
+	ids, txBytes, err := yielder.extractTransactionsFromSlot(slot)
+
+	assert.NoError(t, err)
+	assert.Len(t, ids, 2)
+	assert.Len(t, txBytes, 2)
+	assert.Equal(t, common.HexToHash("0x1234"), ids[0])
+	assert.Equal(t, common.HexToHash("0x5678"), ids[1])
+	assert.Equal(t, []byte{0x01, 0x02, 0x03}, txBytes[0])
+	assert.Equal(t, []byte{0x04, 0x05, 0x06}, txBytes[1])
+}
+
+func TestPoolTransactionYielder_ExtractTransactionsFromSlot_Empty(t *testing.T) {
+	ctx := context.Background()
+	cfg := ethconfig.Zk{}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Create empty slot
+	slot := &types2.TxsRlp{
+		TxIds: []common.Hash{},
+		Txs:   [][]byte{},
+	}
+
+	// Extract transactions
+	ids, txBytes, err := yielder.extractTransactionsFromSlot(slot)
+
+	assert.NoError(t, err)
+	assert.Empty(t, ids)
+	assert.Empty(t, txBytes)
+}
+
+func TestLimboTransactionYielder(t *testing.T) {
+	cfg := ethconfig.Zk{
+		EffectiveGasPriceForEthTransfer: 10,
+	}
+
+	// Create test transactions
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tx1 := createMockTransaction(1, &to, []byte{})
+	tx2 := createMockTransaction(2, &to, []byte{})
+
+	transactions := []types.Transaction{tx1, tx2}
+
+	yielder := NewLimboTransactionYielder(transactions, cfg)
+
+	// Test yielding first transaction
+	tx, effectiveGas, hasMore := yielder.YieldNextTransaction()
+
+	assert.NotNil(t, tx)
+	assert.Equal(t, tx1.Hash(), tx.Hash())
+	assert.Equal(t, uint8(10), effectiveGas)
+	assert.True(t, hasMore)
+
+	// Test yielding second transaction
+	tx, effectiveGas, hasMore = yielder.YieldNextTransaction()
+
+	assert.NotNil(t, tx)
+	assert.Equal(t, tx2.Hash(), tx.Hash())
+	assert.Equal(t, uint8(10), effectiveGas)
+	assert.True(t, hasMore)
+
+	// Test yielding when no more transactions
+	tx, effectiveGas, hasMore = yielder.YieldNextTransaction()
+
+	assert.Nil(t, tx)
+	assert.Equal(t, uint8(0), effectiveGas)
+	assert.False(t, hasMore)
+}
+
+func TestRecoveryTransactionYielder(t *testing.T) {
+	// Create test transactions
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tx1 := createMockTransaction(1, &to, []byte{})
+	tx2 := createMockTransaction(2, &to, []byte{})
+
+	transactions := []types.Transaction{tx1, tx2}
+	effectivePercentages := []uint8{15, 25}
+
+	yielder := NewRecoveryTransactionYielder(transactions, effectivePercentages)
+
+	// Test yielding first transaction
+	tx, effectiveGas, hasMore := yielder.YieldNextTransaction()
+
+	assert.NotNil(t, tx)
+	assert.Equal(t, tx1.Hash(), tx.Hash())
+	assert.Equal(t, uint8(15), effectiveGas)
+	assert.True(t, hasMore)
+
+	// Test yielding second transaction
+	tx, effectiveGas, hasMore = yielder.YieldNextTransaction()
+
+	assert.NotNil(t, tx)
+	assert.Equal(t, tx2.Hash(), tx.Hash())
+	assert.Equal(t, uint8(25), effectiveGas)
+	assert.True(t, hasMore)
+
+	// Test yielding when no more transactions
+	tx, effectiveGas, hasMore = yielder.YieldNextTransaction()
+
+	assert.Nil(t, tx)
+	assert.Equal(t, uint8(0), effectiveGas)
+	assert.False(t, hasMore)
+}
+
+func TestPoolTransactionYielder_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cfg := ethconfig.Zk{}
+
+	mockDB := memdb.NewTestDB(t)
+	cache := expirable.NewLRU[common.Hash, *types.Transaction](100, nil, time.Hour)
+
+	// Use nil TxPool for testing - we're not testing pool functionality
+	var pool *txpool.TxPool = nil
+
+	yielder := NewPoolTransactionYielder(ctx, cfg, pool, 10, mockDB, cache)
+
+	// Start yielding
+	yielder.BeginYielding()
+
+	// Give some time for the goroutine to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Cancel context
+	cancel()
+
+	// Give some time for the goroutine to stop
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify the yielder stopped
+	assert.False(t, yielder.startedYielding)
+}

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -309,7 +309,7 @@ func sequencingBatchStep(
 		}
 
 		yielder.SetExecutionDetails(executionAt, batchState.forkId)
-		go yielder.BeginYielding()
+		yielder.BeginYielding()
 
 		if batchState.isL1Recovery() {
 			blockNumbersInBatchSoFar, err := batchContext.sdb.hermezDb.GetL2BlockNosByBatch(batchState.batchNumber)

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -448,6 +448,9 @@ func sequencingBatchStep(
 			for {
 				transaction, effectiveGas, ok := yielder.YieldNextTransaction()
 				if !ok {
+					if !batchState.isAnyRecovery() {
+						time.Sleep(cfg.zk.SequencerTimeoutOnEmptyTxPool)
+					}
 					break InnerLoopTransactions
 				}
 

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -24,7 +24,7 @@ import (
 
 var shouldCheckForExecutionAndDataStreamAlignment = true
 
-type txYielder interface {
+type TxYielder interface {
 	YieldNextTransaction() (types.Transaction, uint8, bool)
 	RemoveMinedTransactions(hashes []common.Hash)
 	AddMined(hash common.Hash)
@@ -266,7 +266,7 @@ func sequencingBatchStep(
 	sendersToSkip := make(map[common.Address]struct{})
 
 	// default to using the normal transaction yielder
-	var yielder txYielder = cfg.txYielder
+	var yielder TxYielder = cfg.txYielder
 	minedTxHashes := make([]common.Hash, 0)
 
 	for blockNumber := executionAt + 1; runLoopBlocks; blockNumber++ {

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -17,9 +17,9 @@ import (
 	"github.com/erigontech/erigon/eth/stagedsync/stages"
 	"github.com/erigontech/erigon/zk"
 	"github.com/erigontech/erigon/zk/hermez_db"
+	"github.com/erigontech/erigon/zk/sequencer"
 	zktx "github.com/erigontech/erigon/zk/tx"
 	"github.com/erigontech/erigon/zk/utils"
-	"github.com/erigontech/erigon/zk/sequencer"
 )
 
 var shouldCheckForExecutionAndDataStreamAlignment = true
@@ -292,7 +292,10 @@ func sequencingBatchStep(
 			if err != nil {
 				return err
 			}
-			yielder = sequencer.NewRecoveryTransactionYielder(transactions, effectivePercentages)
+			yielder, err = sequencer.NewRecoveryTransactionYielder(transactions, effectivePercentages)
+			if err != nil {
+				return err
+			}
 		} else if batchState.isL1Recovery() {
 			blockNumbersInBatchSoFar, err := batchContext.sdb.hermezDb.GetL2BlockNosByBatch(batchState.batchNumber)
 			if err != nil {
@@ -305,7 +308,10 @@ func sequencingBatchStep(
 				break
 			}
 
-			yielder = sequencer.NewRecoveryTransactionYielder(decodedBatchL2Data.Transactions, decodedBatchL2Data.EffectiveGasPricePercentages)
+			yielder, err = sequencer.NewRecoveryTransactionYielder(decodedBatchL2Data.Transactions, decodedBatchL2Data.EffectiveGasPricePercentages)
+			if err != nil {
+				return err
+			}
 		}
 
 		yielder.SetExecutionDetails(executionAt, batchState.forkId)

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -19,9 +19,18 @@ import (
 	"github.com/erigontech/erigon/zk/hermez_db"
 	zktx "github.com/erigontech/erigon/zk/tx"
 	"github.com/erigontech/erigon/zk/utils"
+	"github.com/erigontech/erigon/zk/sequencer"
 )
 
 var shouldCheckForExecutionAndDataStreamAlignment = true
+
+type txYielder interface {
+	YieldNextTransaction() (types.Transaction, uint8, bool)
+	RemoveMinedTransactions(hashes []common.Hash)
+	AddMined(hash common.Hash)
+	SetExecutionDetails(executionAt uint64, forkId uint64)
+	BeginYielding()
+}
 
 func SpawnSequencingStage(
 	s *stagedsync.StageState,
@@ -256,6 +265,10 @@ func sequencingBatchStep(
 	// until the next batch starts
 	sendersToSkip := make(map[common.Address]struct{})
 
+	// default to using the normal transaction yielder
+	var yielder txYielder = cfg.txYielder
+	minedTxHashes := make([]common.Hash, 0)
+
 	for blockNumber := executionAt + 1; runLoopBlocks; blockNumber++ {
 		if batchTimedOut {
 			log.Debug(fmt.Sprintf("[%s] Closing batch due to timeout", logPrefix))
@@ -267,6 +280,36 @@ func sequencingBatchStep(
 		blockTimer := time.NewTimer(cfg.zk.SequencerBlockSealTime)
 		emptyBlockTimer := time.NewTimer(cfg.zk.SequencerEmptyBlockSealTime)
 		ethBlockGasPool := new(core.GasPool).AddGas(transactionGasLimit) // used only in normalcy mode per block
+
+		if batchState.isLimboRecovery() {
+			transactions, err := getLimboTransaction(ctx, cfg, batchState.limboRecoveryData.limboTxHash, executionAt)
+			if err != nil {
+				return err
+			}
+			yielder = sequencer.NewLimboTransactionYielder(transactions, *cfg.zk)
+		} else if batchState.isResequence() {
+			transactions, effectivePercentages, err := batchState.resequenceBatchJob.YieldNextBlockTransactions(zktx.DecodeTx)
+			if err != nil {
+				return err
+			}
+			yielder = sequencer.NewRecoveryTransactionYielder(transactions, effectivePercentages)
+		} else if batchState.isL1Recovery() {
+			blockNumbersInBatchSoFar, err := batchContext.sdb.hermezDb.GetL2BlockNosByBatch(batchState.batchNumber)
+			if err != nil {
+				return err
+			}
+
+			decodedBatchL2Data, found := batchState.batchL1RecoveryData.getDecodedL1RecoveredBatchDataByIndex(uint64(len(blockNumbersInBatchSoFar)))
+			if !found {
+				log.Info(fmt.Sprintf("[%s] Block %d is not part of batch %d. Stopping blocks loop", logPrefix, blockNumber, batchState.batchNumber))
+				break
+			}
+
+			yielder = sequencer.NewRecoveryTransactionYielder(decodedBatchL2Data.Transactions, decodedBatchL2Data.EffectiveGasPricePercentages)
+		}
+
+		yielder.SetExecutionDetails(executionAt, batchState.forkId)
+		go yielder.BeginYielding()
 
 		if batchState.isL1Recovery() {
 			blockNumbersInBatchSoFar, err := batchContext.sdb.hermezDb.GetL2BlockNosByBatch(batchState.batchNumber)
@@ -285,7 +328,9 @@ func sequencingBatchStep(
 			if !batchState.resequenceBatchJob.HasMoreBlockToProcess() {
 				for {
 					if pending, _ := streamWriter.legacyVerifier.HasPendingVerifications(); pending {
-						streamWriter.CommitNewUpdates()
+						if _, _, err = streamWriter.CommitNewUpdates(); err != nil {
+							return fmt.Errorf("failed to commit new updates: %w", err)
+						}
 						time.Sleep(1 * time.Second)
 					} else {
 						break
@@ -343,6 +388,8 @@ func sequencingBatchStep(
 		innerBreak := false
 		emptyBlockOverflow := false
 		sendersToTriggerStatechanges := make(map[common.Address]struct{})
+		yieldedSomething := false
+		badTxHashes := make([]common.Hash, 0)
 
 	OuterLoopTransactions:
 		for {
@@ -397,46 +444,15 @@ func sequencingBatchStep(
 			default:
 			}
 
-			if batchState.isLimboRecovery() {
-				batchState.blockState.transactionsForInclusion, err = getLimboTransaction(ctx, cfg, batchState.limboRecoveryData.limboTxHash, executionAt)
-				if err != nil {
-					return err
-				}
-			} else if batchState.isResequence() {
-				batchState.blockState.transactionsForInclusion, err = batchState.resequenceBatchJob.YieldNextBlockTransactions(zktx.DecodeTx)
-				if err != nil {
-					return err
-				}
-			} else if !batchState.isL1Recovery() {
-
-				var newTransactions []types.Transaction
-				var newIds []common.Hash
-
-				newTransactions, newIds, _, err = getNextPoolTransactions(ctx, cfg, executionAt, batchState.forkId, batchState.yieldedTransactions)
-				if err != nil {
-					return err
-				}
-
-				batchState.blockState.transactionsForInclusion = append(batchState.blockState.transactionsForInclusion, newTransactions...)
-				for idx, tx := range newTransactions {
-					batchState.blockState.transactionHashesToSlots[tx.Hash()] = newIds[idx]
-				}
-			}
-
-			if len(batchState.blockState.transactionsForInclusion) == 0 {
-				if !batchState.isAnyRecovery() {
-					log.Trace(fmt.Sprintf("[%s] Sleep on SequencerTimeoutOnEmptyTxPool", logPrefix), "time in ms", batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool.Milliseconds())
-					time.Sleep(batchContext.cfg.zk.SequencerTimeoutOnEmptyTxPool)
-				}
-			} else {
-				log.Trace(fmt.Sprintf("[%s] Yielded transactions from the pool", logPrefix), "txCount", len(batchState.blockState.transactionsForInclusion))
-			}
-
-			badTxHashes := make([]common.Hash, 0)
-			minedTxHashes := make([]common.Hash, 0)
-
 		InnerLoopTransactions:
-			for i, transaction := range batchState.blockState.transactionsForInclusion {
+			for {
+				transaction, effectiveGas, ok := yielder.YieldNextTransaction()
+				if !ok {
+					break InnerLoopTransactions
+				}
+
+				yieldedSomething = true
+
 				// quick check if we should stop handling transactions
 				select {
 				case <-blockTimer.C:
@@ -469,8 +485,6 @@ func sequencingBatchStep(
 				if _, found := sendersToSkip[txSender]; found {
 					continue
 				}
-
-				effectiveGas := batchState.blockState.getL1EffectiveGases(cfg, i)
 
 				// The copying of this structure is intentional
 				backupDataSizeChecker := *blockDataSizeChecker
@@ -603,6 +617,7 @@ func sequencingBatchStep(
 					blockDataSizeChecker = &backupDataSizeChecker
 					batchState.onAddedTransaction(transaction, receipt, execResult, effectiveGas)
 					minedTxHashes = append(minedTxHashes, txHash)
+					yielder.AddMined(txHash)
 				}
 
 				// We will only update the processed index in resequence job if there isn't overflow
@@ -612,7 +627,7 @@ func sequencingBatchStep(
 			}
 
 			if batchState.isResequence() {
-				if len(batchState.blockState.transactionsForInclusion) == 0 {
+				if !yieldedSomething {
 					// We need to jump to the next block here if there are no transactions in current block
 					batchState.resequenceBatchJob.UpdateLastProcessedTx(batchState.resequenceBatchJob.CurrentBlock().L2Blockhash)
 					break OuterLoopTransactions
@@ -624,25 +639,6 @@ func sequencingBatchStep(
 				} else {
 					if cfg.zk.SequencerResequenceStrict {
 						return fmt.Errorf("strict mode enabled, but resequenced batch %d has transactions that overflowed counters or failed transactions", batchState.batchNumber)
-					}
-				}
-			}
-
-			// remove bad and mined transactions from the list for inclusion
-			for i := len(batchState.blockState.transactionsForInclusion) - 1; i >= 0; i-- {
-				tx := batchState.blockState.transactionsForInclusion[i]
-				hash := tx.Hash()
-				for _, badHash := range badTxHashes {
-					if badHash == hash {
-						batchState.blockState.transactionsForInclusion = removeInclusionTransaction(batchState.blockState.transactionsForInclusion, i)
-						break
-					}
-				}
-
-				for _, minedHash := range minedTxHashes {
-					if minedHash == hash {
-						batchState.blockState.transactionsForInclusion = removeInclusionTransaction(batchState.blockState.transactionsForInclusion, i)
-						break
 					}
 				}
 			}
@@ -674,7 +670,7 @@ func sequencingBatchStep(
 		// if we had some transactions yielded but didn't mine any in this block then we shouldn't commit it and move on.
 		// this could happen if there were lots of nonce issues from transaction in the pool due to a failed tx processing or similar and
 		// there wasn't much time left in the batch to mine any transactions
-		if len(batchState.blockState.transactionsForInclusion) > 0 && len(batchState.blockState.builtBlockElements.transactions) == 0 {
+		if yieldedSomething && len(batchState.blockState.builtBlockElements.transactions) == 0 {
 			log.Info(fmt.Sprintf("[%s] Skipping block: no transactions mined in block %d, skipping block for now", logPrefix, blockNumber))
 			break
 		}
@@ -703,9 +699,6 @@ func sequencingBatchStep(
 		}
 
 		// remove the decoded transactions from the cache
-		for _, txHash := range batchState.blockState.builtBlockElements.txSlots {
-			cfg.decodedTxCache.Remove(txHash)
-		}
 		for _, txHash := range batchState.blockState.transactionsToDiscard {
 			cfg.decodedTxCache.Remove(txHash)
 		}
@@ -766,6 +759,10 @@ func sequencingBatchStep(
 		}
 	}
 
+	// notify the yielder that we can remove mined transactions from the queue
+	yielder.RemoveMinedTransactions(minedTxHashes)
+	minedTxHashes = minedTxHashes[:0]
+
 	/*
 		if adding something below that line we must ensure
 		- it is also handled property in processInjectedInitialBatch
@@ -779,19 +776,14 @@ func sequencingBatchStep(
 	return sdb.tx.Commit()
 }
 
-func removeInclusionTransaction(orig []types.Transaction, index int) []types.Transaction {
-	if index < 0 || index >= len(orig) {
-		return orig
-	}
-	return append(orig[:index], orig[index+1:]...)
-}
-
 func handleBadTxHashCounter(hermezDb *hermez_db.HermezDb, txHash common.Hash) (uint64, error) {
 	counter, err := hermezDb.GetBadTxHashCounter(txHash)
 	if err != nil {
 		return 0, err
 	}
 	newCounter := counter + 1
-	hermezDb.WriteBadTxHashCounter(txHash, newCounter)
+	if err = hermezDb.WriteBadTxHashCounter(txHash, newCounter); err != nil {
+		return 0, fmt.Errorf("failed to write bad tx hash counter: %w", err)
+	}
 	return newCounter, nil
 }

--- a/zk/stages/stage_sequence_execute_injected_batch.go
+++ b/zk/stages/stage_sequence_execute_injected_batch.go
@@ -19,6 +19,7 @@ import (
 	zktx "github.com/erigontech/erigon/zk/tx"
 	zktypes "github.com/erigontech/erigon/zk/types"
 	"github.com/erigontech/erigon/zk/utils"
+	"github.com/erigontech/erigon/zk/sequencer"
 )
 
 const (
@@ -139,7 +140,7 @@ func handleInjectedBatch(
 	ethBlockGasPool := new(core.GasPool).AddGas(transactionGasLimit) // used only in normalcy mode in stage sequencer to create a pool at block level
 
 	// process the tx and we can ignore the counters as an overflow at this stage means no network anyway
-	effectiveGas := DeriveEffectiveGasPrice(*batchContext.cfg, decodedBlocks[0].Transactions[0])
+	effectiveGas := sequencer.DeriveEffectiveGasPrice(*batchContext.cfg.zk, decodedBlocks[0].Transactions[0])
 	receipt, execResult, _, _, err := attemptAddTransaction(*batchContext.cfg, batchContext.sdb, ibs, batchCounters, blockContext, header, decodedBlocks[0].Transactions[0], effectiveGas, false, forkId, 0 /* use 0 for l1InfoIndex in injected batch */, nil, ethBlockGasPool)
 	if err != nil {
 		return nil, nil, nil, 0, err

--- a/zk/stages/stage_sequence_execute_state.go
+++ b/zk/stages/stage_sequence_execute_state.go
@@ -137,7 +137,7 @@ func (bs *BatchState) isThereAnyTransactionsToRecover() bool {
 	// mined blocks vs recovered blocks
 	remainingTransactions := len(bs.blockState.blockL1RecoveryData.Transactions) - len(bs.blockState.builtBlockElements.transactions)
 
-	return remainingTransactions <= 0 || bs.batchL1RecoveryData.recoveredBatchData.IsWorkRemaining
+	return remainingTransactions > 0 || bs.batchL1RecoveryData.recoveredBatchData.IsWorkRemaining
 }
 
 func (bs *BatchState) loadBlockL1RecoveryData(decodedBlocksIndex uint64) bool {

--- a/zk/stages/stage_sequence_execute_state.go
+++ b/zk/stages/stage_sequence_execute_state.go
@@ -252,7 +252,6 @@ func newLimboRecoveryData(limboHeaderTimestamp uint64, limboTxHash *common.Hash)
 
 // TYPE BLOCK STATE
 type BlockState struct {
-	//transactionsForInclusion []types.Transaction
 	transactionHashesToSlots map[common.Hash]common.Hash
 	builtBlockElements       BuiltBlockElements
 	blockL1RecoveryData      *zktx.DecodedBatchL2Data

--- a/zk/stages/stage_sequence_execute_state.go
+++ b/zk/stages/stage_sequence_execute_state.go
@@ -134,7 +134,10 @@ func (bs *BatchState) isThereAnyTransactionsToRecover() bool {
 		return false
 	}
 
-	return bs.blockState.hasAnyTransactionForInclusion() || bs.batchL1RecoveryData.recoveredBatchData.IsWorkRemaining
+	// mined blocks vs recovered blocks
+	remainingTransactions := len(bs.blockState.blockL1RecoveryData.Transactions) - len(bs.blockState.builtBlockElements.transactions)
+
+	return remainingTransactions <= 0 || bs.batchL1RecoveryData.recoveredBatchData.IsWorkRemaining
 }
 
 func (bs *BatchState) loadBlockL1RecoveryData(decodedBlocksIndex uint64) bool {
@@ -165,11 +168,7 @@ func (bs *BatchState) getCoinbase(cfg *SequenceBlockCfg) common.Address {
 }
 
 func (bs *BatchState) onAddedTransaction(transaction types.Transaction, receipt *types.Receipt, execResult *evmtypes.ExecutionResult, effectiveGas uint8) {
-	slotId, ok := bs.blockState.transactionHashesToSlots[transaction.Hash()]
-	if !ok {
-		log.Warn("[batchState] transaction hash not found in transaction hashes to slots map", "hash", transaction.Hash())
-	}
-	bs.blockState.builtBlockElements.onFinishAddingTransaction(transaction, receipt, execResult, effectiveGas, slotId)
+	bs.blockState.builtBlockElements.onFinishAddingTransaction(transaction, receipt, execResult, effectiveGas)
 	bs.hasAnyTransactionsInThisBatch = true
 }
 
@@ -253,7 +252,7 @@ func newLimboRecoveryData(limboHeaderTimestamp uint64, limboTxHash *common.Hash)
 
 // TYPE BLOCK STATE
 type BlockState struct {
-	transactionsForInclusion []types.Transaction
+	//transactionsForInclusion []types.Transaction
 	transactionHashesToSlots map[common.Hash]common.Hash
 	builtBlockElements       BuiltBlockElements
 	blockL1RecoveryData      *zktx.DecodedBatchL2Data
@@ -266,18 +265,8 @@ func newBlockState() *BlockState {
 	}
 }
 
-func (bs *BlockState) hasAnyTransactionForInclusion() bool {
-	return len(bs.transactionsForInclusion) > 0
-}
-
 func (bs *BlockState) setBlockL1RecoveryData(blockL1RecoveryData *zktx.DecodedBatchL2Data) {
 	bs.blockL1RecoveryData = blockL1RecoveryData
-
-	if bs.blockL1RecoveryData != nil {
-		bs.transactionsForInclusion = bs.blockL1RecoveryData.Transactions
-	} else {
-		bs.transactionsForInclusion = []types.Transaction{}
-	}
 }
 
 func (bs *BlockState) getDeltaTimestamp() uint64 {
@@ -288,21 +277,12 @@ func (bs *BlockState) getDeltaTimestamp() uint64 {
 	return math.MaxUint64
 }
 
-func (bs *BlockState) getL1EffectiveGases(cfg SequenceBlockCfg, i int) uint8 {
-	if bs.blockL1RecoveryData != nil {
-		return bs.blockL1RecoveryData.EffectiveGasPricePercentages[i]
-	}
-
-	return DeriveEffectiveGasPrice(cfg, bs.transactionsForInclusion[i])
-}
-
 // TYPE BLOCK ELEMENTS
 type BuiltBlockElements struct {
 	transactions     []types.Transaction
 	receipts         types.Receipts
 	effectiveGases   []uint8
 	executionResults []*evmtypes.ExecutionResult
-	txSlots          []common.Hash
 }
 
 func (bbe *BuiltBlockElements) resetBlockBuildingArrays() {
@@ -312,12 +292,11 @@ func (bbe *BuiltBlockElements) resetBlockBuildingArrays() {
 	bbe.executionResults = []*evmtypes.ExecutionResult{}
 }
 
-func (bbe *BuiltBlockElements) onFinishAddingTransaction(transaction types.Transaction, receipt *types.Receipt, execResult *evmtypes.ExecutionResult, effectiveGas uint8, slotId common.Hash) {
+func (bbe *BuiltBlockElements) onFinishAddingTransaction(transaction types.Transaction, receipt *types.Receipt, execResult *evmtypes.ExecutionResult, effectiveGas uint8) {
 	bbe.transactions = append(bbe.transactions, transaction)
 	bbe.receipts = append(bbe.receipts, receipt)
 	bbe.executionResults = append(bbe.executionResults, execResult)
 	bbe.effectiveGases = append(bbe.effectiveGases, effectiveGas)
-	bbe.txSlots = append(bbe.txSlots, slotId)
 }
 
 type resequenceTxMetadata struct {
@@ -356,24 +335,26 @@ func (r *ResequenceBatchJob) CurrentBlock() *dsTypes.FullL2Block {
 	return nil
 }
 
-func (r *ResequenceBatchJob) YieldNextBlockTransactions(decoder zktx.TxDecoder) ([]types.Transaction, error) {
+func (r *ResequenceBatchJob) YieldNextBlockTransactions(decoder zktx.TxDecoder) ([]types.Transaction, []uint8, error) {
 	blockTransactions := make([]types.Transaction, 0)
+	effectivePercentages := make([]uint8, 0)
 	if r.HasMoreBlockToProcess() {
 		block := r.CurrentBlock()
 		r.txIndexMap[block.L2Blockhash] = resequenceTxMetadata{r.StartBlockIndex, 0}
 
 		for i := r.StartTxIndex; i < len(block.L2Txs); i++ {
 			transaction := block.L2Txs[i]
-			tx, _, err := decoder(transaction.Encoded, transaction.EffectiveGasPricePercentage, block.ForkId)
+			tx, effectivePercentage, err := decoder(transaction.Encoded, transaction.EffectiveGasPricePercentage, block.ForkId)
 			if err != nil {
-				return nil, fmt.Errorf("decode tx error: %v", err)
+				return nil, nil, fmt.Errorf("decode tx error: %v", err)
 			}
 			r.txIndexMap[tx.Hash()] = resequenceTxMetadata{r.StartBlockIndex, i}
 			blockTransactions = append(blockTransactions, tx)
+			effectivePercentages = append(effectivePercentages, effectivePercentage)
 		}
 	}
 
-	return blockTransactions, nil
+	return blockTransactions, effectivePercentages, nil
 }
 
 func (r *ResequenceBatchJob) UpdateLastProcessedTx(h common.Hash) {

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"github.com/erigontech/erigon/zk/sequencer"
 )
 
 func TestSpawnSequencingStage(t *testing.T) {
@@ -178,6 +179,8 @@ func TestSpawnSequencingStage(t *testing.T) {
 	}
 	historyCfg := stagedsync.StageHistoryCfg(db1, prune.DefaultMode, "")
 	quiet := true
+
+	cfg.txYielder = &sequencer.RecoveryTransactionYielder{}
 
 	// Act
 	err = SpawnSequencingStage(s, u, ctx, cfg, historyCfg, quiet)

--- a/zk/stages/stage_sequence_execute_transactions.go
+++ b/zk/stages/stage_sequence_execute_transactions.go
@@ -181,7 +181,7 @@ func attemptAddTransaction(
 
 	if overflow {
 		counters := batchCounters.CombineCollectorsNoChanges().UsedAsString()
-		log.Debug("Transaction overflow detected", "txHash", transaction.Hash(), "coutners", counters)
+		log.Debug("Transaction overflow detected", "txHash", transaction.Hash(), "counters", counters)
 		ibs.RevertToSnapshot(snapshot)
 		return nil, nil, txCounters, overflowCounters, nil
 	}

--- a/zk/stages/stage_sequence_execute_transactions.go
+++ b/zk/stages/stage_sequence_execute_transactions.go
@@ -9,7 +9,6 @@ import (
 
 	"io"
 
-	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/erigontech/erigon-lib/log/v3"
 	types2 "github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon/core"
@@ -17,44 +16,7 @@ import (
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/core/vm"
 	"github.com/erigontech/erigon/core/vm/evmtypes"
-	"github.com/erigontech/erigon/zk/utils"
 )
-
-func getNextPoolTransactions(ctx context.Context, cfg SequenceBlockCfg, executionAt, forkId uint64, alreadyYielded mapset.Set[[32]byte]) ([]types.Transaction, []common.Hash, bool, error) {
-	var ids []common.Hash
-	var transactions []types.Transaction
-	var allConditionsOk bool
-	var err error
-
-	gasLimit := utils.GetBlockGasLimitForFork(forkId)
-
-	ti := utils.StartTimer("txpool", "get-transactions")
-	defer ti.LogTimer()
-
-	cfg.txPool.PreYield()
-	defer cfg.txPool.PostYield()
-
-	if err := cfg.txPoolDb.View(ctx, func(poolTx kv.Tx) error {
-		slots := types2.TxsRlp{}
-		if allConditionsOk, _, err = cfg.txPool.YieldBest(cfg.yieldSize, &slots, poolTx, executionAt, gasLimit, 0, alreadyYielded); err != nil {
-			return err
-		}
-		yieldedTxs, yieldedIds, toRemove, err := extractTransactionsFromSlot(&slots, executionAt, cfg)
-		if err != nil {
-			return err
-		}
-		for _, txId := range toRemove {
-			cfg.txPool.MarkForDiscardFromPendingBest(txId)
-		}
-		transactions = append(transactions, yieldedTxs...)
-		ids = append(ids, yieldedIds...)
-		return nil
-	}); err != nil {
-		return nil, nil, allConditionsOk, err
-	}
-
-	return transactions, ids, allConditionsOk, err
-}
 
 func getLimboTransaction(ctx context.Context, cfg SequenceBlockCfg, txHash *common.Hash, executionAt uint64) ([]types.Transaction, error) {
 	var transactions []types.Transaction
@@ -217,8 +179,8 @@ func attemptAddTransaction(
 		return nil, nil, txCounters, overflowNone, err
 	}
 
-	counters := batchCounters.CombineCollectorsNoChanges().UsedAsString()
 	if overflow {
+		counters := batchCounters.CombineCollectorsNoChanges().UsedAsString()
 		log.Debug("Transaction overflow detected", "txHash", transaction.Hash(), "coutners", counters)
 		ibs.RevertToSnapshot(snapshot)
 		return nil, nil, txCounters, overflowCounters, nil
@@ -228,7 +190,6 @@ func attemptAddTransaction(
 		ibs.RevertToSnapshot(snapshot)
 		return nil, nil, txCounters, overflowGas, nil
 	}
-	log.Debug("Transaction added", "txHash", transaction.Hash(), "coutners", counters)
 
 	// add the gas only if not reverted. This should not be moved above the overflow check
 	header.GasUsed = gasUsed

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -92,7 +92,7 @@ type SequenceBlockCfg struct {
 
 	decodedTxCache *expirable.LRU[common.Hash, *types.Transaction]
 	doneHook       DoneHook
-	txYielder      *sequencer.PoolTransactionYielder
+	txYielder      TxYielder
 }
 
 func StageSequenceBlocksCfg(

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -185,10 +185,8 @@ func (sCfg *SequenceBlockCfg) toErigonExecuteBlockCfg() stagedsync.ExecuteBlockC
 
 func validateIfDatastreamIsAheadOfExecution(
 	s *stagedsync.StageState,
-// u stagedsync.Unwinder,
 	ctx context.Context,
 	cfg SequenceBlockCfg,
-// historyCfg stagedsync.HistoryCfg,
 ) error {
 	roTx, err := cfg.db.BeginRo(ctx)
 	if err != nil {

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -37,6 +37,7 @@ import (
 	zktypes "github.com/erigontech/erigon/zk/types"
 	"github.com/erigontech/erigon/zk/utils"
 	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/erigontech/erigon/zk/sequencer"
 )
 
 const (
@@ -91,6 +92,7 @@ type SequenceBlockCfg struct {
 
 	decodedTxCache *expirable.LRU[common.Hash, *types.Transaction]
 	doneHook       DoneHook
+	txYielder      *sequencer.PoolTransactionYielder
 }
 
 func StageSequenceBlocksCfg(
@@ -121,6 +123,7 @@ func StageSequenceBlocksCfg(
 	yieldSize uint16,
 	infoTreeUpdater *l1infotree.Updater,
 	doneHook DoneHook,
+	txYielder *sequencer.PoolTransactionYielder,
 ) SequenceBlockCfg {
 
 	decodedTxCache := expirable.NewLRU[common.Hash, *types.Transaction](zk.SequencerDecodedTxCacheSize, nil, zk.SequencerDecodedTxCacheTTL)
@@ -152,6 +155,7 @@ func StageSequenceBlocksCfg(
 		infoTreeUpdater:  infoTreeUpdater,
 		decodedTxCache:   decodedTxCache,
 		doneHook:         doneHook,
+		txYielder:        txYielder,
 	}
 }
 
@@ -181,10 +185,10 @@ func (sCfg *SequenceBlockCfg) toErigonExecuteBlockCfg() stagedsync.ExecuteBlockC
 
 func validateIfDatastreamIsAheadOfExecution(
 	s *stagedsync.StageState,
-	// u stagedsync.Unwinder,
+// u stagedsync.Unwinder,
 	ctx context.Context,
 	cfg SequenceBlockCfg,
-	// historyCfg stagedsync.HistoryCfg,
+// historyCfg stagedsync.HistoryCfg,
 ) error {
 	roTx, err := cfg.db.BeginRo(ctx)
 	if err != nil {

--- a/zk/stages/stage_sequence_execute_utils_test.go
+++ b/zk/stages/stage_sequence_execute_utils_test.go
@@ -10,7 +10,7 @@ import (
 	zktx "github.com/erigontech/erigon/zk/tx"
 	zktypes "github.com/erigontech/erigon/zk/types"
 	"github.com/holiman/uint256"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 )
 
 type mockChecker struct {
@@ -341,7 +341,7 @@ func TestResequenceBatchJob_YieldNextBlockTransactions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			txs, err := tt.job.YieldNextBlockTransactions(mockDecodeTx)
+			txs, _, err := tt.job.YieldNextBlockTransactions(mockDecodeTx)
 			if (err != nil) != tt.expectedError {
 				t.Errorf("ResequenceBatchJob.YieldNextBlockTransactions() error = %v, expectedError %v", err, tt.expectedError)
 				return
@@ -376,7 +376,7 @@ func TestResequenceBatchJob_YieldAndUpdate(t *testing.T) {
 	}
 
 	// First call - should yield transaction 2 from block 0
-	txs, err := job.YieldNextBlockTransactions(mockDecodeTx)
+	txs, _, err := job.YieldNextBlockTransactions(mockDecodeTx)
 	if err != nil {
 		t.Fatalf("First call: Unexpected error: %v", err)
 	}
@@ -387,7 +387,7 @@ func TestResequenceBatchJob_YieldAndUpdate(t *testing.T) {
 	tx2 := txs[0]
 
 	// Second call - should yield empty block (block 1)
-	txs, err = job.YieldNextBlockTransactions(mockDecodeTx)
+	txs, _, err = job.YieldNextBlockTransactions(mockDecodeTx)
 	if err != nil {
 		t.Fatalf("Second call: Unexpected error: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestResequenceBatchJob_YieldAndUpdate(t *testing.T) {
 	job.UpdateLastProcessedTx(job.CurrentBlock().L2Blockhash)
 
 	// Third call - should yield empty block (block 2)
-	txs, err = job.YieldNextBlockTransactions(mockDecodeTx)
+	txs, _, err = job.YieldNextBlockTransactions(mockDecodeTx)
 	if err != nil {
 		t.Fatalf("Third call: Unexpected error: %v", err)
 	}
@@ -407,7 +407,7 @@ func TestResequenceBatchJob_YieldAndUpdate(t *testing.T) {
 	job.UpdateLastProcessedTx(job.CurrentBlock().L2Blockhash)
 
 	// Fourth call - should yield transactions 3 and 4, but we'll only process 3
-	txs, err = job.YieldNextBlockTransactions(mockDecodeTx)
+	txs, _, err = job.YieldNextBlockTransactions(mockDecodeTx)
 	if err != nil {
 		t.Fatalf("Fourth call: Unexpected error: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestResequenceBatchJob_YieldAndUpdate(t *testing.T) {
 	}
 
 	// Final call - should yield transaction 4
-	txs, err = job.YieldNextBlockTransactions(mockDecodeTx)
+	txs, _, err = job.YieldNextBlockTransactions(mockDecodeTx)
 	if err != nil {
 		t.Fatalf("Final call: Unexpected error: %v", err)
 	}

--- a/zk/stages/stage_sequencer_l1_block_sync.go
+++ b/zk/stages/stage_sequencer_l1_block_sync.go
@@ -210,6 +210,9 @@ LOOP:
 					// check if we need to stop here based on config
 					if cfg.zkCfg.L1SyncStopBatch > 0 {
 						stopBlockMap[b] = struct{}{}
+						if b > highestBatch {
+							highestBatch = b
+						}
 						if checkStopBlockMap(highestBatch, cfg.zkCfg.L1SyncStopBatch, stopBlockMap) {
 							log.Info("Stopping L1 sync based on stop batch config")
 							break LOOP

--- a/zk/stages/utils.go
+++ b/zk/stages/utils.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
-	"github.com/erigontech/erigon/core/types"
 	db2 "github.com/erigontech/erigon/smt/pkg/db"
 	jsonClient "github.com/erigontech/erigon/zkevm/jsonrpc/client"
 	jsonTypes "github.com/erigontech/erigon/zkevm/jsonrpc/types"
@@ -135,30 +134,6 @@ func RpcGetHighestTxNo(rpcEndpoint string) (uint64, error) {
 	}
 
 	return val, nil
-}
-
-func DeriveEffectiveGasPrice(cfg SequenceBlockCfg, tx types.Transaction) uint8 {
-	if tx.GetTo() == nil {
-		return cfg.zk.EffectiveGasPriceForContractDeployment
-	}
-
-	data := tx.GetData()
-	dataLen := len(data)
-	if dataLen != 0 {
-		if dataLen >= 8 {
-			// transfer's method id 0xa9059cbb
-			isTransfer := data[0] == 169 && data[1] == 5 && data[2] == 156 && data[3] == 187
-			// transfer's method id 0x23b872dd
-			isTransferFrom := data[0] == 35 && data[1] == 184 && data[2] == 114 && data[3] == 221
-			if isTransfer || isTransferFrom {
-				return cfg.zk.EffectiveGasPriceForErc20Transfer
-			}
-		}
-
-		return cfg.zk.EffectiveGasPriceForContractInvocation
-	}
-
-	return cfg.zk.EffectiveGasPriceForEthTransfer
 }
 
 func GetSequencerHighestDataStreamBlock(endpoint string) (uint64, error) {


### PR DESCRIPTION
the aim here is to constantly poll the txpool for the latest transactions outside of the sequencer process so that things can be ready to execute much faster and give us a 200ms~ head start when the pool is very busy.

testing locally using Anansi shows that the sequencer can yield and process up 10k transactions in a single 2s block (SMT processing does extend this out).

One advantage to the approach in this code is that the pool is constantly being processed so any "better" or replaced transactions so we don't need to handle this, and we only pull the hashes and raw data so don't deserialise until the point of consumption which helps keep things speedy.