### PR TITLE
feat(priority): priority senders list for txpool

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -943,6 +943,11 @@ var (
 		Usage: "Location of the ACL JSON file",
 		Value: "",
 	}
+	PrioritySendersJsonLocation = cli.StringFlag{
+		Name:  "txpool.priority-senders-json-location",
+		Usage: "Location of the Priority Senders JSON file",
+		Value: "",
+	}
 	DebugTimers = cli.BoolFlag{
 		Name:  "debug.timers",
 		Usage: "Enable debug timers",

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -107,6 +107,7 @@ type Zk struct {
 	InitialBatchCfgFile            string
 	ACLPrintHistory                int
 	ACLJsonLocation                string
+	PrioritySendersJsonLocation    string
 	InfoTreeUpdateInterval         time.Duration
 	BadBatches                     []uint64
 	IgnoreBadBatchesCheck          bool

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -314,6 +314,7 @@ var DefaultFlags = []cli.Flag{
 
 	&utils.ACLPrintHistory,
 	&utils.ACLJsonLocation,
+	&utils.PrioritySendersJsonLocation,
 	&utils.InfoTreeUpdateInterval,
 	&utils.SealBatchImmediatelyOnOverflow,
 	&utils.MockWitnessGeneration,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -312,6 +312,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		InitialBatchCfgFile:                    ctx.String(utils.InitialBatchCfgFile.Name),
 		ACLPrintHistory:                        ctx.Int(utils.ACLPrintHistory.Name),
 		ACLJsonLocation:                        ctx.String(utils.ACLJsonLocation.Name),
+		PrioritySendersJsonLocation:            ctx.String(utils.PrioritySendersJsonLocation.Name),
 		InfoTreeUpdateInterval:                 ctx.Duration(utils.InfoTreeUpdateInterval.Name),
 		SealBatchImmediatelyOnOverflow:         ctx.Bool(utils.SealBatchImmediatelyOnOverflow.Name),
 		MockWitnessGeneration:                  ctx.Bool(utils.MockWitnessGeneration.Name),

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -331,7 +331,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		pragueTime := mock.ChainConfig.PragueTime
 		blobSchedule := mock.ChainConfig.BlobSchedule
 
-		mock.TxPool, err = txpool.New(newTxs, mock.DB, poolCfg, kvcache.NewDummy(), *chainID, shanghaiTime, agraBlock, cancunTime, pragueTime, blobSchedule, londonBlock, &ethconfig.Defaults, mock.DB)
+		mock.TxPool, err = txpool.New(newTxs, mock.DB, poolCfg, kvcache.NewDummy(), *chainID, shanghaiTime, agraBlock, cancunTime, pragueTime, blobSchedule, londonBlock, &ethconfig.Defaults, mock.DB, nil)
 		if err != nil {
 			tb.Fatal(err)
 		}

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -130,7 +130,7 @@ func TestSpawnSequencingStage(t *testing.T) {
 	cacheMock := cMocks.NewMockCache(mockCtrl)
 	cacheMock.EXPECT().View(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
-	txPool, err := txpool.New(nil, txPoolDb, txpoolcfg.Config{}, cacheMock, chainID, nil, nil, nil, nil, nil, nil, &ethconfig.Config{}, nil)
+	txPool, err := txpool.New(nil, txPoolDb, txpoolcfg.Config{}, cacheMock, chainID, nil, nil, nil, nil, nil, nil, &ethconfig.Config{}, nil, nil)
 	require.NoError(t, err)
 
 	engineMock.EXPECT().

--- a/zk/txpool/fetch_test.go
+++ b/zk/txpool/fetch_test.go
@@ -57,7 +57,7 @@ func TestFetch(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	ethCfg := &ethconfig.Defaults
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, ethCfg, aclsDB)
+	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, ethCfg, aclsDB, nil)
 	assert.NoError(err)
 	require.True(pool != nil)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/zk/txpool/metrics_test.go
+++ b/zk/txpool/metrics_test.go
@@ -99,7 +99,7 @@ func TestCalculateMetrics(t *testing.T) {
 			require.NotNil(t, txPoolDB)
 			require.NotNil(t, aclsDB)
 
-			pool, err := New(ch, coreDB, txpoolcfg.DefaultConfig, kvcache.New(kvcache.DefaultCoherentConfig), uint256.Int(*u256.N1), nil, nil, nil, nil, nil, nil, &ethconfig.Defaults, aclsDB)
+			pool, err := New(ch, coreDB, txpoolcfg.DefaultConfig, kvcache.New(kvcache.DefaultCoherentConfig), uint256.Int(*u256.N1), nil, nil, nil, nil, nil, nil, &ethconfig.Defaults, aclsDB, nil)
 			assert.NoError(err)
 			require.True(pool != nil)
 

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -322,6 +322,7 @@ type TxPool struct {
 	ethCfg          *ethconfig.Config
 	aclDB           kv.RwDB
 	policyValidator PolicyValidator
+	priorityList    *PriorityList
 
 	// we cannot be in a flushing state whilst getting transactions from the pool, so we have this mutex which is
 	// exposed publicly so anything wanting to get "best" transactions can ensure a flush isn't happening and
@@ -351,7 +352,7 @@ type FeeCalculator interface {
 
 func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, cache kvcache.Cache,
 	chainID uint256.Int, shanghaiTime, agraBlock, cancunTime, pragueTime *big.Int, blobSchedule *chain.BlobSchedule,
-	londonBlock *big.Int, ethCfg *ethconfig.Config, aclDB kv.RwDB) (*TxPool, error) {
+	londonBlock *big.Int, ethCfg *ethconfig.Config, aclDB kv.RwDB, priorityList *PriorityList) (*TxPool, error) {
 	var err error
 	localsHistory, err := simplelru.NewLRU[string, struct{}](10_000, nil)
 	if err != nil {
@@ -419,6 +420,7 @@ func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, 
 		policyValidator:         policyValidator,
 		metrics:                 &Metrics{},
 		londonBlock:             londonBlock,
+		priorityList:            priorityList,
 	}
 
 	return res, nil
@@ -575,6 +577,7 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remote.StateChang
 	p.pending.EnforceWorstInvariants()
 	p.baseFee.EnforceInvariants()
 	p.queued.EnforceInvariants()
+	p.updatePendingPoolPrioritySenders()
 	p.promote(pendingBaseFee, pendingBlobFee, &announcements)
 	p.pending.EnforceBestInvariants()
 	p.promoted.Reset()
@@ -1299,6 +1302,7 @@ func (p *TxPool) addTxs(blockNum uint64, cacheView kvcache.CacheView, senders *s
 			protocolBaseFee, blockGasLimit, pending, baseFee, queued, discard)
 	}
 
+	p.updatePendingPoolPrioritySenders()
 	p.promote(pendingBaseFee, pendingBlobFee, &announcements)
 	p.pending.EnforceBestInvariants()
 
@@ -2312,6 +2316,26 @@ func (p *TxPool) deprecatedForEach(_ context.Context, f func(rlp []byte, sender 
 	})
 }
 
+// updatePendingPoolPrioritySenders updates the priority senders in the pending pool
+func (p *TxPool) updatePendingPoolPrioritySenders() {
+	if p.priorityList == nil {
+		return
+	}
+
+	var senderPriorities map[uint64]Priority
+	senderPriorities = make(map[uint64]Priority)
+	priorityAddresses := p.priorityList.Addresses()
+
+	for _, addr := range priorityAddresses {
+		if senderID, exists := p.senders.getID(addr); exists {
+			priority := p.priorityList.GetPriority(addr)
+			senderPriorities[senderID] = priority
+		}
+	}
+
+	p.pending.UpdateSenderPriorities(senderPriorities)
+}
+
 func (p *TxPool) purge() {
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -2627,14 +2651,15 @@ type PendingPool struct {
 }
 
 func NewPendingSubPool(t SubPoolType, limit int) *PendingPool {
-	return &PendingPool{limit: limit, t: t, best: &bestSlice{ms: []*metaTx{}}, worst: &WorstQueue{ms: []*metaTx{}}}
+	return &PendingPool{limit: limit, t: t, best: &bestSlice{ms: []*metaTx{}, senderPriorities: nil}, worst: &WorstQueue{ms: []*metaTx{}}}
 }
 
 // bestSlice - is similar to best queue, but with O(n log n) complexity and
 // it maintains element.bestIndex field
 type bestSlice struct {
-	ms             []*metaTx
-	pendingBaseFee uint64
+	ms               []*metaTx
+	pendingBaseFee   uint64
+	senderPriorities map[uint64]Priority // Map from senderID to priority level
 }
 
 func (s *bestSlice) Len() int { return len(s.ms) }
@@ -2643,6 +2668,33 @@ func (s *bestSlice) Swap(i, j int) {
 	s.ms[i].bestIndex, s.ms[j].bestIndex = i, j
 }
 func (s *bestSlice) Less(i, j int) bool {
+	/*
+		Case 1: 1 Priority sender
+		t = 1, j = 0
+		T takes precedence
+
+		Case 2: 2 Priority senders
+		t = 1, j = 2
+		J takes precedence
+
+		Case 3: No Priority senders
+		Fallback to better method
+
+		Case 4: Same Priority senders
+		t = 1, j = 1
+		Takes precedence based on better method
+	*/
+
+	if s.senderPriorities != nil {
+		iPriority := s.senderPriorities[s.ms[i].Tx.SenderID]
+		jPriority := s.senderPriorities[s.ms[j].Tx.SenderID]
+
+		// If priorities are different, higher priority comes first
+		if iPriority != jPriority {
+			return iPriority > jPriority
+		}
+	}
+
 	return s.ms[i].better(s.ms[j], s.pendingBaseFee)
 }
 func (s *bestSlice) UnsafeRemove(i *metaTx) {
@@ -2656,11 +2708,17 @@ func (s *bestSlice) UnsafeAdd(i *metaTx) {
 	s.ms = append(s.ms, i)
 }
 
+// UpdateSenderPriorities updates the sender priorities map
+func (s *bestSlice) UpdateSenderPriorities(senderPriorities map[uint64]Priority) {
+	s.senderPriorities = senderPriorities
+}
+
 func (p *PendingPool) EnforceWorstInvariants() {
 	heap.Init(p.worst)
 }
 func (p *PendingPool) EnforceBestInvariants() {
 	if !p.sorted {
+		// Sort with priority senders consideration (handled in bestSlice.Less method)
 		sort.Sort(p.best)
 		p.sorted = true
 	}
@@ -2722,6 +2780,11 @@ func (p *PendingPool) DebugPrint(prefix string) {
 	for i, it := range p.worst.ms {
 		fmt.Printf("%s.worst: %d, %d, %d,%d\n", prefix, i, it.subPool, it.worstIndex, it.Tx.Nonce)
 	}
+}
+
+// UpdateSenderPriorities updates the sender priorities for the pending pool
+func (p *PendingPool) UpdateSenderPriorities(senderPriorities map[uint64]Priority) {
+	p.best.UpdateSenderPriorities(senderPriorities)
 }
 
 type SubPool struct {

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -393,6 +393,9 @@ func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, 
 
 	lock := &sync.Mutex{}
 
+	sendersCache := newSendersCache(tracedSenders)
+	sendersCache.registerPrioritySenders(priorityList)
+
 	res := &TxPool{
 		lock:                    lock,
 		lastSeenCond:            sync.NewCond(lock),
@@ -406,7 +409,7 @@ func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, 
 		queued:                  NewSubPool(QueuedSubPool, cfg.QueuedSubPoolLimit),
 		newPendingTxs:           newTxs,
 		_stateCache:             cache,
-		senders:                 newSendersCache(tracedSenders),
+		senders:                 sendersCache,
 		_chainDB:                coreDB,
 		cfg:                     cfg,
 		chainID:                 chainID,
@@ -422,6 +425,8 @@ func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, 
 		londonBlock:             londonBlock,
 		priorityList:            priorityList,
 	}
+
+	res.updatePendingPoolPrioritySenders()
 
 	return res, nil
 }
@@ -577,7 +582,6 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remote.StateChang
 	p.pending.EnforceWorstInvariants()
 	p.baseFee.EnforceInvariants()
 	p.queued.EnforceInvariants()
-	p.updatePendingPoolPrioritySenders()
 	p.promote(pendingBaseFee, pendingBlobFee, &announcements)
 	p.pending.EnforceBestInvariants()
 	p.promoted.Reset()
@@ -1302,7 +1306,6 @@ func (p *TxPool) addTxs(blockNum uint64, cacheView kvcache.CacheView, senders *s
 			protocolBaseFee, blockGasLimit, pending, baseFee, queued, discard)
 	}
 
-	p.updatePendingPoolPrioritySenders()
 	p.promote(pendingBaseFee, pendingBlobFee, &announcements)
 	p.pending.EnforceBestInvariants()
 
@@ -1973,8 +1976,20 @@ func (p *TxPool) flushLocked(tx kv.RwTx) (err error) {
 		if !p.all.hasTxs(id) {
 			addr, ok := p.senders.senderID2Addr[id]
 			if ok {
-				delete(p.senders.senderID2Addr, id)
-				delete(p.senders.senderIDs, addr)
+				if p.priorityList != nil {
+					prioSenders := p.priorityList.Addresses()
+					found := false
+					for _, prioAddr := range prioSenders {
+						if prioAddr == addr {
+							found = true
+							break
+						}
+					}
+					if !found {
+						delete(p.senders.senderID2Addr, id)
+						delete(p.senders.senderIDs, addr)
+					}
+				}
 			}
 		}
 		//fmt.Printf("del:%d,%d,%d\n", mt.Tx.senderID, mt.Tx.nonce, mt.Tx.tip)
@@ -2473,6 +2488,15 @@ func (sc *sendersBatch) info(cacheView kvcache.CacheView, id uint64) (nonce uint
 		return 0, emptySender.balance, err
 	}
 	return nonce, balance, nil
+}
+
+func (sc *sendersBatch) registerPrioritySenders(priorityList *PriorityList) {
+	if priorityList == nil {
+		return
+	}
+	for _, addr := range priorityList.Addresses() {
+		sc.getOrCreateID(addr)
+	}
 }
 
 func (sc *sendersBatch) registerNewSenders(newTxs *types.TxSlots) (err error) {

--- a/zk/txpool/pool_test.go
+++ b/zk/txpool/pool_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	mapset "github.com/deckarep/golang-set/v2"
 	types2 "github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/zk/utils"
 
@@ -383,8 +382,7 @@ func TestPriorityYieldBest(t *testing.T) {
 
 	yieldSlots := &types.TxsRlp{}
 	yieldSize := uint16(4)
-	yieldedTransactions := mapset.NewSet[[32]byte]()
-	allConditionsOk, _, err := pool.YieldBest(yieldSize, yieldSlots, tx, 0, utils.ForkId8BlockGasLimit, 0, yieldedTransactions)
+	allConditionsOk, _, err := pool.YieldBest(yieldSize, yieldSlots, tx, 0, utils.ForkId8BlockGasLimit, 0)
 	assert.NoError(t, err)
 	assert.True(t, allConditionsOk, "all conditions should be ok")
 	assert.Equal(t, yieldSize, uint16(len(yieldSlots.Txs)), "should yield the expected number of transactions")

--- a/zk/txpool/pool_test.go
+++ b/zk/txpool/pool_test.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/big"
 	"testing"
 	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	types2 "github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/zk/utils"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/datadir"
@@ -47,7 +52,7 @@ func TestNonceFromAddress(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	ethCfg := &ethconfig.Defaults
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, ethCfg, aclsDB)
+	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, ethCfg, aclsDB, nil)
 	assert.NoError(err)
 	require.True(pool != nil)
 	ctx := context.Background()
@@ -243,4 +248,177 @@ func TestOnNewBlock(t *testing.T) {
 	err := fetch.handleStateChanges(ctx, stateChanges)
 	assert.ErrorIs(t, io.EOF, err)
 	assert.Equal(t, 3, len(minedTxs.Txs))
+}
+
+func TestUnmarshalPrioritySendersList(t *testing.T) {
+	list, err := UnmarshalDynamicPriorityList("test-priority-list.json")
+	require.NoError(t, err)
+	assert.NotNil(t, list)
+	assert.Equal(t, 3, len(list.Addresses()), "should have 3 addresses in the priority list")
+	assert.Equal(t, list.GetPriority(common.HexToAddress("0x2581c81825C961199e84130E25442A9B3eafCB21")), Priority(3), "should have priority 3 for address 0x2581c81825C961199e84130E25442A9B3eafCB21")
+	assert.Equal(t, list.GetPriority(common.HexToAddress("0xa974239DdC8cFb90eACd44470cC8889c6d997799")), Priority(2), "should have priority 2 for address 0xa974239DdC8cFb90eACd44470cC8889c6d997799")
+	assert.Equal(t, list.GetPriority(common.HexToAddress("0x1a32F6e7Cf3062f1aB0D25EF0ba4Ac13593D60BA")), Priority(1), "should have priority 1 for address 0x1a32F6e7Cf3062f1aB0D25EF0ba4Ac13593D60BA")
+}
+
+func TestPriorityYieldBest(t *testing.T) {
+	ctx := context.Background()
+	addr1 := common.HexToAddress("0xA967E10A7f04cD54fb8419040BD400654b008777")
+	addr2 := common.HexToAddress("0xa974239DdC8cFb90eACd44470cC8889c6d997799")
+	addr3 := common.HexToAddress("0x784bCB8cb9AE8cdD1c1532185c02FDd25588643a")
+	addr4 := common.HexToAddress("0x2581c81825C961199e84130E25442A9B3eafCB21")
+	addr5 := common.HexToAddress("0xB7245c3D6D1c49F26b89Df890931495B9608ed17")
+	addr6 := common.HexToAddress("0x1a32F6e7Cf3062f1aB0D25EF0ba4Ac13593D60BA")
+
+	ch := make(chan types.Announcements, 100)
+	_, coreDB, _ := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
+	defer coreDB.Close()
+	require.NotNil(t, coreDB)
+	db := memdb.NewTestPoolDB(t)
+	path := fmt.Sprintf("/tmp/db-test-%v", time.Now().UTC().Format(time.RFC3339Nano))
+	txPoolDB := newTestTxPoolDB(t, path)
+	defer txPoolDB.Close()
+	aclDB := newTestACLDB(t, path)
+	defer aclDB.Close()
+	require.NotNil(t, db)
+	require.NotNil(t, txPoolDB)
+	require.NotNil(t, aclDB)
+	priorityList, err := UnmarshalDynamicPriorityList("test-priority-list.json")
+	require.NoError(t, err)
+	assert.NotNil(t, priorityList)
+	pool, err := New(ch, coreDB, txpoolcfg.DefaultConfig, kvcache.New(kvcache.DefaultCoherentConfig), uint256.Int(*u256.N1), nil, nil, nil, nil, nil, nil, &ethconfig.Defaults, aclDB, priorityList)
+	assert.NoError(t, err)
+	require.True(t, pool != nil)
+
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	v := make([]byte, types.EncodeSenderLengthForStorage(2, *uint256.NewInt(18 * common.Ether)))
+	types.EncodeSender(2, *uint256.NewInt(18 * common.Ether), v)
+	var stateVersionID uint64 = 0
+	pendingBaseFee := uint64(200000)
+	h1 := gointerfaces.ConvertHashToH256([32]byte{})
+
+	change := &remote.StateChangeBatch{
+		StateVersionId:      stateVersionID,
+		PendingBlockBaseFee: pendingBaseFee,
+		BlockGasLimit:       1000000,
+		ChangeBatch: []*remote.StateChange{
+			{BlockHeight: 0, BlockHash: h1},
+		},
+	}
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
+		Action:  remote.Action_UPSERT,
+		Address: gointerfaces.ConvertAddressToH160(addr1),
+		Data:    v,
+	})
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
+		Action:  remote.Action_UPSERT,
+		Address: gointerfaces.ConvertAddressToH160(addr2),
+		Data:    v,
+	})
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
+		Action:  remote.Action_UPSERT,
+		Address: gointerfaces.ConvertAddressToH160(addr3),
+		Data:    v,
+	})
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
+		Action:  remote.Action_UPSERT,
+		Address: gointerfaces.ConvertAddressToH160(addr4),
+		Data:    v,
+	})
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
+		Action:  remote.Action_UPSERT,
+		Address: gointerfaces.ConvertAddressToH160(addr5),
+		Data:    v,
+	})
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
+		Action:  remote.Action_UPSERT,
+		Address: gointerfaces.ConvertAddressToH160(addr6),
+		Data:    v,
+	})
+
+	err = pool.OnNewBlock(ctx, change, types.TxSlots{}, types.TxSlots{}, tx)
+	assert.NoError(t, err)
+
+	parseCtx := types.NewTxParseContext(*uint256.NewInt(779)).ChainIDRequired()
+
+	txRlps := [][]byte{
+		// signed: 0xA967E10A7f04cD54fb8419040BD400654b008777 (No Priority)
+		decodeHex("f86702842e3b19288252089451025f088a8e17718e03f2450a99dc495e2536c58227108082063aa0c2c6252efe24ca1b9cde5d5684812faa4f500b884fc1f89cd5898304bcd961c4a01df722403fa62a0efc63911317638bba8844571c8987eea33bdb5e8b5544661d"),
+		// signed: 0xa974239DdC8cFb90eACd44470cC8889c6d997799 (Priority)
+		decodeHex("f86702842e3b19288252089451025f088a8e17718e03f2450a99dc495e2536c58227108082063aa0757b0371b4e9dd8f158d776bcf1fa6d5ebb625d9a6a36f3d21aeaf9d30ca1942a05f81ce37c134c73cdf39df3988f04d3265c40cce30150ce910a1f1009920e9c7"),
+		// signed: 0x784bCB8cb9AE8cdD1c1532185c02FDd25588643a (No Priority)
+		decodeHex("f86702842e3b19288252089451025f088a8e17718e03f2450a99dc495e2536c582271080820639a0789dc60dc7f9bd1d082e06eb712a1b8ad7d1e1045ffae571b82c5f294926b6eba05df2304715fdf65a0e846bfe00a2133b0428b765e9c030ba3574d5db7a6ee448"),
+		// signed: 0x2581c81825C961199e84130E25442A9B3eafCB21 (Priority)
+		decodeHex("f86702842e3b19288252089451025f088a8e17718e03f2450a99dc495e2536c582271080820639a0385fb29260083b3ba56f3d85f64efa1200cbc106beb1ff1898cf70faee8fa76aa040e985552584672bbbdcd8da227e88cbd0f0b4627b0d2adfbf2086b568f6daea"),
+		// signed: 0xB7245c3D6D1c49F26b89Df890931495B9608ed17 (No Priority)
+		decodeHex("f86702842e3b19288252089451025f088a8e17718e03f2450a99dc495e2536c58227108082063aa031244c55c18ceb4d4773ceb88cf84eababd81b27d0b173d6352f3a983c445a9ba07c330b2cbfa8399a2eceab4186b2812e0ffb8cb86af4317319dc8b9af7270b59"),
+		// signed: 0x1a32F6e7Cf3062f1aB0D25EF0ba4Ac13593D60BA (Priority)
+		decodeHex("f86702842e3b192882520894a94f5374fce5edbc8e2a8697c15331677e6ebf0b82271080820639a04777a5be6cba3c48da288945a8de5ef836d0dd3d06f2460694df50cee733125da0763268a31fea68d85481b119bdbd587d15b0f39444ada7acd8e1bdc2cbeb2353"),
+	}
+
+	var slots types.TxSlots
+	for i, rlp := range txRlps {
+		txSlot := &types.TxSlot{}
+		s := common.Address{}
+		senderSlice := s[:]
+
+		_, err = parseCtx.ParseTransaction(rlp, 0, txSlot, senderSlice, false, false, func(hash []byte) error {
+			return nil
+		})
+		assert.NoError(t, err, "should parse transaction without error")
+
+		slots.Resize(uint(i + 1))
+		slots.Txs[i] = txSlot
+		copy(slots.Senders.At(i), senderSlice)
+		slots.IsLocal[i] = true
+	}
+
+	dReasons, err := pool.AddLocalTxs(ctx, slots, tx)
+	assert.NoError(t, err)
+	for _, reason := range dReasons {
+		assert.Equal(t, Success, reason, reason.String())
+	}
+
+	yieldSlots := &types.TxsRlp{}
+	yieldSize := uint16(4)
+	yieldedTransactions := mapset.NewSet[[32]byte]()
+	allConditionsOk, _, err := pool.YieldBest(yieldSize, yieldSlots, tx, 0, utils.ForkId8BlockGasLimit, 0, yieldedTransactions)
+	assert.NoError(t, err)
+	assert.True(t, allConditionsOk, "all conditions should be ok")
+	assert.Equal(t, yieldSize, uint16(len(yieldSlots.Txs)), "should yield the expected number of transactions")
+
+	// slot 1: addr4 (0x2581c81825C961199e84130E25442A9B3eafCB21: Priority 3)
+	yield1 := yieldSlots.Txs[0]
+	transaction1, err := types2.DecodeTransaction(yield1)
+	assert.NoError(t, err, "should decode transaction without error")
+	signer := types2.LatestSignerForChainID(big.NewInt(779))
+	sdr1, err := transaction1.Sender(*signer)
+	assert.NoError(t, err, "should get sender without error")
+	assert.True(t, sdr1 == addr4, "should yield the transaction from the priority sender %s", addr4.Hex())
+
+	// slot 2: addr2 (0xa974239DdC8cFb90eACd44470cC8889c6d997799: Priority 2)
+	yield2 := yieldSlots.Txs[1]
+	transaction2, err := types2.DecodeTransaction(yield2)
+	assert.NoError(t, err, "should decode transaction without error")
+	sdr2, err := transaction2.Sender(*signer)
+	assert.NoError(t, err, "should get sender without error")
+	assert.True(t, sdr2 == addr2, "should yield the transaction from the priority sender %s", addr2.Hex())
+
+	// slot 3: addr6 (0x1a32F6e7Cf3062f1aB0D25EF0ba4Ac13593D60BA: Priority 1)
+	yield3 := yieldSlots.Txs[2]
+	transaction3, err := types2.DecodeTransaction(yield3)
+	assert.NoError(t, err, "should decode transaction without error")
+	sdr3, err := transaction3.Sender(*signer)
+	assert.NoError(t, err, "should get sender without error")
+	assert.True(t, sdr3 == addr6, "should yield the transaction from the priority sender %s", addr6.Hex())
+
+	// slot 4: any addr (No Priority). We should still yield from the non-priority senders.
+	yield4 := yieldSlots.Txs[3]
+	transaction4, err := types2.DecodeTransaction(yield4)
+	assert.NoError(t, err, "should decode transaction without error")
+	sdr4, err := transaction4.Sender(*signer)
+	assert.NoError(t, err, "should get sender without error")
+	assert.True(t, sdr4 == addr1 || sdr4 == addr3 || sdr4 == addr5, "should yield the transaction from any address %s, %s or %s", addr1.Hex(), addr3.Hex(), addr5.Hex())
 }

--- a/zk/txpool/pool_zk_limbo_persistent_test.go
+++ b/zk/txpool/pool_zk_limbo_persistent_test.go
@@ -44,7 +44,7 @@ func store(t *testing.T, dbPath string) *TxPool {
 	ethCfg := &ethconfig.Defaults
 	ethCfg.Zk.Limbo = true
 
-	pSource, err := New(make(chan types.Announcements), db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), ethCfg, aclDb)
+	pSource, err := New(make(chan types.Announcements), db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), ethCfg, aclDb, nil)
 	assert.NilError(t, err)
 
 	parseCtx := types.NewTxParseContext(pSource.chainID)
@@ -147,7 +147,7 @@ func store(t *testing.T, dbPath string) *TxPool {
 	assert.NilError(t, err)
 
 	// restore
-	pTarget, err := New(make(chan types.Announcements), db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), ethCfg, aclDb)
+	pTarget, err := New(make(chan types.Announcements), db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), ethCfg, aclDb, nil)
 	assert.NilError(t, err)
 
 	cacheView, err := pTarget._stateCache.View(context.Background(), tx)
@@ -184,7 +184,7 @@ func restoreRo(t *testing.T, dbPath string, pSource *TxPool) {
 	newTxs := make(chan types.Announcements, 1024)
 	defer close(newTxs)
 
-	pTarget, err := New(newTxs, db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), &ethconfig.Defaults, aclDb)
+	pTarget, err := New(newTxs, db, txpoolcfg.DefaultConfig, kvcache.NewDummy(), *uint256.NewInt(1101), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), &ethconfig.Defaults, aclDb, nil)
 	assert.NilError(t, err)
 
 	err = db.View(context.Background(), func(tx kv.Tx) error {

--- a/zk/txpool/priority.go
+++ b/zk/txpool/priority.go
@@ -1,0 +1,79 @@
+package txpool
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/erigontech/erigon-lib/common"
+)
+
+// priorityListJSON represents the JSON structure with senders array
+type priorityListJSON struct {
+	Senders []string `json:"senders"`
+}
+
+// UnmarshalDynamicPriorityList reads a JSON file of accounts from the given path.
+func UnmarshalDynamicPriorityList(path string) (*PriorityList, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var jsonData priorityListJSON
+	if err = json.Unmarshal(data, &jsonData); err != nil {
+		return nil, err
+	}
+
+	priorityList := &PriorityList{
+		addresses: make(map[common.Address]uint64),
+	}
+
+	for i, addrStr := range jsonData.Senders {
+		addr := common.HexToAddress(addrStr)
+		priority := uint64(len(jsonData.Senders) - i)
+		priorityList.addresses[addr] = priority
+	}
+
+	return priorityList, nil
+}
+
+type Priority uint64
+
+const (
+	NoPriority Priority = 0
+)
+
+type PriorityList struct {
+	addresses map[common.Address]uint64
+}
+
+func (p *PriorityList) GetPriority(addr common.Address) Priority {
+	if priority, exists := p.addresses[addr]; exists {
+		return Priority(priority)
+	}
+	return NoPriority
+}
+
+func (p *PriorityList) Addresses() []common.Address {
+	if p.addresses == nil {
+		return []common.Address{}
+	}
+
+	addresses := make([]common.Address, 0, len(p.addresses))
+	for addr := range p.addresses {
+		addresses = append(addresses, addr)
+	}
+
+	return addresses
+}

--- a/zk/txpool/test-priority-list.json
+++ b/zk/txpool/test-priority-list.json
@@ -1,0 +1,7 @@
+{
+    "senders": [
+        "0x2581c81825C961199e84130E25442A9B3eafCB21",
+        "0xa974239DdC8cFb90eACd44470cC8889c6d997799",
+        "0x1a32F6e7Cf3062f1aB0D25EF0ba4Ac13593D60BA"
+    ]
+}

--- a/zk/txpool/txpooluitl/all_components.go
+++ b/zk/txpool/txpooluitl/all_components.go
@@ -149,7 +149,15 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, ethCfg *ethconfig.
 		shanghaiTime = cfg.OverrideShanghaiTime
 	}
 
-	txPool, err := txpool.New(newTxs, chainDB, cfg, cache, *chainID, shanghaiTime, agraBlock, cancunTime, pragueTime, chainConfig.BlobSchedule, chainConfig.LondonBlock, ethCfg, aclDB)
+	var priorityList *txpool.PriorityList
+	if len(ethCfg.Zk.PrioritySendersJsonLocation) > 0 {
+		priorityList, err = txpool.UnmarshalDynamicPriorityList(ethCfg.Zk.PrioritySendersJsonLocation)
+		if err != nil {
+			return nil, nil, nil, nil, nil, fmt.Errorf("failed to unmarshal dynamic priority list: %w", err)
+		}
+	}
+
+	txPool, err := txpool.New(newTxs, chainDB, cfg, cache, *chainID, shanghaiTime, agraBlock, cancunTime, pragueTime, chainConfig.BlobSchedule, chainConfig.LondonBlock, ethCfg, aclDB, priorityList)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
### Description

Unmarshal a senders list JSON of addresses that will get priority on the txpool yield. So if there are 600 tx's in the pool and we yield 500, we make sure the senders on the priority list are included and take priority.

### Flags

`txpool.priority-senders-json-location` Location for the senders list json. 
"/cdk-erigon/senders-list.json"

### Senders List Json
The higher addresses take the most priority

```
{
    "senders": [
        "0x2581c81825C961199e84130E25442A9B3eafCB21",
        "0xa974239DdC8cFb90eACd44470cC8889c6d997799"
    ]
}
```