### PR TITLE
enable pmt on block

### DIFF
--- a/.github/actions/setup-kurtosis-type1/action.yml
+++ b/.github/actions/setup-kurtosis-type1/action.yml
@@ -79,7 +79,7 @@ runs:
         sed -i '/zkevm.datastream-version:/d' ./templates/cdk-erigon/config.yml
         sed -i 's/zkevm\.disable-virtual-counters: false/zkevm.disable-virtual-counters: true/' ./templates/cdk-erigon/config.yml
         sed -i '$a\zkevm.honour-chainspec: true' ./templates/cdk-erigon/config.yml
-        sed -i '$a\zkevm.initial-commitment: pmt' ./templates/cdk-erigon/config.yml
+        sed -i 's/"pmtEnabledBlock": [0-9]\+/"pmtEnabledBlock": 0/' ./templates/cdk-erigon/chainspec.json
         sed -i 's/"londonBlock": [0-9]\+/"londonBlock": 0/' ./templates/cdk-erigon/chainspec.json
         sed -i 's/"normalcyBlock": [0-9]\+/"normalcyBlock": 0/' ./templates/cdk-erigon/chainspec.json
         sed -i 's/"shanghaiTime": [0-9]\+/"shanghaiTime": 0/' ./templates/cdk-erigon/chainspec.json

--- a/cmd/integration/commands/stages_zkevm.go
+++ b/cmd/integration/commands/stages_zkevm.go
@@ -71,11 +71,6 @@ func newSyncZk(ctx context.Context, db kv.RwDB) (consensus.Engine, *vm.Config, *
 		genesis.GasLimit = dConf.GasLimit
 		genesis.Difficulty = big.NewInt(dConf.Difficulty)
 
-		if !zkCfg.Commitment.IsValid() {
-			panic(fmt.Sprintf("Invalid commitment: %s. Must be one of: %s", zkCfg.Commitment, ethconfig.ValidCommitments()))
-		}
-
-		genesis.Type1 = zkCfg.Commitment.IsType1()
 		genesis.HonourChainspec = zkCfg.HonourChainspec
 	} else {
 		genesis = core.GenesisBlockByChainName(chain)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -20,6 +20,7 @@ package utils
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"github.com/erigontech/erigon/core/types"
 	"math/big"
 	"path/filepath"
 	"runtime"
@@ -116,6 +117,22 @@ var (
 	OverridePragueFlag = flags.BigFlag{
 		Name:  "override.prague",
 		Usage: "Manually specify the Prague fork time, overriding the bundled setting",
+	}
+	OverrideNormalcyBlockFlag = flags.BigFlag{
+		Name:  "override.normalcyblock",
+		Usage: "Manually specify the NormalcyBlock fork block, overriding the bundled setting",
+	}
+	OverrideShanghaiTimeFlag = flags.BigFlag{
+		Name:  "override.shanghaitime",
+		Usage: "Manually specify the time for shanghai fork",
+	}
+	OverrideLondonBlockFlag = flags.BigFlag{
+		Name:  "override.londonblock",
+		Usage: "Manually specify the block for london fork",
+	}
+	OverridePmtEnabledBlockFlag = flags.BigFlag{
+		Name:  "override.pmtenabledblock",
+		Usage: "Manually specify the block for london fork",
 	}
 	TrustedSetupFile = cli.StringFlag{
 		Name:  "trusted-setup-file",
@@ -923,14 +940,14 @@ var (
 		Usage: "Exclude zkevm flags from startup logging on zkevm flags.",
 		Value: cli.NewStringSlice("zkevm.l1-rpc-url"),
 	}
-	Commitment = cli.StringFlag{
-		Name:  "zkevm.initial-commitment",
-		Usage: "Values { smt | pmt }. Default, smt.",
-		Value: "smt",
-	}
 	HonourChainspec = cli.BoolFlag{
 		Name:  "zkevm.honour-chainspec",
 		Usage: "Honour the actual chainspec values. This means that no chainspec values will get changed based on normalcy mode. Default false.",
+		Value: false,
+	}
+	SimultaneousPmtAndSmt = cli.BoolFlag{
+		Name:  "zkevm.simultaneous-pmt-and-smt",
+		Usage: "Build the PMT as a standalone tree. To be used for promoting the SMT to PMT.",
 		Value: false,
 	}
 	ACLPrintHistory = cli.IntFlag{
@@ -2461,11 +2478,6 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		genesis.GasLimit = dConf.GasLimit
 		genesis.Difficulty = big.NewInt(dConf.Difficulty)
 		genesis.HonourChainspec = ctx.Bool(HonourChainspec.Name)
-		commitment := ethconfig.Commitment(ctx.String(Commitment.Name))
-		if !commitment.IsValid() {
-			panic(fmt.Sprintf("Invalid commitment: %s. Must be one of: %s", ctx.String(Commitment.Name), ethconfig.ValidCommitments()))
-		}
-		genesis.Type1 = commitment.IsType1()
 
 		cfg.Genesis = genesis
 
@@ -2513,8 +2525,30 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	}
 
 	if ctx.IsSet(OverridePragueFlag.Name) {
-		cfg.OverridePragueTime = flags.GlobalBig(ctx, OverridePragueFlag.Name)
-		cfg.TxPool.OverridePragueTime = cfg.OverridePragueTime
+		cfg.GenesisOverrides = &types.GenesisOverrides{
+			OverridePragueTime: flags.GlobalBig(ctx, OverridePragueFlag.Name),
+		}
+		cfg.TxPool.OverridePragueTime = cfg.GenesisOverrides.OverridePragueTime
+	}
+	if ctx.IsSet(OverrideNormalcyBlockFlag.Name) {
+		cfg.GenesisOverrides = &types.GenesisOverrides{
+			OverrideNormalcyBlock: flags.GlobalBig(ctx, OverrideNormalcyBlockFlag.Name),
+		}
+	}
+	if ctx.IsSet(OverrideLondonBlockFlag.Name) {
+		cfg.GenesisOverrides = &types.GenesisOverrides{
+			OverrideLondonBlock: flags.GlobalBig(ctx, OverrideLondonBlockFlag.Name),
+		}
+	}
+	if ctx.IsSet(OverrideShanghaiTimeFlag.Name) {
+		cfg.GenesisOverrides = &types.GenesisOverrides{
+			OverrideShanghaiTime: flags.GlobalBig(ctx, OverrideShanghaiTimeFlag.Name),
+		}
+	}
+	if ctx.IsSet(OverridePmtEnabledBlockFlag.Name) {
+		cfg.GenesisOverrides = &types.GenesisOverrides{
+			OverridePmtEnabledBlock: flags.GlobalBig(ctx, OverridePmtEnabledBlockFlag.Name),
+		}
 	}
 
 	if ctx.IsSet(InternalConsensusFlag.Name) && clparams.EmbeddedSupported(cfg.NetworkID) {

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -74,14 +74,14 @@ func CommitGenesisBlock(db kv.RwDB, genesis *types.Genesis, tmpDir string, logge
 	return CommitGenesisBlockWithOverride(db, genesis, nil, tmpDir, logger)
 }
 
-func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, overridePragueTime *big.Int, tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
+func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, overrides *types.GenesisOverrides, tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
 	tx, err := db.BeginRw(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}
 	defer tx.Rollback()
 	// honourChainspec is false here, CommitGenesisBlock is for integration.
-	c, b, err := WriteGenesisBlock(tx, genesis, overridePragueTime, tmpDir, logger)
+	c, b, err := WriteGenesisBlock(tx, genesis, overrides, tmpDir, logger)
 	if err != nil {
 		return c, b, err
 	}
@@ -92,7 +92,7 @@ func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, override
 	return c, b, nil
 }
 
-func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overridePragueTime *big.Int, tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
+func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrides *types.GenesisOverrides, tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
 	var storedBlock *types.Block
 	if genesis != nil && genesis.Config == nil {
 		return params.AllProtocolChanges, nil, types.ErrGenesisNoConfig
@@ -104,8 +104,22 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overridePragueTime *b
 	}
 
 	applyOverrides := func(config *chain.Config) {
-		if overridePragueTime != nil {
-			config.PragueTime = overridePragueTime
+		if overrides != nil {
+			if overrides.OverridePragueTime != nil {
+				config.PragueTime = overrides.OverridePragueTime
+			}
+			if overrides.OverrideNormalcyBlock != nil {
+				config.NormalcyBlock = overrides.OverrideNormalcyBlock
+			}
+			if overrides.OverrideLondonBlock != nil {
+				config.LondonBlock = overrides.OverrideLondonBlock
+			}
+			if overrides.OverrideShanghaiTime != nil {
+				config.ShanghaiTime = overrides.OverrideShanghaiTime
+			}
+			if overrides.OverridePmtEnabledBlock != nil {
+				config.PmtEnabledBlock = overrides.OverridePmtEnabledBlock
+			}
 		}
 	}
 
@@ -610,10 +624,8 @@ func GenesisToBlock(g *types.Genesis, tmpDir string, logger log.Logger) (*types.
 		r, w := state.NewDbStateReader(tx), state.NewDbStateWriter(tx, 0)
 		statedb = state.New(r)
 
-		if g.Config != nil {
-			g.Config.Type1 = g.Type1
-		}
-		statedb.SetType1(g.Type1)
+		type1 := g.Config.PmtEnabledBlock != nil && g.Config.PmtEnabledBlock.Cmp(head.Number) <= 0
+		statedb.SetType1(type1)
 
 		hasConstructorAllocation := false
 		for _, account := range g.Alloc {
@@ -657,7 +669,7 @@ func GenesisToBlock(g *types.Genesis, tmpDir string, logger log.Logger) (*types.
 				statedb.SetIncarnation(addr, state.FirstContractIncarnation)
 			}
 
-			if !g.Type1 {
+			if !type1 {
 				ro, err = processAccount(sparseTree, ro, &account, addr)
 				if err != nil {
 					return
@@ -668,7 +680,7 @@ func GenesisToBlock(g *types.Genesis, tmpDir string, logger log.Logger) (*types.
 			return
 		}
 
-		if g.Type1 {
+		if type1 {
 			if root, err = trie.CalcRoot("genesis", tx); err != nil {
 				return
 			}

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -902,7 +902,7 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase libcomm
 		}
 	}
 
-	sdb.isType1 = rules.IsType1
+	sdb.isType1 = rules.IsPmtEnabled && rules.IsNormalcy
 
 	// Reset transient storage at the beginning of transaction execution
 	sdb.transientStorage = newTransientStorage()

--- a/core/types/genesis.go
+++ b/core/types/genesis.go
@@ -70,7 +70,14 @@ type Genesis struct {
 
 	// Zkevm fields
 	HonourChainspec bool `json:"honourChainspec,omitempty"` // Used in normalcy mode
-	Type1           bool `json:"type1,omitempty"`
+}
+
+type GenesisOverrides struct {
+	OverridePragueTime      *big.Int `toml:",omitempty"`
+	OverrideNormalcyBlock   *big.Int `toml:",omitempty"`
+	OverrideLondonBlock     *big.Int `toml:",omitempty"`
+	OverrideShanghaiTime    *big.Int `toml:",omitempty"`
+	OverridePmtEnabledBlock *big.Int `toml:",omitempty"`
 }
 
 type AuRaSeal struct {

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -119,6 +119,9 @@ type Config struct {
 	ForkId13Durian          *big.Int `json:"forkID13Durian,omitempty"`
 	NormalcyBlock           *big.Int `json:"normalcyBlock,omitempty"`
 
+	// The block at which the PMT is enabled over the SMT.
+	PmtEnabledBlock *big.Int `json:"pmtEnabledBlock,omitempty"`
+
 	AllowFreeTransactions bool   `json:"allowFreeTransactions,omitempty"`
 	FreeInjectedBatch     bool   `json:"freeInjectedBatch,omitempty"`
 	ZkDefaultGasPrice     uint64 `json:"zkDefaultGasFee,omitempty"`
@@ -127,7 +130,6 @@ type Config struct {
 	// this option should only be used in conjunction with normalcy, it is designed for testing
 	// vanilla EVM execution for comparison of state roots only and not to be used in production
 	DebugDisableZkevmStateChanges bool `json:"debugDisableZkevmStateChanges,omitempty"`
-	Type1                         bool `json:"type1,omitempty"` // if true, type1 behavior is enabled (normalcy + PMT), otherwise type2 behavior is used
 }
 
 type BlobConfig struct {
@@ -193,7 +195,7 @@ type BorConfig interface {
 func (c *Config) String() string {
 	engine := c.getEngine()
 
-	return fmt.Sprintf("{ChainID: %v, Homestead: %v, DAO: %v, Tangerine Whistle: %v, Spurious Dragon: %v, Byzantium: %v, Constantinople: %v, Petersburg: %v, Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Gray Glacier: %v, Terminal Total Difficulty: %v, Merge Netsplit: %v, Shanghai: %v, Cancun: %v, Prague: %v, Osaka: %v, Normalcy: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v, Homestead: %v, DAO: %v, Tangerine Whistle: %v, Spurious Dragon: %v, Byzantium: %v, Constantinople: %v, Petersburg: %v, Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Gray Glacier: %v, Terminal Total Difficulty: %v, Merge Netsplit: %v, Shanghai: %v, Cancun: %v, Prague: %v, Osaka: %v, Normalcy: %v, PMT Enabled: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -215,6 +217,7 @@ func (c *Config) String() string {
 		c.PragueTime,
 		c.OsakaTime,
 		c.NormalcyBlock,
+		c.PmtEnabledBlock,
 		engine,
 	)
 }
@@ -408,6 +411,10 @@ func (c *Config) GetBlobGasPriceUpdateFraction(t uint64) uint64 {
 
 func (c *Config) IsNormalcy(num uint64) bool {
 	return isForked(c.NormalcyBlock, num)
+}
+
+func (c *Config) IsPmtEnabled(num uint64) bool {
+	return isForked(c.PmtEnabledBlock, num)
 }
 
 func (c *Config) IsForkID4(num uint64) bool {
@@ -703,7 +710,7 @@ type Rules struct {
 	IsPrague, isOsaka                                                                                                                                    bool
 	IsAura                                                                                                                                               bool
 	IsNormalcy                                                                                                                                           bool
-	IsType1                                                                                                                                              bool
+	IsPmtEnabled                                                                                                                                         bool
 	IsForkID4, IsForkID5Dragonfruit, IsForkID6IncaBerry, IsForkID7Etrog, IsForkID8Elderberry, IsForkId10, IsForkId11, IsForkID12Banana, IsForkID13Durian bool
 }
 
@@ -731,7 +738,7 @@ func (c *Config) Rules(num uint64, time uint64) *Rules {
 		IsPrague:             c.IsPrague(time),
 		isOsaka:              c.IsOsaka(time),
 		IsNormalcy:           c.IsNormalcy(num),
-		IsType1:              c.Type1,
+		IsPmtEnabled:         c.IsPmtEnabled(num),
 		IsAura:               c.Aura != nil,
 		IsForkID4:            c.IsForkID4(num),
 		IsForkID5Dragonfruit: c.IsForkID5Dragonfruit(num),

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -335,7 +335,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			genesisSpec = nil
 		}
 		var genesisErr error
-		chainConfig, genesis, genesisErr = core.WriteGenesisBlock(tx, genesisSpec, config.OverridePragueTime, tmpdir, logger)
+		chainConfig, genesis, genesisErr = core.WriteGenesisBlock(tx, genesisSpec, config.GenesisOverrides, tmpdir, logger)
 		if _, ok := genesisErr.(*chain.ConfigCompatError); genesisErr != nil && !ok {
 			return genesisErr
 		}
@@ -1027,7 +1027,6 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		backend.chainConfig.AllowFreeTransactions = cfg.AllowFreeTransactions
 		backend.chainConfig.ZkDefaultGasPrice = cfg.DefaultGasPrice
 		backend.chainConfig.FreeInjectedBatch = cfg.FreeInjectedBatch
-		backend.chainConfig.Type1 = cfg.Zk.Commitment.IsType1()
 		l1Urls := strings.Split(cfg.L1RpcUrl, ",")
 
 		if cfg.Zk.L1CacheEnabled {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -254,7 +254,7 @@ type Config struct {
 	SentinelAddr                string
 	SentinelPort                uint64
 
-	OverridePragueTime *big.Int `toml:",omitempty"`
+	GenesisOverrides *types.GenesisOverrides `toml:",omitempty"`
 
 	//[zkevm]
 	*Zk

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -1,7 +1,6 @@
 package ethconfig
 
 import (
-	"strings"
 	"time"
 
 	"github.com/c2h5oh/datasize"
@@ -129,36 +128,11 @@ type Zk struct {
 	L2InfoTreeUpdatesBatchSize     uint64
 	L2InfoTreeUpdatesEnabled       bool
 
-	Commitment      Commitment `yaml:"zkevm.initial-commitment"`
-	HonourChainspec bool       `yaml:"zkevm.honour-chainspec"`
+	HonourChainspec       bool
+	SimultaneousPmtAndSmt bool
 }
 
-type Commitment string
-
-const (
-	CommitmentPMT Commitment = "pmt"
-	CommitmentSMT Commitment = "smt"
-)
-
-func (c Commitment) IsValid() bool {
-	switch Commitment(strings.ToLower(string(c))) {
-	case CommitmentPMT, CommitmentSMT:
-		return true
-	}
-	return false
-}
-
-func ValidCommitments() []Commitment {
-	return []Commitment{CommitmentPMT, CommitmentSMT}
-}
-
-func (c Commitment) IsType1() bool {
-	return c == CommitmentPMT
-}
-
-var DefaultZkConfig = &Zk{
-	Commitment: CommitmentSMT,
-}
+var DefaultZkConfig = &Zk{}
 
 func (c *Zk) ShouldCountersBeUnlimited(l1Recovery bool) bool {
 	return l1Recovery || (c.DisableVirtualCounters && !c.ExecutorStrictMode && !c.HasExecutors())
@@ -179,14 +153,6 @@ func (c *Zk) ShouldImportInitialBatch() bool {
 
 func (c *Zk) IsL1Recovery() bool {
 	return c.L1SyncStartBlock > 0
-}
-
-func (c *Zk) UsingSMT() bool {
-	return c.Commitment == CommitmentSMT
-}
-
-func (c *Zk) UsingPMT() bool {
-	return c.Commitment == CommitmentPMT
 }
 
 type L1InfoTreeOffset struct {

--- a/eth/stagedsync/stages/stages.go
+++ b/eth/stagedsync/stages/stages.go
@@ -29,24 +29,25 @@ import (
 type SyncStage string
 
 var (
-	Snapshots           SyncStage = "Snapshots"   // Snapshots
-	Headers             SyncStage = "Headers"     // Headers are downloaded, their Proof-Of-Work validity and chaining is verified
-	BorHeimdall         SyncStage = "BorHeimdall" // Downloading data from heimdall corresponding to the downloaded headers (validator sets and sync events)
-	BlockHashes         SyncStage = "BlockHashes" // Headers Number are written, fills blockHash => number bucket
-	Bodies              SyncStage = "Bodies"      // Block bodies are downloaded, TxHash and UncleHash are getting verified
-	Senders             SyncStage = "Senders"     // "From" recovered from signatures, bodies re-written
-	DataStream          SyncStage = "DataStream"
-	Execution           SyncStage = "Execution"   // Executing each block w/o buildinf a trie
-	Translation         SyncStage = "Translation" // Translation each marked for translation contract (from EVM to TEVM)
-	VerkleTrie          SyncStage = "VerkleTrie"
-	IntermediateHashes  SyncStage = "IntermediateHashes"  // Generate intermediate hashes, calculate the state root hash
-	HashState           SyncStage = "HashState"           // Apply Keccak256 to all the keys in the state
-	AccountHistoryIndex SyncStage = "AccountHistoryIndex" // Generating history index for accounts
-	StorageHistoryIndex SyncStage = "StorageHistoryIndex" // Generating history index for storage
-	LogIndex            SyncStage = "LogIndex"            // Generating logs index (from receipts)
-	CallTraces          SyncStage = "CallTraces"          // Generating call traces index
-	TxLookup            SyncStage = "TxLookup"            // Generating transactions lookup index
-	Finish              SyncStage = "Finish"              // Nominal stage after all other stages
+	Snapshots                    SyncStage = "Snapshots"   // Snapshots
+	Headers                      SyncStage = "Headers"     // Headers are downloaded, their Proof-Of-Work validity and chaining is verified
+	BorHeimdall                  SyncStage = "BorHeimdall" // Downloading data from heimdall corresponding to the downloaded headers (validator sets and sync events)
+	BlockHashes                  SyncStage = "BlockHashes" // Headers Number are written, fills blockHash => number bucket
+	Bodies                       SyncStage = "Bodies"      // Block bodies are downloaded, TxHash and UncleHash are getting verified
+	Senders                      SyncStage = "Senders"     // "From" recovered from signatures, bodies re-written
+	DataStream                   SyncStage = "DataStream"
+	Execution                    SyncStage = "Execution"   // Executing each block w/o buildinf a trie
+	Translation                  SyncStage = "Translation" // Translation each marked for translation contract (from EVM to TEVM)
+	VerkleTrie                   SyncStage = "VerkleTrie"
+	IntermediateHashes           SyncStage = "IntermediateHashes"           // Generate intermediate hashes, calculate the state root hash
+	IntermediateHashesStandalone SyncStage = "IntermediateHashesStandalone" // Generate intermediate hashes, calculate the state root hash
+	HashState                    SyncStage = "HashState"                    // Apply Keccak256 to all the keys in the state
+	AccountHistoryIndex          SyncStage = "AccountHistoryIndex"          // Generating history index for accounts
+	StorageHistoryIndex          SyncStage = "StorageHistoryIndex"          // Generating history index for storage
+	LogIndex                     SyncStage = "LogIndex"                     // Generating logs index (from receipts)
+	CallTraces                   SyncStage = "CallTraces"                   // Generating call traces index
+	TxLookup                     SyncStage = "TxLookup"                     // Generating transactions lookup index
+	Finish                       SyncStage = "Finish"                       // Nominal stage after all other stages
 
 	MiningCreateBlock SyncStage = "MiningCreateBlock"
 	MiningBorHeimdall SyncStage = "MiningBorHeimdall"

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -173,6 +173,10 @@ var DefaultFlags = []cli.Flag{
 	&utils.PolygonSyncFlag,
 	&utils.EthStatsURLFlag,
 	&utils.OverridePragueFlag,
+	&utils.OverrideNormalcyBlockFlag,
+	&utils.OverrideLondonBlockFlag,
+	&utils.OverrideShanghaiTimeFlag,
+	&utils.OverridePmtEnabledBlockFlag,
 
 	&utils.LightClientDiscoveryAddrFlag,
 	&utils.LightClientDiscoveryPortFlag,
@@ -333,6 +337,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.BadTxPurge,
 	&utils.ZkevmLogExcludeFlags,
 
-	&utils.Commitment,
 	&utils.HonourChainspec,
+	&utils.SimultaneousPmtAndSmt,
 }

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -182,9 +182,11 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		}
 	}
 
-	commitment := ethconfig.Commitment(ctx.String(utils.Commitment.Name))
-	if !commitment.IsValid() {
-		panic(fmt.Sprintf("Invalid commitment: %s. Must be one of: %s", ctx.String(utils.Commitment.Name), ethconfig.ValidCommitments()))
+	var simultaneousPmtAndSmt bool
+	if sequencer.IsSequencer() {
+		simultaneousPmtAndSmt = false
+	} else {
+		simultaneousPmtAndSmt = ctx.Bool(utils.SimultaneousPmtAndSmt.Name)
 	}
 
 	var l1InfoTreeOffset *ethconfig.L1InfoTreeOffset
@@ -331,8 +333,8 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		BadTxPurge:                             ctx.Bool(utils.BadTxPurge.Name),
 		L2InfoTreeUpdatesBatchSize:             ctx.Uint64(utils.L2InfoTreeUpdatesBatchSize.Name),
 		L2InfoTreeUpdatesEnabled:               ctx.Bool(utils.L2InfoTreeUpdatesEnabled.Name),
-		Commitment:                             commitment,
 		HonourChainspec:                        ctx.Bool(utils.HonourChainspec.Name),
+		SimultaneousPmtAndSmt:                  simultaneousPmtAndSmt,
 	}
 
 	utils2.EnableTimer(cfg.DebugTimers)

--- a/turbo/jsonrpc/zkevm_api.go
+++ b/turbo/jsonrpc/zkevm_api.go
@@ -947,9 +947,6 @@ func (api *ZkEvmAPIImpl) populateBlockDetail(
 // }
 
 func (api *ZkEvmAPIImpl) GetWitness(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, mode *WitnessMode, debug *bool) (hexutility.Bytes, error) {
-	if api.config.Zk.UsingPMT() {
-		return nil, errors.New("state trie does not support witness")
-	}
 	checkedMode := WitnessModeNone
 	if mode != nil && *mode != WitnessModeFull && *mode != WitnessModeTrimmed {
 		return nil, errors.New("invalid mode, must be full or trimmed")
@@ -965,9 +962,6 @@ func (api *ZkEvmAPIImpl) GetWitness(ctx context.Context, blockNrOrHash rpc.Block
 }
 
 func (api *ZkEvmAPIImpl) GetBlockRangeWitness(ctx context.Context, startBlockNrOrHash rpc.BlockNumberOrHash, endBlockNrOrHash rpc.BlockNumberOrHash, mode *WitnessMode, debug *bool) (hexutility.Bytes, error) {
-	if api.config.Zk.UsingPMT() {
-		return nil, errors.New("state trie does not support witness")
-	}
 	checkedMode := WitnessModeNone
 	if mode != nil && *mode != WitnessModeFull && *mode != WitnessModeTrimmed {
 		return nil, errors.New("invalid mode, must be full or trimmed")
@@ -1090,6 +1084,15 @@ func (api *ZkEvmAPIImpl) getBlockRangeWitness(ctx context.Context, db kv.RoDB, s
 		return nil, fmt.Errorf("start block number must be less than or equal to end block number, start=%d end=%d", blockNr, endBlockNr)
 	}
 
+	cc, err := api.ethApi.chainConfig(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if cc.IsPmtEnabled(blockNr) {
+		return nil, errors.New("state trie does not support witness")
+	}
+
 	generator, fullWitness, err := api.buildGenerator(ctx, tx, witnessMode)
 	if err != nil {
 		return nil, err
@@ -1109,9 +1112,6 @@ const (
 )
 
 func (api *ZkEvmAPIImpl) GetBatchWitness(ctx context.Context, batchNumber uint64, mode *WitnessMode) (interface{}, error) {
-	if api.config.Zk.UsingPMT() {
-		return nil, errors.New("state trie does not support witness")
-	}
 	tx, err := api.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
@@ -1158,9 +1158,6 @@ func (api *ZkEvmAPIImpl) GetBatchWitness(ctx context.Context, batchNumber uint64
 }
 
 func (api *ZkEvmAPIImpl) GetProverInput(ctx context.Context, batchNumber uint64, mode *WitnessMode, debug *bool) (*legacy_executor_verifier.RpcPayload, error) {
-	if api.config.Zk.UsingPMT() {
-		return nil, errors.New("state trie does not support witness")
-	}
 	if !sequencer.IsSequencer() {
 		return nil, errors.New("method only supported from a sequencer node")
 	}
@@ -1644,6 +1641,11 @@ func (zkapi *ZkEvmAPIImpl) GetProof(ctx context.Context, address common.Address,
 		return nil, err
 	}
 
+	cc, err := api.chainConfig(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
 	if blockNr < latestBlock {
 		if latestBlock-blockNr > uint64(api.MaxGetProofRewindBlockCount) {
 			return nil, fmt.Errorf("requested block is too old, block must be within %d blocks of the head block number (currently %d)", api.MaxGetProofRewindBlockCount, latestBlock)
@@ -1651,7 +1653,7 @@ func (zkapi *ZkEvmAPIImpl) GetProof(ctx context.Context, address common.Address,
 		unwindState := &stagedsync.UnwindState{UnwindPoint: blockNr}
 		stageState := &stagedsync.StageState{BlockNumber: latestBlock}
 
-		interHashStageCfg := zkStages.StageZkInterHashesCfg(nil, !api.DisableStateRootCheck, true, false, api.dirs.Tmp, api._blockReader, nil, api.historyV3(tx), api._agg, nil)
+		interHashStageCfg := zkStages.StageZkInterHashesCfg(nil, !api.DisableStateRootCheck, true, false, api.dirs.Tmp, api._blockReader, nil, api.historyV3(tx), api._agg, zkapi.config.Zk, cc)
 
 		if err = zkStages.UnwindZkIntermediateHashesStage(unwindState, stageState, batch, interHashStageCfg, ctx, true); err != nil {
 			return nil, fmt.Errorf("unwind intermediate hashes: %w", err)

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -2,7 +2,6 @@ package stages
 
 import (
 	"context"
-
 	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloader"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/state"
@@ -80,7 +79,7 @@ func NewDefaultZkStages(ctx context.Context,
 			nil,
 		),
 		stagedsync.StageHashStateCfg(db, dirs, cfg.HistoryV3, agg),
-		zkStages.StageZkInterHashesCfg(db, !cfg.DebugDisableStateRootCheck, true, false, dirs.Tmp, blockReader, controlServer.Hd, cfg.HistoryV3, agg, cfg.Zk),
+		zkStages.StageZkInterHashesCfg(db, !cfg.DebugDisableStateRootCheck, true, false, dirs.Tmp, blockReader, controlServer.Hd, cfg.HistoryV3, agg, cfg.Zk, controlServer.ChainConfig),
 		zkStages.StageWitnessCfg(db, cfg.Zk, controlServer.ChainConfig, engine, blockReader, agg, cfg.HistoryV3, dirs, cfg.WitnessContractInclusion, cfg.WitnessUnwindLimit),
 		stagedsync.StageHistoryCfg(db, cfg.Prune, dirs.Tmp),
 		stagedsync.StageLogIndexCfg(db, cfg.Prune, dirs.Tmp, &cfg.Genesis.Config.DepositContract),
@@ -120,7 +119,7 @@ func NewSequencerZkStages(ctx context.Context,
 	runInTestMode := cfg.ImportMode
 
 	hashStateCfg := stagedsync.StageHashStateCfg(db, dirs, cfg.HistoryV3, agg)
-	zkIntersCfg := zkStages.StageZkInterHashesCfg(db, !cfg.DebugDisableStateRootCheck, true, false, dirs.Tmp, blockReader, controlServer.Hd, cfg.HistoryV3, agg, cfg.Zk)
+	zkIntersCfg := zkStages.StageZkInterHashesCfg(db, !cfg.DebugDisableStateRootCheck, true, false, dirs.Tmp, blockReader, controlServer.Hd, cfg.HistoryV3, agg, cfg.Zk, controlServer.ChainConfig)
 
 	return zkStages.SequencerZkStages(ctx,
 		zkStages.StageL1SyncerCfg(db, l1Syncer, cfg.Zk),

--- a/zk/stages/stage_interhashes.go
+++ b/zk/stages/stage_interhashes.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"fmt"
+	"github.com/erigontech/erigon-lib/chain"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/length"
@@ -50,6 +51,7 @@ type ZkInterHashesCfg struct {
 	historyV3 bool
 	agg       *state.Aggregator
 	zk        *ethconfig.Zk
+	chainCfg  *chain.Config
 }
 
 func StageZkInterHashesCfg(
@@ -61,6 +63,7 @@ func StageZkInterHashesCfg(
 	historyV3 bool,
 	agg *state.Aggregator,
 	zk *ethconfig.Zk,
+	chainCfg *chain.Config,
 ) ZkInterHashesCfg {
 	return ZkInterHashesCfg{
 		db:                db,
@@ -74,6 +77,7 @@ func StageZkInterHashesCfg(
 		historyV3: historyV3,
 		agg:       agg,
 		zk:        zk,
+		chainCfg:  chainCfg,
 	}
 }
 

--- a/zk/stages/stage_sequence_execute_blocks.go
+++ b/zk/stages/stage_sequence_execute_blocks.go
@@ -194,7 +194,9 @@ func finaliseBlock(
 
 	// this is actually the interhashes stage
 	var newRoot common.Hash
-	if batchContext.cfg.zk.UsingPMT() {
+	var commitment string
+	if batchContext.cfg.chainConfig.IsPmtEnabled(newHeader.Number.Uint64()) {
+		commitment = "PMT"
 		logger := log.New()
 		if err = stagedsync.HashStateFromTo(batchContext.s.LogPrefix(), batchContext.sdb.tx, batchContext.cfg.hashStateCfg, newHeader.Number.Uint64()-1, newHeader.Number.Uint64(), batchContext.ctx, logger); err != nil {
 			return nil, err
@@ -202,6 +204,7 @@ func finaliseBlock(
 
 		newRoot, err = stagedsync.IncrementIntermediateHashes(batchContext.s.LogPrefix(), batchContext.s, batchContext.sdb.tx, thisBlockNumber, trieConfigSequencer(batchContext.cfg.intersCfg), common.Hash{}, quit, logger)
 	} else {
+		commitment = "SMT"
 		newRoot, err = zkIncrementIntermediateHashes(batchContext.ctx, batchContext.s.LogPrefix(), batchContext.s, batchContext.sdb.tx, batchContext.sdb.eridb, batchContext.sdb.smt, newHeader.Number.Uint64()-1, newHeader.Number.Uint64())
 	}
 	if err != nil {
@@ -209,7 +212,7 @@ func finaliseBlock(
 		return nil, err
 	}
 
-	log.Info(fmt.Sprintf("[%s] IncrementIntermediateHashes finished newRoot: %s", batchContext.s.LogPrefix(), newRoot.String()), "from", batchContext.s.BlockNumber, "to", thisBlockNumber)
+	log.Info(fmt.Sprintf("[%s] IncrementIntermediateHashes for %s finished newRoot: %s", batchContext.s.LogPrefix(), commitment, newRoot.String()), "from", batchContext.s.BlockNumber, "to", thisBlockNumber)
 
 	if err = batchContext.sdb.eridb.CommitBatch(); err != nil {
 		return nil, err

--- a/zk/stages/stage_witness.go
+++ b/zk/stages/stage_witness.go
@@ -75,7 +75,7 @@ func SpawnStageWitness(
 		log.Info(fmt.Sprintf("[%s] skipping -- sequencer", logPrefix))
 		return nil
 	}
-	if cfg.zkCfg.UsingPMT() {
+	if cfg.chainConfig.IsPmtEnabled(s.BlockNumber) {
 		log.Info(fmt.Sprintf("[%s] skipping -- using PMT", logPrefix))
 		return nil
 	}

--- a/zk/stages/stages.go
+++ b/zk/stages/stages.go
@@ -115,7 +115,7 @@ func SequencerZkStages(
 				return SpawnSequencerInterhashesStage(s, u, txc.Tx, ctx, zkInterHashesCfg, true)
 			},
 			Unwind: func(firstCycle bool, u *stages.UnwindState, s *stages.StageState, txc wrap.TxContainer, logger log.Logger) error {
-				if zkInterHashesCfg.zk.UsingPMT() {
+				if zkInterHashesCfg.chainCfg.IsPmtEnabled(s.BlockNumber) {
 					return stages.UnwindIntermediateHashesStage(u, s, txc.Tx, trieConfigSequencer(zkInterHashesCfg), ctx, logger)
 				}
 				return UnwindSequencerInterhashsStage(u, s, txc.Tx, ctx, zkInterHashesCfg)
@@ -130,7 +130,7 @@ func SequencerZkStages(
 			Disabled:    false,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *stages.StageState, u stages.Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				// this is only used in normalcy and the forward is used in execution stage before inters.
-				if !zkInterHashesCfg.zk.UsingPMT() {
+				if !zkInterHashesCfg.chainCfg.IsPmtEnabled(s.BlockNumber) {
 					return stages.SpawnHashStateStage(s, txc.Tx, hashStateCfg, ctx, logger)
 				}
 				return nil
@@ -373,11 +373,29 @@ func DefaultZkStages(
 			},
 		},
 		{
+			ID:          stages2.IntermediateHashesStandalone,
+			Description: "Standalone intermediate hashes for the PMT",
+			Disabled:    !zkInterHashesCfg.zk.SimultaneousPmtAndSmt,
+			Forward: func(firstCycle bool, badBlockUnwind bool, s *stages.StageState, u stages.Unwinder, txc wrap.TxContainer, logger log.Logger) error {
+				// This should be false because we are using the SMT but building the PMT as a standalone.
+				zkInterHashesCfg.checkRoot = false
+				_, err := stages.SpawnIntermediateHashesStage(s, u, txc.Tx, trieConfigRPC(zkInterHashesCfg), ctx, logger)
+				return err
+			},
+			Unwind: func(firstCycle bool, u *stages.UnwindState, s *stages.StageState, txc wrap.TxContainer, logger log.Logger) error {
+				zkInterHashesCfg.checkRoot = false
+				return stages.UnwindIntermediateHashesStage(u, s, txc.Tx, trieConfigRPC(zkInterHashesCfg), ctx, logger)
+			},
+			Prune: func(firstCycle bool, p *stages.PruneState, tx kv.RwTx, logger log.Logger) error {
+				return nil
+			},
+		},
+		{
 			ID:          stages2.IntermediateHashes,
 			Description: "Generate intermediate hashes and computing state root",
 			Disabled:    false,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *stages.StageState, u stages.Unwinder, txc wrap.TxContainer, logger log.Logger) error {
-				if zkInterHashesCfg.zk.UsingPMT() {
+				if zkInterHashesCfg.chainCfg.IsPmtEnabled(s.BlockNumber) {
 					_, err := stages.SpawnIntermediateHashesStage(s, u, txc.Tx, trieConfigRPC(zkInterHashesCfg), ctx, logger)
 					return err
 				}
@@ -386,7 +404,7 @@ func DefaultZkStages(
 				return err
 			},
 			Unwind: func(firstCycle bool, u *stages.UnwindState, s *stages.StageState, txc wrap.TxContainer, logger log.Logger) error {
-				if zkInterHashesCfg.zk.UsingPMT() {
+				if zkInterHashesCfg.chainCfg.IsPmtEnabled(s.BlockNumber) {
 					return stages.UnwindIntermediateHashesStage(u, s, txc.Tx, trieConfigRPC(zkInterHashesCfg), ctx, logger)
 				}
 

--- a/zk/tests/unwinds/config-type1-normalcy-pmt-pectra/dynamic-integration-chainspec.json
+++ b/zk/tests/unwinds/config-type1-normalcy-pmt-pectra/dynamic-integration-chainspec.json
@@ -19,7 +19,7 @@
   "shanghaiTime": 0,
   "cancunTime": 0,
   "normalcyBlock": 0,
+  "pmtEnabledBlock": 0,
   "pragueTime": 0,
-  "type1": true,
   "ethash": {}
 }

--- a/zk/tests/unwinds/config-type1-normalcy-pmt-pectra/dynamic-integration8.yaml
+++ b/zk/tests/unwinds/config-type1-normalcy-pmt-pectra/dynamic-integration8.yaml
@@ -36,4 +36,3 @@ zkevm.default-gas-price: 1000000000
 zkevm.l1-cache-enabled: false
 
 zkevm.honour-chainspec: true
-zkevm.initial-commitment: pmt


### PR DESCRIPTION
### Description

Enable PMT via block in the chainspec. This allows for swapping over from SMT to PMT. Also enable simultaneous building of PMT and SMT.

### Chainspec

`"pmtEnabledBlock": 0`

### Flags

`zkevm.simultaneous-pmt-and-smt: true`