### PR TITLE
fix(get-batch): fix for panic on getBatchByNumber on nil batch blocks

### DIFF
--- a/turbo/jsonrpc/zkevm_api.go
+++ b/turbo/jsonrpc/zkevm_api.go
@@ -387,6 +387,10 @@ func (api *ZkEvmAPIImpl) getOrCalcBatchData(ctx context.Context, tx kv.Tx, dbRea
 		return nil, err
 	}
 
+	if batchBlocks == nil {
+		return []byte{}, nil
+	}
+
 	// batch l2 data - must build on the fly
 	forkId, err := dbReader.GetForkId(batchNo)
 	if err != nil {


### PR DESCRIPTION
This is a fix for a panic on getBatchByNumber if the batch has no blocks. Currently we panic on Bali because of this on batch 37.