### PR TITLE
Optimize utils.HashContractBytecodeBigInt

### DIFF
--- a/smtv2/smt_v2_utils_test.go
+++ b/smtv2/smt_v2_utils_test.go
@@ -1,7 +1,6 @@
 package smtv2
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon/smt/pkg/utils"
-	"github.com/status-im/keycard-go/hexutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -141,36 +139,6 @@ func Test_BytesToSmtValue8_Comparison(t *testing.T) {
 			if fromBig[i] != fromBytes[i] {
 				t.Errorf("BytesToSmtValue8(%v) = %v; expected %v", test.bytes, fromBytes, fromBig)
 			}
-		}
-	}
-}
-
-func Test_InterimBytecodeHash(t *testing.T) {
-	tests := []struct {
-		code []byte
-	}{
-		{[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}},
-		{common.Hex2Bytes("0x1233459845676739438575623497394545968734592354837456948576498567948576")},
-	}
-
-	for _, test := range tests {
-		asHex := hexutils.BytesToHex(test.code)
-		oldInterim := utils.CreateInterimBytecodeHash(asHex)
-		newInterim := InterimBytecodeHash(asHex)
-
-		for i := 0; i < 4; i++ {
-			if newInterim[i] != oldInterim[i] {
-				t.Errorf("InterimBytecodeHash(%v) = %v; expected %v", test.code, newInterim, oldInterim)
-			}
-		}
-
-		asBigInt := utils.ArrayToScalar(oldInterim[:])
-		oldBytes := asBigInt.Bytes()
-
-		newBytes := HashToBytes(newInterim)
-
-		if !bytes.Equal(oldBytes, newBytes) {
-			t.Errorf("HashToBytes(%v) = %v; expected %v", newInterim, newBytes, oldBytes)
 		}
 	}
 }


### PR DESCRIPTION
<img width="1725" alt="Screenshot 2025-07-08 at 13 38 17" src="https://github.com/user-attachments/assets/edcc93a1-f439-47f8-ace0-b2bb407428ac" />
This function takes up 27% of CPU cycles in my load testing
Benchmark results:

```
BenchmarkInterimBytecodeHash/SMTv2            69343             17304 ns/op           26177 B/op        396 allocs/op
BenchmarkHashContractBytecode/Old-12         	   42402	     28079 ns/op	   15072 B/op	     563 allocs/op
BenchmarkHashContractBytecode/OKX-12         	  123895	      9773 ns/op	     776 B/op	       9 allocs/op
BenchmarkHashContractBytecode/New-12  	  112896	      8888 ns/op	    1290 B/op	      34 allocs/op
```

Keeping the New version
