### PR TITLE
Fix/l2 rpc infotree

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -930,10 +930,9 @@ var (
 		Usage: "Size of the batch of L2 info tree updates to retrieve at a time. L2 info tree updates must be enabled to use this.",
 		Value: 500,
 	}
-	L2InfoTreeUpdatesEnabled = cli.BoolFlag{
-		Name:  "zkevm.l2-info-tree-updates-enabled",
-		Usage: "When enabled a RPC node can use the L2 to build the InfoTree.",
-		Value: false,
+	L2InfoTreeUpdatesURL = cli.StringFlag{
+		Name:  "zkevm.l2-info-tree-updates-url",
+		Usage: "L2 RPC node url to initialize the info tree.",
 	}
 	ZkevmLogExcludeFlags = cli.StringSliceFlag{
 		Name:  "zkevm.log-exclude-flags",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -926,12 +926,12 @@ var (
 		Usage: "File path for the zk config containing allocs, chainspec, and other zk specific configurations.",
 	}
 	L2InfoTreeUpdatesBatchSize = cli.Uint64Flag{
-		Name:  "zkevm.l2-info-tree-updates-batch-size",
-		Usage: "Size of the batch of L2 info tree updates to retrieve at a time. L2 info tree updates must be enabled to use this.",
+		Name:  "zkevm.l1-info-tree-updates-batch-size",
+		Usage: "Size of the batch of L1 info tree updates to retrieve at a time from L2 RPC. l1-info-tree-updates-l2-url must be set.",
 		Value: 500,
 	}
 	L2InfoTreeUpdatesURL = cli.StringFlag{
-		Name:  "zkevm.l2-info-tree-updates-url",
+		Name:  "zkevm.l1-info-tree-updates-l2-url",
 		Usage: "L2 RPC node url to initialize the info tree.",
 	}
 	ZkevmLogExcludeFlags = cli.StringSliceFlag{

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1108,6 +1108,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			cfg.L1BlockRange,
 			cfg.L1QueryDelay,
 			cfg.L1HighestBlockType,
+			cfg.Zk.L1FirstBlock,
 		)
 
 		backend.l1Syncer = syncer.NewL1Syncer(
@@ -1118,6 +1119,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			cfg.L1BlockRange,
 			cfg.L1QueryDelay,
 			cfg.L1HighestBlockType,
+			cfg.Zk.L1FirstBlock,
 		)
 
 		log.Info("Rollup ID", "rollupId", cfg.L1RollupId)
@@ -1133,6 +1135,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			cfg.L1BlockRange,
 			cfg.L1QueryDelay,
 			cfg.L1HighestBlockType,
+			cfg.Zk.L1FirstBlock,
 		)
 
 		l1InfoTreeUpdater := l1infotree.NewUpdater(cfg.Zk, l1InfoTreeSyncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, cfg.Zk))
@@ -1197,6 +1200,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 				cfg.L1BlockRange,
 				cfg.L1QueryDelay,
 				cfg.L1HighestBlockType,
+				cfg.L1FirstBlock,
 			)
 
 			decodedTxCache := expirable.NewLRU[libcommon.Hash, *types.Transaction](cfg.SequencerDecodedTxCacheSize, nil, cfg.SequencerDecodedTxCacheTTL)

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -127,7 +127,7 @@ type Zk struct {
 	BadTxStoreValue                uint64
 	BadTxPurge                     bool
 	L2InfoTreeUpdatesBatchSize     uint64
-	L2InfoTreeUpdatesEnabled       bool
+	L2InfoTreeUpdatesURL           string
 
 	Hardfork        Hardfork
 	Commitment      Commitment `yaml:"zkevm.initial-commitment"`

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -271,7 +271,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.ShadowSequencer,
 	&utils.ZKGenesisConfigPathFlag,
 	&utils.L2InfoTreeUpdatesBatchSize,
-	&utils.L2InfoTreeUpdatesEnabled,
+	&utils.L2InfoTreeUpdatesURL,
 
 	&utils.SilkwormExecutionFlag,
 	&utils.SilkwormRpcDaemonFlag,

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -330,7 +330,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		BadTxStoreValue:                        ctx.Uint64(utils.BadTxStoreValue.Name),
 		BadTxPurge:                             ctx.Bool(utils.BadTxPurge.Name),
 		L2InfoTreeUpdatesBatchSize:             ctx.Uint64(utils.L2InfoTreeUpdatesBatchSize.Name),
-		L2InfoTreeUpdatesEnabled:               ctx.Bool(utils.L2InfoTreeUpdatesEnabled.Name),
+		L2InfoTreeUpdatesURL:                   ctx.String(utils.L2InfoTreeUpdatesURL.Name),
 		Commitment:                             commitment,
 		HonourChainspec:                        ctx.Bool(utils.HonourChainspec.Name),
 		InjectGers:                             ctx.Bool(utils.InjectGers.Name),

--- a/turbo/jsonrpc/zkevm_api_test.go
+++ b/turbo/jsonrpc/zkevm_api_test.go
@@ -389,6 +389,7 @@ func TestGetBatchByNumber(t *testing.T) {
 		10,
 		0,
 		"latest",
+		0,
 	)
 	cfg := &ethconfig.Defaults
 	cfg.Zk.L1RollupId = 1
@@ -668,6 +669,7 @@ func TestGetExitRootsByGER(t *testing.T) {
 		10,
 		0,
 		"latest",
+		0,
 	)
 	zkEvmImpl := NewZkEvmAPI(ethImpl, db, 100_000, &ethconfig.Defaults, l1Syncer, "", nil)
 	tx, err := db.BeginRw(ctx)
@@ -743,6 +745,7 @@ func TestLatestGlobalExitRoot(t *testing.T) {
 		10,
 		0,
 		"latest",
+		0,
 	)
 	zkEvmImpl := NewZkEvmAPI(ethImpl, db, 100_000, &ethconfig.Defaults, l1Syncer, "", nil)
 	tx, err := db.BeginRw(ctx)

--- a/zk/stages/stage_l1_info_tree.go
+++ b/zk/stages/stage_l1_info_tree.go
@@ -54,7 +54,7 @@ func SpawnL1InfoTreeStage(
 		return err
 	}
 	// L2InfoTreeUpdatesEnabled must be enabled, this method uses an updated rpc method that uses to and from.
-	if progress == 0 && !sequencer.IsSequencer() && cfg.zkCfg.L2InfoTreeUpdatesEnabled {
+	if progress == 0 && !sequencer.IsSequencer() && cfg.zkCfg.L2InfoTreeUpdatesURL != "" {
 		select {
 		default:
 			// If we are a rpc node, and we are starting from the beginning, we need to check for updates from the L2

--- a/zk/stages/stage_l1_info_tree.go
+++ b/zk/stages/stage_l1_info_tree.go
@@ -58,7 +58,7 @@ func SpawnL1InfoTreeStage(
 		select {
 		default:
 			// If we are a rpc node, and we are starting from the beginning, we need to check for updates from the L2
-			infoTrees, err := cfg.updater.CheckL2RpcForInfoTreeUpdates(logPrefix, tx)
+			infoTrees, err := cfg.updater.CheckL2RpcForInfoTreeUpdates(ctx, logPrefix, tx)
 			if err != nil {
 				log.Warn(fmt.Sprintf("[%s] L2 Info Tree sync failed, getting Info Tree from L1", logPrefix), "err", err)
 				break

--- a/zk/stages/stage_l1_info_tree_test.go
+++ b/zk/stages/stage_l1_info_tree_test.go
@@ -85,7 +85,7 @@ func TestSpawnL1InfoTreeStage(t *testing.T) {
 	filteredLogs := []types.Log{l1InfoTreeLog}
 	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
 
-	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest")
+	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest", 0)
 	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{
 		L2RpcUrl: "http://127.0.0.1:8545",
 	}))

--- a/zk/stages/stage_l1_sequencer_sync_test.go
+++ b/zk/stages/stage_l1_sequencer_sync_test.go
@@ -260,7 +260,7 @@ func TestSpawnL1SequencerSyncStage(t *testing.T) {
 
 	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
 
-	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest")
+	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest", 0)
 	// 	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer)
 	zkCfg := &ethconfig.Zk{
 		L1RollupId:                  uint64(99999),

--- a/zk/stages/stage_l1_syncer_test.go
+++ b/zk/stages/stage_l1_syncer_test.go
@@ -296,7 +296,7 @@ func TestSpawnStageL1Syncer(t *testing.T) {
 
 	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
 
-	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest")
+	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest", 0)
 
 	zkCfg := &ethconfig.Zk{
 		L1RollupId:   rollupID,

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -138,7 +138,7 @@ func TestSpawnSequencingStage(t *testing.T) {
 
 	ethermanMock.EXPECT().BlockByNumber(gomock.Any(), nil).Return(latestL1Block, nil).AnyTimes()
 
-	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{ethermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest")
+	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{ethermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest", 0)
 	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{}))
 
 	cacheMock := cMocks.NewMockCache(mockCtrl)


### PR DESCRIPTION
Fix an issue with L1 root log search range too large which caused RPC provider timeout.
`L2InfoTreeUpdatesEnabled` flag replaced with `L2InfoTreeUpdatesURL`
Implemented proper error handling of InfoTreeL2RpcSyncer (being stuck forever on error)
Fixed contexts in syncer and updater for better shutdown
Fixed L2Syncer interface to avoid misuse when channel is not initialised