### PR TITLE
Feat/speedup l1infotree sync

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1136,6 +1136,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			cfg.L1HighestBlockType,
 			cfg.Zk.L1FirstBlock,
 		)
+		l1InfoTreeSyncer.SetFetchHeaders(true)
 
 		l1InfoTreeUpdater := l1infotree.NewUpdater(ctx, cfg.Zk, l1InfoTreeSyncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, cfg.Zk))
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1137,7 +1137,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			cfg.Zk.L1FirstBlock,
 		)
 
-		l1InfoTreeUpdater := l1infotree.NewUpdater(cfg.Zk, l1InfoTreeSyncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, cfg.Zk))
+		l1InfoTreeUpdater := l1infotree.NewUpdater(ctx, cfg.Zk, l1InfoTreeSyncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, cfg.Zk))
 
 		var dataStreamServer server.DataStreamServer
 		if backend.streamServer != nil {

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/status-im/keycard-go v0.3.2
 	github.com/stretchr/testify v1.10.0
-	github.com/sugawarayuuta/sonnet v0.0.0-20231004000330-239c7b6e4ce8
 	github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e
 	github.com/tidwall/btree v1.6.0
 	github.com/ugorji/go/codec v1.1.13

--- a/go.mod
+++ b/go.mod
@@ -132,6 +132,7 @@ require (
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pion/transport/v3 v3.0.7 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -960,6 +960,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -974,10 +975,10 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/supranational/blst v0.3.13 h1:AYeSxdOMacwu7FBmpfloBz5pbFXDmJL33RuwnKtmTjk=
-github.com/supranational/blst v0.3.13/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/sugawarayuuta/sonnet v0.0.0-20231004000330-239c7b6e4ce8 h1:u+kxnRXxx+0O5SiefP3oTt4jeeIx+rYf1jkdW2qd2Ss=
 github.com/sugawarayuuta/sonnet v0.0.0-20231004000330-239c7b6e4ce8/go.mod h1:6M53rd6DvbzoLbFnL3bjCsDSkCYh4i2yqW04hxr1/5o=
+github.com/supranational/blst v0.3.13 h1:AYeSxdOMacwu7FBmpfloBz5pbFXDmJL33RuwnKtmTjk=
+github.com/supranational/blst v0.3.13/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/supranational/blst v0.3.14 h1:xNMoHRJOTwMn63ip6qoWJ2Ymgvj7E2b9jY2FAwY+qRo=
 github.com/supranational/blst v0.3.14/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=

--- a/go.sum
+++ b/go.sum
@@ -975,10 +975,6 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/sugawarayuuta/sonnet v0.0.0-20231004000330-239c7b6e4ce8 h1:u+kxnRXxx+0O5SiefP3oTt4jeeIx+rYf1jkdW2qd2Ss=
-github.com/sugawarayuuta/sonnet v0.0.0-20231004000330-239c7b6e4ce8/go.mod h1:6M53rd6DvbzoLbFnL3bjCsDSkCYh4i2yqW04hxr1/5o=
-github.com/supranational/blst v0.3.13 h1:AYeSxdOMacwu7FBmpfloBz5pbFXDmJL33RuwnKtmTjk=
-github.com/supranational/blst v0.3.13/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/supranational/blst v0.3.14 h1:xNMoHRJOTwMn63ip6qoWJ2Ymgvj7E2b9jY2FAwY+qRo=
 github.com/supranational/blst v0.3.14/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=

--- a/zk/l1infotree/info_tree_l2_rpc_syncer.go
+++ b/zk/l1infotree/info_tree_l2_rpc_syncer.go
@@ -59,12 +59,16 @@ func (s *InfoTreeL2RpcSyncer) RunSyncInfoTree() <-chan []zkTypes.L1InfoTreeUpdat
 	batchSize := s.zkCfg.L2InfoTreeUpdatesBatchSize
 
 	go func() {
-		defer close(s.infoTreeChan)
+		defer func {
+			close(s.infoTreeChan)
+			s.isSyncStarted.Store(true)
+		}()
 
 		retry := 0
 		for {
 			select {
 			case <-s.ctx.Done():
+				s.isSyncFinished.Store(true)
 				return
 			default:
 				query := exitRootQuery{

--- a/zk/l1infotree/info_tree_l2_rpc_syncer.go
+++ b/zk/l1infotree/info_tree_l2_rpc_syncer.go
@@ -59,16 +59,15 @@ func (s *InfoTreeL2RpcSyncer) RunSyncInfoTree() <-chan []zkTypes.L1InfoTreeUpdat
 	batchSize := s.zkCfg.L2InfoTreeUpdatesBatchSize
 
 	go func() {
-		defer func {
+		defer func() {
 			close(s.infoTreeChan)
-			s.isSyncStarted.Store(true)
+			s.isSyncStarted.Store(false)
 		}()
 
 		retry := 0
 		for {
 			select {
 			case <-s.ctx.Done():
-				s.isSyncFinished.Store(true)
 				return
 			default:
 				query := exitRootQuery{

--- a/zk/l1infotree/updater.go
+++ b/zk/l1infotree/updater.go
@@ -317,7 +317,6 @@ func (u *Updater) CheckForInfoTreeUpdates(logPrefix string, tx kv.RwTx) (process
 				}
 				receivedAnyLogs = true
 				lastActivity = time.Now()
-				log.Info(fmt.Sprintf("[%s] Received %d logs", logPrefix, len(logs)))
 				allLogs = append(allLogs, logs...)
 				for _, lg := range logs {
 					workerPool.AddTask(NewL1InfoTask(lg, u.syncer))
@@ -428,7 +427,6 @@ drain:
 
 	var tree *L1InfoTree
 	if len(allLogs) > 0 {
-		log.Info(fmt.Sprintf("[%s] Checking for L1 info tree updates, logs count: %v", logPrefix, len(allLogs)), "len(indexUpdateMap)", len(indexUpdateMap))
 		tree, err = InitialiseL1InfoTree(hermezDb)
 		if err != nil {
 			return 0, fmt.Errorf("InitialiseL1InfoTree: %w", err)
@@ -505,10 +503,6 @@ drain:
 		return 0, fmt.Errorf("SaveStageProgress: %w", err)
 	}
 
-	if tree != nil {
-		log.Info(fmt.Sprintf("[%s] L1 Info Tree updates processed", logPrefix), "count", processed, "latestIndex", u.latestUpdate.Index, "latestRoot", tree.currentRoot)
-	}
-
 	return processed, nil
 }
 
@@ -548,7 +542,8 @@ func (u *Updater) HandleL1InfoTreeUpdate(hermezDb *hermez_db.HermezDb, tree *L1I
 }
 
 func (u *Updater) RollbackL1InfoTree(hermezDb *hermez_db.HermezDb, tx kv.RwTx) error {
-	log.Info("Rolling back L1 Info Tree", "progress", u.progress)
+	log.Debug("Rolling back L1 Info Tree", "progress", u.progress)
+
 	// unexpected confirmedIndex means we missed a leaf somewhere so we need to rollback our data and start re-syncing
 	confirmedIndex, confirmedL1BlockNumber, err := hermezDb.GetConfirmedL1InfoTreeUpdate()
 	if err != nil {
@@ -604,7 +599,7 @@ func (u *Updater) RollbackL1InfoTree(hermezDb *hermez_db.HermezDb, tx kv.RwTx) e
 		return fmt.Errorf("SaveStageProgress: %w", err)
 	}
 
-	log.Info("L1 Info Tree rollback complete", "progress", u.progress, "confirmedIndex", confirmedIndex, "confirmedL1BlockNumber", confirmedL1BlockNumber)
+	log.Debug("L1 Info Tree rollback complete", "progress", u.progress, "confirmedIndex", confirmedIndex, "confirmedL1BlockNumber", confirmedL1BlockNumber)
 
 	return nil
 }

--- a/zk/l1infotree/updater_test.go
+++ b/zk/l1infotree/updater_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/kv/memdb"
-	"github.com/erigontech/erigon-lib/log/v3"
 
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/eth/ethconfig"
@@ -275,11 +274,6 @@ func TestInitialiseL1InfoTree(t *testing.T) {
 }
 
 func TestCheckForInfoTreeUpdates(t *testing.T) {
-	// Force the logger to print everything
-	log.Root().SetHandler(
-		log.LvlFilterHandler(log.LvlDebug, log.StderrHandler),
-	)
-
 	testCases := []struct {
 		name              string
 		logs              []types.Log

--- a/zk/l1infotree/updater_test.go
+++ b/zk/l1infotree/updater_test.go
@@ -437,10 +437,8 @@ func TestCheckForInfoTreeUpdates(t *testing.T) {
 
 			time.AfterFunc(1*time.Millisecond, func() {
 				// Send logs to channel
-				// if len(tc.logs) > 0 {
 				logsChan <- tc.logs
 				close(logsChan)
-				// }
 			})
 
 			processed, err := updater.CheckForInfoTreeUpdates("test", tx)

--- a/zk/l1infotree/updater_test.go
+++ b/zk/l1infotree/updater_test.go
@@ -1,0 +1,479 @@
+package l1infotree
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/kv/memdb"
+
+	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/eth/ethconfig"
+	"github.com/erigontech/erigon/zk/contracts"
+	"github.com/erigontech/erigon/zk/hermez_db"
+	zkTypes "github.com/erigontech/erigon/zk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Mock implementations
+type MockSyncer struct {
+	mock.Mock
+}
+
+func (m *MockSyncer) IsSyncStarted() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockSyncer) RunQueryBlocks(lastCheckedBlock uint64) {
+	m.Called(lastCheckedBlock)
+}
+
+func (m *MockSyncer) GetLogsChan() chan []types.Log {
+	args := m.Called()
+	return args.Get(0).(chan []types.Log)
+}
+
+func (m *MockSyncer) GetProgressMessageChan() chan string {
+	args := m.Called()
+	return args.Get(0).(chan string)
+}
+
+func (m *MockSyncer) IsDownloading() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockSyncer) GetHeader(blockNumber uint64) (*types.Header, error) {
+	args := m.Called(blockNumber)
+	return args.Get(0).(*types.Header), args.Error(1)
+}
+
+func (m *MockSyncer) L1QueryHeaders(logs []types.Log) (map[uint64]*types.Header, error) {
+	args := m.Called(logs)
+	return args.Get(0).(map[uint64]*types.Header), args.Error(1)
+}
+
+func (m *MockSyncer) StopQueryBlocks() {
+	m.Called()
+}
+
+func (m *MockSyncer) ConsumeQueryBlocks() {
+	m.Called()
+}
+
+func (m *MockSyncer) WaitQueryBlocksToFinish() {
+	m.Called()
+}
+
+func (m *MockSyncer) QueryForRootLog(to uint64) (*types.Log, error) {
+	args := m.Called(to)
+	return args.Get(0).(*types.Log), args.Error(1)
+}
+
+func (m *MockSyncer) ClearHeaderCache() {
+	m.Called()
+}
+
+func (m *MockSyncer) GetDoneChan() <-chan struct{} {
+	args := m.Called()
+	return args.Get(0).(<-chan struct{})
+}
+
+type MockL2Syncer struct {
+	mock.Mock
+}
+
+func (m *MockL2Syncer) IsSyncStarted() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockL2Syncer) IsSyncFinished() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockL2Syncer) GetInfoTreeChan() chan []zkTypes.L1InfoTreeUpdate {
+	args := m.Called()
+	return args.Get(0).(chan []zkTypes.L1InfoTreeUpdate)
+}
+
+func (m *MockL2Syncer) RunSyncInfoTree() {
+	m.Called()
+}
+
+func (m *MockL2Syncer) ConsumeInfoTree() {
+	m.Called()
+}
+
+func TestUpdater_WarmUp(t *testing.T) {
+	db := memdb.NewTestDB(t)
+	defer db.Close()
+
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	mockSyncer := &MockSyncer{}
+	cfg := &ethconfig.Zk{L1FirstBlock: 1000}
+	updater := NewUpdater(context.Background(), cfg, mockSyncer, nil)
+
+	// Set up mock expectations
+	mockSyncer.On("IsSyncStarted").Return(false)
+	mockSyncer.On("RunQueryBlocks", uint64(999)).Once()
+
+	err = updater.WarmUp(tx)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(999), updater.progress)
+	mockSyncer.AssertExpectations(t)
+}
+
+func TestL1InfoWorkerPool_NewAndStart(t *testing.T) {
+	ctx := context.Background()
+	mockSyncer := &MockSyncer{}
+	numWorkers := 3
+
+	pool := NewL1InfoWorkerPool(ctx, numWorkers, mockSyncer)
+
+	assert.NotNil(t, pool)
+	assert.Len(t, pool.workers, numWorkers)
+	assert.NotNil(t, pool.taskChan)
+	assert.NotNil(t, pool.taskResChan)
+
+	pool.Start()
+	time.Sleep(10 * time.Millisecond) // Allow workers to start
+
+	pool.Stop()
+	pool.Wait()
+}
+
+func TestL1InfoTask_Run(t *testing.T) {
+	mockSyncer := &MockSyncer{}
+	log := types.Log{
+		BlockNumber: 100,
+		Topics:      []common.Hash{common.Hash{}, common.Hash{}, common.Hash{}},
+	}
+	header := &types.Header{
+		Number: big.NewInt(100),
+		Time:   uint64(time.Now().Unix()),
+	}
+
+	task := NewL1InfoTask(log, mockSyncer)
+
+	// Test successful case
+	mockSyncer.On("GetHeader", uint64(100)).Return(header, nil).Once()
+
+	result := task.Run()
+	assert.NoError(t, result.err)
+	assert.NotNil(t, result.l1InfoTreeUpdate)
+
+	// Test header not found
+	mockSyncer.On("GetHeader", uint64(100)).Return((*types.Header)(nil), assert.AnError).Once()
+
+	result = task.Run()
+	assert.Error(t, result.err)
+	assert.Nil(t, result.l1InfoTreeUpdate)
+
+	mockSyncer.AssertExpectations(t)
+}
+
+func TestL1InfoTask_Run_WrongTopicsCount(t *testing.T) {
+	mockSyncer := &MockSyncer{}
+	log := types.Log{
+		BlockNumber: 100,
+		Topics:      []common.Hash{common.Hash{}}, // Only 1 topic instead of 3
+	}
+	header := &types.Header{
+		Number: big.NewInt(100),
+		Time:   uint64(time.Now().Unix()),
+	}
+
+	task := NewL1InfoTask(log, mockSyncer)
+
+	mockSyncer.On("GetHeader", uint64(100)).Return(header, nil).Once()
+
+	result := task.Run()
+	assert.NoError(t, result.err)
+	assert.Nil(t, result.l1InfoTreeUpdate) // Should be nil for wrong log
+}
+
+func TestCreateL1InfoTreeUpdate(t *testing.T) {
+	timestamp := uint64(time.Now().Unix())
+	parentHash := common.HexToHash("0x123")
+
+	log := types.Log{
+		BlockNumber: 100,
+		Topics: []common.Hash{
+			contracts.UpdateL1InfoTreeTopic,
+			common.HexToHash("0x456"), // mainnetExitRoot
+			common.HexToHash("0x789"), // rollupExitRoot
+		},
+	}
+
+	header := &types.Header{
+		Number:     big.NewInt(100),
+		Time:       timestamp,
+		ParentHash: parentHash,
+	}
+
+	update, err := createL1InfoTreeUpdate(log, header)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(100), update.BlockNumber)
+	assert.Equal(t, timestamp, update.Timestamp)
+	assert.Equal(t, parentHash, update.ParentHash)
+	assert.Equal(t, log.Topics[1], update.MainnetExitRoot)
+	assert.Equal(t, log.Topics[2], update.RollupExitRoot)
+}
+
+func TestCreateL1InfoTreeUpdate_InvalidTopics(t *testing.T) {
+	log := types.Log{
+		BlockNumber: 100,
+		Topics:      []common.Hash{common.Hash{}}, // Wrong number of topics
+	}
+
+	header := &types.Header{Number: big.NewInt(100)}
+
+	_, err := createL1InfoTreeUpdate(log, header)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "did not have 3 topics")
+}
+
+func TestCreateL1InfoTreeUpdate_BlockNumberMismatch(t *testing.T) {
+	log := types.Log{
+		BlockNumber: 100,
+		Topics:      []common.Hash{common.Hash{}, common.Hash{}, common.Hash{}},
+	}
+
+	header := &types.Header{Number: big.NewInt(200)}
+
+	_, err := createL1InfoTreeUpdate(log, header)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "did not match the block number")
+}
+
+func TestInitialiseL1InfoTree(t *testing.T) {
+	db := memdb.NewTestDB(t)
+	defer db.Close()
+
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	hermezDb := hermez_db.NewHermezDb(tx)
+
+	tree, err := InitialiseL1InfoTree(hermezDb)
+	require.NoError(t, err)
+	assert.NotNil(t, tree)
+}
+
+func TestCheckForInfoTreeUpdates(t *testing.T) {
+	testCases := []struct {
+		name              string
+		logs              []types.Log
+		expectedProcessed uint64
+		expectedError     bool
+		mockHeaders       map[uint64]*types.Header
+	}{
+		{
+			name: "single valid log",
+			logs: []types.Log{
+				{
+					BlockNumber: 10,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, common.HexToHash("0x111"), common.HexToHash("0x222")},
+				},
+			},
+			expectedProcessed: 1,
+			expectedError:     false,
+			mockHeaders: map[uint64]*types.Header{
+				10: {
+					Number: big.NewInt(10),
+					Time:   uint64(time.Now().Unix()),
+				},
+			},
+		},
+		{
+			name: "multiple valid logs",
+			logs: []types.Log{
+				{
+					BlockNumber: 10,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, common.HexToHash("0x111"), common.HexToHash("0x222")},
+				},
+				{
+					BlockNumber: 11,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, common.HexToHash("0x333"), common.HexToHash("0x444")},
+				},
+			},
+			expectedProcessed: 2,
+			expectedError:     false,
+			mockHeaders: map[uint64]*types.Header{
+				10: {Number: big.NewInt(10), Time: uint64(time.Now().Unix())},
+				11: {Number: big.NewInt(11), Time: uint64(time.Now().Unix())},
+			},
+		},
+		{
+			name: "log with wrong topic (should be skipped)",
+			logs: []types.Log{
+				{
+					BlockNumber: 10,
+					Topics:      []common.Hash{common.HexToHash("0xwrongtopic"), common.HexToHash("0x111"), common.HexToHash("0x222")},
+				},
+			},
+			expectedProcessed: 0,
+			expectedError:     false,
+			mockHeaders: map[uint64]*types.Header{
+				10: {Number: big.NewInt(10), Time: uint64(time.Now().Unix())},
+			},
+		},
+		{
+			name: "log with insufficient topics (should be skipped)",
+			logs: []types.Log{
+				{
+					BlockNumber: 10,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, common.HexToHash("0x111")}, // Only 2 topics
+				},
+			},
+			expectedProcessed: 0,
+			expectedError:     false, // only warning, some weird case that must not happen
+			mockHeaders: map[uint64]*types.Header{
+				10: {Number: big.NewInt(10), Time: uint64(time.Now().Unix())},
+			},
+		},
+		{
+			name: "mixed valid and invalid logs",
+			logs: []types.Log{
+				{
+					BlockNumber: 10,
+					Topics:      []common.Hash{common.HexToHash("0xwrongtopic"), common.HexToHash("0x111"), common.HexToHash("0x222")},
+				},
+				{
+					BlockNumber: 11,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, common.HexToHash("0x333"), common.HexToHash("0x444")},
+				},
+				{
+					BlockNumber: 12,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, common.HexToHash("0x555")}, // Insufficient topics
+				},
+			},
+			expectedProcessed: 1,
+			expectedError:     false,
+			mockHeaders: map[uint64]*types.Header{
+				10: {Number: big.NewInt(10), Time: uint64(time.Now().Unix())},
+				11: {Number: big.NewInt(11), Time: uint64(time.Now().Unix() + 1)},
+				12: {Number: big.NewInt(12), Time: uint64(time.Now().Unix() + 2)},
+			},
+		},
+		{
+			name: "UpdateL1InfoTreeTopic followed by UpdateL1InfoTreeV2Topic",
+			logs: []types.Log{
+				{
+					BlockNumber: 10,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, common.HexToHash("0x111"), common.HexToHash("0x222")},
+					TxIndex:     0,
+					Index:       0, // must be V2 topic leaf count (0x1) - 1
+				},
+				{
+					BlockNumber: 10,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeV2Topic, common.HexToHash("0x1"), common.HexToHash("0x444")},
+					Data:        common.FromHex("0x26896ed3a18c507006d6bcb9f30c8bd37ca1ec07148254600e51f1e73b6e9ad6"), // precalculated for v1 event
+					TxIndex:     0,
+					Index:       1,
+				},
+			},
+			expectedProcessed: 2,
+			expectedError:     false,
+			mockHeaders: map[uint64]*types.Header{
+				10: {Number: big.NewInt(10), Time: 1},
+			},
+		},
+		{
+			name: "UpdateL1InfoTreeV2Topic followed by UpdateL1InfoTreeTopic is invalid",
+			logs: []types.Log{
+				{
+					BlockNumber: 10,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeV2Topic, common.HexToHash("0x333"), common.HexToHash("0x444")},
+					Data:        make([]byte, 32), // Simulating data for V2
+				},
+				{
+					BlockNumber: 10,
+					Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, common.HexToHash("0x111"), common.HexToHash("0x222")},
+				},
+			},
+			expectedProcessed: 0,
+			expectedError:     true,
+			mockHeaders: map[uint64]*types.Header{
+				10: {Number: big.NewInt(10), Time: 1},
+			},
+		},
+		{
+			name:              "empty logs array",
+			logs:              []types.Log{},
+			expectedProcessed: 0,
+			expectedError:     false,
+			mockHeaders:       map[uint64]*types.Header{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := memdb.NewTestDB(t)
+			defer db.Close()
+
+			tx, err := db.BeginRw(context.Background())
+			require.NoError(t, err)
+			defer tx.Rollback()
+
+			mockSyncer := &MockSyncer{}
+			cfg := &ethconfig.Zk{L1FirstBlock: 1000}
+			updater := NewUpdater(context.Background(), cfg, mockSyncer, nil)
+
+			logsChan := make(chan []types.Log, 1)
+			doneChan := make(chan struct{}, 1)
+
+			// Set up mock expectations
+			mockSyncer.On("GetLogsChan").Return(logsChan)
+			mockSyncer.On("GetDoneChan").Return((<-chan struct{})(doneChan))
+			mockSyncer.On("GetProgressMessageChan").Return(make(chan string))
+			mockSyncer.On("IsDownloading").Return(false).Maybe()
+			mockSyncer.On("ClearHeaderCache").Return()
+			mockSyncer.On("StopQueryBlocks").Return().Maybe()
+			mockSyncer.On("ConsumeQueryBlocks").Return().Maybe()
+			mockSyncer.On("WaitQueryBlocksToFinish").Return().Maybe()
+			mockSyncer.On("RunQueryBlocks", mock.AnythingOfType("uint64")).Return().Maybe()
+
+			// Set up header mocks
+			for blockNum, header := range tc.mockHeaders {
+				mockSyncer.On("GetHeader", blockNum).Return(header, nil).Maybe() // any times
+			}
+			// Add a catch-all mock for any other GetHeader calls (like block 0)
+			mockSyncer.On("GetHeader", mock.AnythingOfType("uint64")).Return((*types.Header)(nil), assert.AnError).Maybe()
+
+			// Send logs to channel
+			if len(tc.logs) > 0 {
+				logsChan <- tc.logs
+			} else {
+				logsChan <- []types.Log{}
+			}
+
+			time.AfterFunc(1*time.Millisecond, func() {
+				close(doneChan) // Closed by syncer in prod
+			})
+			processed, err := updater.CheckForInfoTreeUpdates("test", tx)
+
+			if tc.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedProcessed, processed)
+			}
+
+			mockSyncer.AssertExpectations(t)
+		})
+	}
+}

--- a/zk/stages/stage_l1_info_tree.go
+++ b/zk/stages/stage_l1_info_tree.go
@@ -86,6 +86,8 @@ func SpawnL1InfoTreeStage(
 		return fmt.Errorf("cfg.updater.WarmUp: %w", err)
 	}
 
+	// latestL1Block := cfg.updater.GetLatestL1Block()
+	// processedLogs, err := cfg.updater.CheckForInfoTreeUpdates(logPrefix, tx, cfg.updater.GetProgress(), latestL1Block)
 	processedLogs, err := cfg.updater.CheckForInfoTreeUpdates(logPrefix, tx)
 	if err != nil {
 		return fmt.Errorf("CheckForInfoTreeUpdates: %w", err)

--- a/zk/stages/stage_l1_info_tree.go
+++ b/zk/stages/stage_l1_info_tree.go
@@ -86,8 +86,6 @@ func SpawnL1InfoTreeStage(
 		return fmt.Errorf("cfg.updater.WarmUp: %w", err)
 	}
 
-	// latestL1Block := cfg.updater.GetLatestL1Block()
-	// processedLogs, err := cfg.updater.CheckForInfoTreeUpdates(logPrefix, tx, cfg.updater.GetProgress(), latestL1Block)
 	processedLogs, err := cfg.updater.CheckForInfoTreeUpdates(logPrefix, tx)
 	if err != nil {
 		return fmt.Errorf("CheckForInfoTreeUpdates: %w", err)

--- a/zk/stages/stage_l1_info_tree_test.go
+++ b/zk/stages/stage_l1_info_tree_test.go
@@ -1,4 +1,4 @@
-// package stages
+package stages
 
 import (
 	"context"
@@ -218,7 +218,7 @@ func TestSpawnL1InfoTreeStage_HappyPath(t *testing.T) {
 	assert.Equal(t, env.blockNumber.Uint64(), progress)
 }
 
-func TestSpawnL1InfoTreeStage_UnhappyPath_SkipV1Log(t *testing.T) {
+func TestSpawnL1InfoTreeStage_SkipV1Log(t *testing.T) {
 	env := newStageEnv(t)
 
 	const n = 8
@@ -246,7 +246,7 @@ func TestSpawnL1InfoTreeStage_UnhappyPath_SkipV1Log(t *testing.T) {
 	assert.Equal(t, skippedTxIndex, len(leaves))
 }
 
-func TestSpawnL1InfoTreeStage_UnhappyPath_GetHeaderFails(t *testing.T) {
+func TestSpawnL1InfoTreeStage_GetHeaderFails(t *testing.T) {
 	env := newStageEnv(t)
 
 	logs := makeV1V2Pairs(t, 1, env.contracts[0], env.blockNumber.Uint64(), env.parentHash, env.blockTime)
@@ -261,12 +261,7 @@ func TestSpawnL1InfoTreeStage_UnhappyPath_GetHeaderFails(t *testing.T) {
 	require.Nil(t, err)
 }
 
-func TestSpawnL1InfoTreeStage_UnhappyPath_GetHeaderAlwaysFails(t *testing.T) {
-	// Force the logger to print everything
-	log.Root().SetHandler(
-		log.LvlFilterHandler(log.LvlDebug, log.StderrHandler),
-	)
-
+func TestSpawnL1InfoTreeStage_GetHeaderAlwaysFailsTimeout(t *testing.T) {
 	l1infotree.NoActivityTimeout = 100 * time.Millisecond
 
 	env := newStageEnv(t)
@@ -279,7 +274,7 @@ func TestSpawnL1InfoTreeStage_UnhappyPath_GetHeaderAlwaysFails(t *testing.T) {
 	require.Error(t, err) // will fail on timeout
 }
 
-func TestSpawnL1InfoTreeStage_UnhappyPath_FilterLogsFails(t *testing.T) {
+func TestSpawnL1InfoTreeStage_FilterLogsFails(t *testing.T) {
 	l1infotree.NoActivityTimeout = 100 * time.Millisecond
 
 	env := newStageEnv(t)
@@ -287,14 +282,10 @@ func TestSpawnL1InfoTreeStage_UnhappyPath_FilterLogsFails(t *testing.T) {
 	env.em.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("filter logs error")).AnyTimes()
 
 	err := runStageOnce(t, env)
-	// require.Error(t, err)
 	require.Nil(t, err) // Though filter logs failed, it was retrying until a timeout, if timeout is less than max timeout for retries
 }
 
-func TestSpawnL1InfoTreeStage_UnhappyPath_GetHeadersFailsThenNextIterationOK(t *testing.T) {
-	log.Root().SetHandler(
-		log.LvlFilterHandler(log.LvlDebug, log.StderrHandler),
-	)
+func TestSpawnL1InfoTreeStage_GetHeadersFailsThenNextIterationOK(t *testing.T) {
 	l1infotree.NoActivityTimeout = 100 * time.Millisecond
 
 	env := newStageEnv(t)

--- a/zk/stages/stage_l1_info_tree_test.go
+++ b/zk/stages/stage_l1_info_tree_test.go
@@ -86,7 +86,7 @@ func TestSpawnL1InfoTreeStage(t *testing.T) {
 	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
 
 	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest", 0)
-	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{
+	updater := l1infotree.NewUpdater(ctx, &ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{
 		L2RpcUrl: "http://127.0.0.1:8545",
 	}))
 	cfg := StageL1InfoTreeCfg(db1, &ethconfig.Zk{}, updater)

--- a/zk/stages/stage_l1_info_tree_test.go
+++ b/zk/stages/stage_l1_info_tree_test.go
@@ -264,6 +264,7 @@ func TestSpawnL1InfoTreeStage_GetHeaderAlwaysFailsTimeout(t *testing.T) {
 	syncer.L1FetchHeaderRetryDelay = 50 * time.Millisecond
 
 	env := newStageEnv(t)
+	env.l1Syncer.SetFetchHeaders(true)
 
 	logs := makeV1V2Pairs(t, 1, env.contracts[0], env.blockNumber.Uint64(), env.parentHash, env.blockTime)
 	env.em.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return(logs, nil).AnyTimes()

--- a/zk/stages/stage_l1_info_tree_test.go
+++ b/zk/stages/stage_l1_info_tree_test.go
@@ -1,13 +1,14 @@
-package stages
+// package stages
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
 
-	ethereum "github.com/erigontech/erigon"
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/memdb"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
@@ -26,128 +27,245 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestSpawnL1InfoTreeStage(t *testing.T) {
-	// arrange
-	ctx, db1 := context.Background(), memdb.NewTestDB(t)
+// Shared test scaffolding
+
+type stageEnv struct {
+	ctx         context.Context
+	db          kv.RwDB
+	tx          kv.RwTx
+	hdb         *hermez_db.HermezDb
+	em          *mocks.MockIEtherman
+	l1Syncer    *syncer.L1Syncer
+	updater     *l1infotree.Updater
+	cfg         L1InfoTreeCfg
+	blockNumber *big.Int
+	parentHash  common.Hash
+	blockTime   uint64
+	contracts   []common.Address
+}
+
+func newStageEnv(t *testing.T) *stageEnv {
+	t.Helper()
+
+	ctx := context.Background()
+	db1 := memdb.NewTestDB(t)
 	tx := memdb.BeginRw(t, db1)
-	err := hermez_db.CreateHermezBuckets(tx)
-	require.NoError(t, err)
-	err = db.CreateEriDbBuckets(tx)
-	require.NoError(t, err)
+	require.NoError(t, hermez_db.CreateHermezBuckets(tx))
+	require.NoError(t, db.CreateEriDbBuckets(tx))
 
-	hDB := hermez_db.NewHermezDb(tx)
-	err = hDB.WriteBlockBatch(0, 0)
-	require.NoError(t, err)
-	err = stages.SaveStageProgress(tx, stages.L1InfoTree, 20)
-	require.NoError(t, err)
+	hdb := hermez_db.NewHermezDb(tx)
 
-	s := &stagedsync.StageState{ID: stages.L1InfoTree, BlockNumber: 0}
-	u := &stagedsync.Sync{}
+	// Start progress just before our target block
+	latest := uint64(1000)
+	require.NoError(t, stages.SaveStageProgress(tx, stages.L1InfoTree, latest))
 
-	// mocks
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	EthermanMock := mocks.NewMockIEtherman(mockCtrl)
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	em := mocks.NewMockIEtherman(ctrl)
 
-	l1ContractAddresses := []common.Address{
-		common.HexToAddress("0x1"),
-		common.HexToAddress("0x2"),
-		common.HexToAddress("0x3"),
+	cntrcts := []common.Address{
+		common.HexToAddress("0x1000"),
 	}
-	l1ContractTopics := [][]common.Hash{
-		[]common.Hash{common.HexToHash("0x1")},
-		[]common.Hash{common.HexToHash("0x2")},
-		[]common.Hash{common.HexToHash("0x3")},
+	topics := [][]common.Hash{
+		// The syncer uses these to construct FilterLogs; we match AnyTimes() in mocks
+		{contracts.UpdateL1InfoTreeTopic, contracts.UpdateL1InfoTreeV2Topic},
 	}
 
-	latestBlockParentHash := common.HexToHash("0x123456789")
-	latestBlockTime := uint64(time.Now().Unix())
-	latestBlockNumber := big.NewInt(21)
-	latestBlockHeader := &types.Header{ParentHash: latestBlockParentHash, Number: latestBlockNumber, Time: latestBlockTime}
-	latestBlock := types.NewBlockWithHeader(latestBlockHeader)
+	parent := common.HexToHash("0xabc")
+	ts := uint64(time.Now().Unix())
+	bn := big.NewInt(int64(latest + 1))
+	header := &types.Header{ParentHash: parent, Number: bn, Time: ts}
+	block := types.NewBlockWithHeader(header)
 
-	EthermanMock.EXPECT().HeaderByNumber(gomock.Any(), latestBlockNumber).Return(latestBlockHeader, nil).AnyTimes()
-	EthermanMock.EXPECT().BlockByNumber(gomock.Any(), nil).Return(latestBlock, nil).AnyTimes()
-	filterQuery := ethereum.FilterQuery{
-		FromBlock: latestBlockNumber,
-		ToBlock:   latestBlockNumber,
-		Addresses: l1ContractAddresses,
-		Topics:    l1ContractTopics,
-	}
-	mainnetExitRoot := common.HexToHash("0x111")
-	rollupExitRoot := common.HexToHash("0x222")
+	// Remove default HeaderByNumber here; keep BlockByNumber
+	em.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil).AnyTimes()
 
-	l1InfoTreeLog := types.Log{
-		BlockNumber: latestBlockNumber.Uint64(),
-		Address:     l1ContractAddresses[0],
-		Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, mainnetExitRoot, rollupExitRoot},
-	}
-	filteredLogs := []types.Log{l1InfoTreeLog}
-	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
-
-	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest", 0)
-	updater := l1infotree.NewUpdater(ctx, &ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{
+	l1 := syncer.NewL1Syncer(ctx, []syncer.IEtherman{em}, cntrcts, topics, 10000, 0, "latest", 0)
+	updater := l1infotree.NewUpdater(ctx, &ethconfig.Zk{L1FirstBlock: latest + 1}, l1, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{
 		L2RpcUrl: "http://127.0.0.1:8545",
 	}))
 	cfg := StageL1InfoTreeCfg(db1, &ethconfig.Zk{}, updater)
 
-	// act
-	err = SpawnL1InfoTreeStage(s, u, tx, cfg, ctx, log.New())
+	return &stageEnv{
+		ctx:         ctx,
+		db:          db1,
+		tx:          tx,
+		hdb:         hdb,
+		em:          em,
+		l1Syncer:    l1,
+		updater:     updater,
+		cfg:         cfg,
+		blockNumber: bn,
+		parentHash:  parent,
+		blockTime:   ts,
+		contracts:   cntrcts,
+	}
+}
+
+func runStageOnce(t *testing.T, env *stageEnv) error {
+	t.Helper()
+	s := &stagedsync.StageState{ID: stages.L1InfoTree}
+	u := &stagedsync.Sync{}
+	return SpawnL1InfoTreeStage(s, u, env.tx, env.cfg, env.ctx, log.New())
+}
+
+// Helpers for encoding/index/roots
+
+func u256Bytes(n uint64) []byte {
+	var out [32]byte
+	b := new(big.Int).SetUint64(n).Bytes()
+	copy(out[32-len(b):], b)
+	return out[:]
+}
+
+func computeGERFromV1Log(l types.Log) common.Hash {
+	// GER = keccak(mainnetExitRoot || rollupExitRoot)
+	combined := append(l.Topics[1].Bytes(), l.Topics[2].Bytes()...)
+	return common.BytesToHash(keccak256.Hash(combined))
+}
+
+func leafFromV1(l types.Log, parent common.Hash, ts uint64) [32]byte {
+	ger := computeGERFromV1Log(l)
+	return l1infotree.HashLeafData(ger, parent, ts)
+}
+
+func makeV1Log(addr common.Address, block uint64, txIndex, logIndex uint) types.Log {
+	// V1: topics[0]=V1 topic; topics[1]=mainnet root; topics[2]=rollup root; data = uint256 index
+	mainnetExitRoot := common.HexToHash(fmt.Sprintf("0x%064x", block+uint64(txIndex)+0x111))
+	rollupExitRoot := common.HexToHash(fmt.Sprintf("0x%064x", block+uint64(txIndex)+0x222))
+	data := u256Bytes(uint64(logIndex / 2)) // logical index for V1 leaf
+	return types.Log{
+		BlockNumber: block,
+		Address:     addr,
+		Topics:      []common.Hash{contracts.UpdateL1InfoTreeTopic, mainnetExitRoot, rollupExitRoot},
+		Data:        data,
+		TxIndex:     txIndex,
+		Index:       logIndex,
+	}
+}
+
+func makeV2Log(addr common.Address, block uint64, txIndex, logIndex uint, leafCount uint64, root common.Hash) types.Log {
+	// V2: topics[0]=V2 topic; topics[1]=leafCount (uint256=index+1); data[0:32]=root
+	return types.Log{
+		BlockNumber: block,
+		Address:     addr,
+		Topics:      []common.Hash{contracts.UpdateL1InfoTreeV2Topic, common.BigToHash(new(big.Int).SetUint64(leafCount))},
+		Data:        root.Bytes(), // exactly 32 bytes
+		TxIndex:     txIndex,
+		Index:       logIndex,
+	}
+}
+
+// Build V1/V2 pairs with V2.root equal to the trie root after inserting the previous V1 leaf.
+func makeV1V2Pairs(t *testing.T, n int, addr common.Address, block uint64, parent common.Hash, ts uint64) []types.Log {
+	t.Helper()
+	logs := make([]types.Log, 0, n*2)
+
+	// Local trie to compute expected roots (same logic as production)
+	tree, err := l1infotree.NewL1InfoTree(32, nil)
 	require.NoError(t, err)
 
-	// assert
-	// check tree
-	tree, err := l1infotree.InitialiseL1InfoTree(hDB)
+	for i := 0; i < n; i++ {
+		txIdx := uint(i)
+		v1Idx := uint(2 * i)
+		v2Idx := v1Idx + 1
+
+		v1 := makeV1Log(addr, block, txIdx, v1Idx)
+		leaf := leafFromV1(v1, parent, ts)
+
+		newRoot, err := tree.AddLeaf(uint32(i), leaf)
+		require.NoError(t, err)
+
+		v2 := makeV2Log(addr, block, txIdx, v2Idx, uint64(i+1), common.BytesToHash(newRoot[:]))
+
+		logs = append(logs, v1, v2)
+	}
+
+	return logs
+}
+
+func expectHeaderOK(env *stageEnv, header *types.Header) {
+	env.em.EXPECT().HeaderByNumber(gomock.Any(), env.blockNumber).Return(header, nil).AnyTimes()
+}
+
+func expectHeaderErrorOnce(env *stageEnv) {
+	env.em.EXPECT().HeaderByNumber(gomock.Any(), env.blockNumber).Return(nil, fmt.Errorf("header error")).Times(1)
+}
+
+// Tests
+
+func TestSpawnL1InfoTreeStage_HappyPath(t *testing.T) {
+	env := newStageEnv(t)
+
+	const n = 10
+	logs := makeV1V2Pairs(t, n, env.contracts[0], env.blockNumber.Uint64(), env.parentHash, env.blockTime)
+
+	// Provide logs
+	env.em.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return(logs, nil).AnyTimes()
+	expectHeaderOK(env, &types.Header{ParentHash: env.parentHash, Number: env.blockNumber, Time: env.blockTime})
+
+	err := runStageOnce(t, env)
 	require.NoError(t, err)
 
-	combined := append(mainnetExitRoot.Bytes(), rollupExitRoot.Bytes()...)
-	gerBytes := keccak256.Hash(combined)
-	ger := common.BytesToHash(gerBytes)
-	leafBytes := l1infotree.HashLeafData(ger, latestBlockParentHash, latestBlockTime)
-
-	assert.True(t, tree.LeafExists(leafBytes))
-
-	// check WriteL1InfoTreeLeaf
-	leaves, err := hDB.GetAllL1InfoTreeLeaves()
+	// Only V1 logs create leaves
+	leaves, err := env.hdb.GetAllL1InfoTreeLeaves()
 	require.NoError(t, err)
+	assert.Len(t, leaves, n)
 
-	leafHash := common.BytesToHash(leafBytes[:])
-	assert.Len(t, leaves, 1)
-	assert.Equal(t, leafHash.String(), leaves[0].String())
-
-	// check WriteL1InfoTreeUpdate
-	l1InfoTreeUpdate, err := hDB.GetL1InfoTreeUpdate(0)
+	// Progress advanced to the block containing logs
+	progress, err := stages.GetStageProgress(env.tx, stages.L1InfoTree)
 	require.NoError(t, err)
+	assert.Equal(t, env.blockNumber.Uint64(), progress)
+}
 
-	assert.Equal(t, uint64(0), l1InfoTreeUpdate.Index)
-	assert.Equal(t, ger, l1InfoTreeUpdate.GER)
-	assert.Equal(t, mainnetExitRoot, l1InfoTreeUpdate.MainnetExitRoot)
-	assert.Equal(t, rollupExitRoot, l1InfoTreeUpdate.RollupExitRoot)
-	assert.Equal(t, latestBlockNumber.Uint64(), l1InfoTreeUpdate.BlockNumber)
-	assert.Equal(t, latestBlockTime, l1InfoTreeUpdate.Timestamp)
-	assert.Equal(t, latestBlockParentHash, l1InfoTreeUpdate.ParentHash)
+func TestSpawnL1InfoTreeStage_UnhappyPath_SkipV1Log(t *testing.T) {
+	env := newStageEnv(t)
 
-	//check  WriteL1InfoTreeUpdateToGer
-	l1InfoTreeUpdateToGer, err := hDB.GetL1InfoTreeUpdateByGer(ger)
+	const n = 8
+	all := makeV1V2Pairs(t, n, env.contracts[0], env.blockNumber.Uint64(), env.parentHash, env.blockTime)
+
+	// Drop one V1 (txIndex==3), keep its V2
+	skippedTxIndex := 3
+	filtered := make([]types.Log, 0, len(all)-1)
+	for _, l := range all {
+		if l.Topics[0] == contracts.UpdateL1InfoTreeTopic && l.TxIndex == uint(skippedTxIndex) {
+			continue
+		}
+		filtered = append(filtered, l)
+	}
+
+	env.em.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return(filtered, nil).AnyTimes()
+	expectHeaderOK(env, &types.Header{ParentHash: env.parentHash, Number: env.blockNumber, Time: env.blockTime})
+
+	// Stage will notice mismatch on V2 and attempt rollback; we accept an early return with no error or an error depending on implementation.
+	_ = runStageOnce(t, env)
+
+	leaves, err := env.hdb.GetAllL1InfoTreeLeaves()
 	require.NoError(t, err)
+	// We will rollback the tree up to the confirmed index - skippedTxIndex
+	assert.Equal(t, skippedTxIndex, len(leaves))
+}
 
-	assert.Equal(t, uint64(0), l1InfoTreeUpdateToGer.Index)
-	assert.Equal(t, ger, l1InfoTreeUpdateToGer.GER)
-	assert.Equal(t, mainnetExitRoot, l1InfoTreeUpdateToGer.MainnetExitRoot)
-	assert.Equal(t, rollupExitRoot, l1InfoTreeUpdateToGer.RollupExitRoot)
-	assert.Equal(t, latestBlockNumber.Uint64(), l1InfoTreeUpdateToGer.BlockNumber)
-	assert.Equal(t, latestBlockTime, l1InfoTreeUpdateToGer.Timestamp)
-	assert.Equal(t, latestBlockParentHash, l1InfoTreeUpdateToGer.ParentHash)
+func TestSpawnL1InfoTreeStage_UnhappyPath_GetHeaderFails(t *testing.T) {
+	env := newStageEnv(t)
 
-	// check WriteL1InfoTreeRoot
-	root, _, _ := tree.GetCurrentRootCountAndSiblings()
-	index, found, err := hDB.GetL1InfoTreeIndexByRoot(root)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(0), index)
-	assert.True(t, found)
+	logs := makeV1V2Pairs(t, 1, env.contracts[0], env.blockNumber.Uint64(), env.parentHash, env.blockTime)
+	env.em.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return(logs, nil).AnyTimes()
 
-	// check SaveStageProgress
-	progress, err := stages.GetStageProgress(tx, stages.L1InfoTree)
-	require.NoError(t, err)
-	assert.Equal(t, latestBlockNumber.Uint64(), progress)
+	// Expect header error
+	expectHeaderErrorOnce(env)
+
+	err := runStageOnce(t, env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "header error")
+}
+
+func TestSpawnL1InfoTreeStage_UnhappyPath_FilterLogsFails(t *testing.T) {
+	env := newStageEnv(t)
+
+	env.em.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("filter logs error")).AnyTimes()
+
+	err := runStageOnce(t, env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "filter logs error")
 }

--- a/zk/stages/stage_l1_sequencer_sync.go
+++ b/zk/stages/stage_l1_sequencer_sync.go
@@ -94,6 +94,7 @@ func SpawnL1SequencerSyncStage(
 
 	logChan := cfg.syncer.GetLogsChan()
 	progressChan := cfg.syncer.GetProgressMessageChan()
+	doneChan := cfg.syncer.GetDoneChan()
 
 Loop:
 	for {
@@ -184,11 +185,10 @@ Loop:
 			}
 		case progMsg := <-progressChan:
 			log.Info(fmt.Sprintf("[%s] %s", logPrefix, progMsg))
-		default:
-			if !cfg.syncer.IsDownloading() {
-				break Loop
-			}
-			time.Sleep(10 * time.Millisecond)
+		case <-doneChan:
+			break Loop
+		case <-ctx.Done():
+			break Loop
 		}
 	}
 

--- a/zk/stages/stage_l1_sequencer_sync_test.go
+++ b/zk/stages/stage_l1_sequencer_sync_test.go
@@ -261,7 +261,6 @@ func TestSpawnL1SequencerSyncStage(t *testing.T) {
 	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
 
 	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest", 0)
-	// 	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer)
 	zkCfg := &ethconfig.Zk{
 		L1RollupId:                  uint64(99999),
 		L1FirstBlock:                l1FirstBlock.Uint64(),

--- a/zk/stages/stage_l1_syncer.go
+++ b/zk/stages/stage_l1_syncer.go
@@ -31,7 +31,7 @@ type IL1Syncer interface {
 	// Channels
 	GetLogsChan() chan []ethTypes.Log
 	GetProgressMessageChan() chan string
-	GetDoneChan() <-chan struct{}
+	GetDoneChan() <-chan uint64
 
 	L1QueryHeaders(logs []ethTypes.Log) (map[uint64]*ethTypes.Header, error)
 	GetBlock(number uint64) (*ethTypes.Block, error)
@@ -186,6 +186,7 @@ Loop:
 		case progressMessage := <-progressMessageChan:
 			log.Info(fmt.Sprintf("[%s] %s", logPrefix, progressMessage))
 		case <-doneChan:
+			log.Info(fmt.Sprintf("[%s] Done channel received, exiting", logPrefix))
 			break Loop
 		case <-ctx.Done():
 			break Loop

--- a/zk/stages/stage_l1_syncer.go
+++ b/zk/stages/stage_l1_syncer.go
@@ -115,7 +115,6 @@ Loop:
 	for {
 		select {
 		case logs, ok := <-logsChan:
-			log.Debug("SpawnStageL1Syncer l1 sync: got logs from chan", "count", len(logs))
 			if !ok {
 				break Loop
 			}

--- a/zk/stages/stage_l1_syncer.go
+++ b/zk/stages/stage_l1_syncer.go
@@ -186,7 +186,6 @@ Loop:
 		case progressMessage := <-progressMessageChan:
 			log.Info(fmt.Sprintf("[%s] %s", logPrefix, progressMessage))
 		case <-doneChan:
-			log.Info(fmt.Sprintf("[%s] Done channel received, exiting", logPrefix))
 			break Loop
 		case <-ctx.Done():
 			break Loop

--- a/zk/stages/stage_l1_syncer_test.go
+++ b/zk/stages/stage_l1_syncer_test.go
@@ -295,6 +295,7 @@ func TestSpawnStageL1Syncer(t *testing.T) {
 	}
 
 	EthermanMock.EXPECT().FilterLogs(gomock.Any(), filterQuery).Return(filteredLogs, nil).AnyTimes()
+	EthermanMock.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(genesisHeader, nil).AnyTimes()
 
 	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{EthermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest", 0)
 

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -196,6 +196,11 @@ func TestSpawnSequencingStage(t *testing.T) {
 
 	cfg.txYielder = &sequencer.RecoveryTransactionYielder{}
 
+	// Stop syncer on timeout, because normally it is stopped only in case of error, but we have no error here
+	time.AfterFunc(500*time.Millisecond, func() {
+		l1Syncer.StopQueryBlocks()
+	})
+
 	// Act
 	err = SpawnSequencingStage(s, u, ctx, cfg, historyCfg, quiet)
 	require.NoError(t, err)

--- a/zk/stages/stage_sequence_execute_test.go
+++ b/zk/stages/stage_sequence_execute_test.go
@@ -139,7 +139,7 @@ func TestSpawnSequencingStage(t *testing.T) {
 	ethermanMock.EXPECT().BlockByNumber(gomock.Any(), nil).Return(latestL1Block, nil).AnyTimes()
 
 	l1Syncer := syncer.NewL1Syncer(ctx, []syncer.IEtherman{ethermanMock}, l1ContractAddresses, l1ContractTopics, 10, 0, "latest", 0)
-	updater := l1infotree.NewUpdater(&ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{}))
+	updater := l1infotree.NewUpdater(ctx, &ethconfig.Zk{}, l1Syncer, l1infotree.NewInfoTreeL2RpcSyncer(ctx, &ethconfig.Zk{}))
 
 	cacheMock := cMocks.NewMockCache(mockCtrl)
 	cacheMock.EXPECT().View(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()

--- a/zk/stages/stage_sequencer_l1_block_sync.go
+++ b/zk/stages/stage_sequencer_l1_block_sync.go
@@ -125,6 +125,7 @@ func SpawnSequencerL1BlockSyncStage(
 
 	logChan := cfg.syncer.GetLogsChan()
 	progressChan := cfg.syncer.GetProgressMessageChan()
+	doneChan := cfg.syncer.GetDoneChan()
 
 	logTicker := time.NewTicker(10 * time.Second)
 	defer logTicker.Stop()
@@ -225,11 +226,10 @@ LOOP:
 			log.Info(fmt.Sprintf("[%s] %s", logPrefix, msg))
 		case <-logTicker.C:
 			log.Info(fmt.Sprintf("[%s] Syncing L1 blocks", logPrefix), "latest-batch", latestBatch)
-		default:
-			if !cfg.syncer.IsDownloading() {
-				break LOOP
-			}
-			time.Sleep(10 * time.Millisecond)
+		case <-doneChan:
+			break LOOP
+		case <-ctx.Done():
+			break LOOP
 		}
 	}
 

--- a/zk/stages/stage_sequencer_l1_block_sync.go
+++ b/zk/stages/stage_sequencer_l1_block_sync.go
@@ -125,7 +125,7 @@ func SpawnSequencerL1BlockSyncStage(
 
 	logChan := cfg.syncer.GetLogsChan()
 	progressChan := cfg.syncer.GetProgressMessageChan()
-	doneChan := cfg.syncer.GetDoneChan()
+	defer cfg.syncer.ClearHeaderCache()
 
 	logTicker := time.NewTicker(10 * time.Second)
 	defer logTicker.Stop()
@@ -135,7 +135,10 @@ func SpawnSequencerL1BlockSyncStage(
 LOOP:
 	for {
 		select {
-		case logs := <-logChan:
+		case logs, ok := <-logChan:
+			if !ok {
+				break LOOP
+			}
 			for _, l := range logs {
 				// for some reason some endpoints seem to not have certain transactions available to
 				// them even they are perfectly valid and other RPC nodes return them fine.  So, leaning
@@ -226,8 +229,6 @@ LOOP:
 			log.Info(fmt.Sprintf("[%s] %s", logPrefix, msg))
 		case <-logTicker.C:
 			log.Info(fmt.Sprintf("[%s] Syncing L1 blocks", logPrefix), "latest-batch", latestBatch)
-		case <-doneChan:
-			break LOOP
 		case <-ctx.Done():
 			break LOOP
 		}

--- a/zk/syncer/l1_syncer.go
+++ b/zk/syncer/l1_syncer.go
@@ -210,7 +210,6 @@ func (s *L1Syncer) RunQueryBlocks(lastCheckedBlock uint64) {
 
 func (s *L1Syncer) GetHeader(number uint64) (*ethTypes.Header, error) {
 	if header, ok := s.headersCache.Load(number); ok {
-		log.Info("Cache hit for header", "number", number)
 		return header.(*ethTypes.Header), nil
 	}
 

--- a/zk/syncer/l1_syncer.go
+++ b/zk/syncer/l1_syncer.go
@@ -502,15 +502,6 @@ func (s *L1Syncer) getSequencedLogs(jobs <-chan fetchJob, results chan jobResult
 				if err != nil {
 					log.Debug("getSequencedLogs retry error", "err", err)
 					retry++
-					if retry > getLogsMaxRetry {
-						log.Error(fmt.Sprintf("L1 syncer (getSequencedLogs) exceeded %d retries", retry), "err", err)
-						results <- jobResult{
-							Size:  j.To - j.From,
-							Error: err,
-							Logs:  logs,
-						}
-						return
-					}
 					time.Sleep(time.Duration(retry*2) * time.Second)
 					continue
 				}

--- a/zk/syncer/l1_syncer.go
+++ b/zk/syncer/l1_syncer.go
@@ -419,6 +419,7 @@ func (s *L1Syncer) queryBlocks(startBlock, endBlock uint64) (numLogs uint64, err
 	aimingFor := endBlock - startBlock
 	complete := 0
 	var progress uint64 = 0
+	var prevProgress uint64 = 0
 loop:
 	for {
 		select {
@@ -459,6 +460,10 @@ loop:
 				continue
 			}
 			s.logsChanProgress <- fmt.Sprintf("L1 Blocks processed progress (amounts): %d/%d (%d%%)", progress, aimingFor, (progress*100)/aimingFor)
+			if progress > prevProgress {
+				prevProgress = progress
+				s.logsProduceChan <- nil // send a nil log to indicate activity in case no logs for long in big range
+			}
 		}
 	}
 

--- a/zk/types/zk_types.go
+++ b/zk/types/zk_types.go
@@ -80,6 +80,11 @@ func (l *L1InfoTreeUpdate) Unmarshall(input []byte) {
 	}
 }
 
+type L1InfoTreeUpdateWithLeafHash struct {
+	L1InfoTreeUpdate
+	LeafHash common.Hash `json:"leaf_hash,omitempty"`
+}
+
 type L1InjectedBatch struct {
 	L1BlockNumber      uint64         `json:"l1BlockNumber,omitempty"`
 	Timestamp          uint64         `json:"timestamp,omitempty"`


### PR DESCRIPTION
Made log processing immediate and hash calculation via a pool of workers. Building tree is done after all logs collected as before. Dedup of BlockByNumber calls and cache headers.

Verification:
- Synced integration8 - OK
- Synced Bali - OK (6h34m -> 5.5m)
