### PR TITLE
fix(hermez_db): correct DeleteForkIdBlock to delete by block number range

### DIFF
--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -1109,7 +1109,32 @@ func (db *HermezDbReader) GetAllForkBlocks() (map[uint64]uint64, error) {
 }
 
 func (db *HermezDb) DeleteForkIdBlock(fromBlockNo, toBlockNo uint64) error {
-	return db.deleteFromBucketWithUintKeysRange(FORKID_BLOCK, fromBlockNo, toBlockNo)
+	c, err := db.tx.Cursor(FORKID_BLOCK)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	var forkIdsToDelete []uint64
+	var k, v []byte
+
+	for k, v, err = c.First(); k != nil; k, v, err = c.Next() {
+		if err != nil {
+			return err
+		}
+		blockNum := BytesToUint64(v)
+		if blockNum >= fromBlockNo && blockNum <= toBlockNo {
+			forkIdsToDelete = append(forkIdsToDelete, BytesToUint64(k))
+		}
+	}
+
+	for _, forkId := range forkIdsToDelete {
+		if err := db.tx.Delete(FORKID_BLOCK, Uint64ToBytes(forkId)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (db *HermezDb) WriteForkIdBlockOnce(forkId, blockNum uint64) error {

--- a/zk/hermez_db/db_forkid_test.go
+++ b/zk/hermez_db/db_forkid_test.go
@@ -1,0 +1,82 @@
+package hermez_db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteForkIdBlock(t *testing.T) {
+	tx, cleanup := GetDbTx()
+	defer cleanup()
+	db := NewHermezDb(tx)
+
+	require.NoError(t, db.WriteForkIdBlockOnce(1, 100))
+	require.NoError(t, db.WriteForkIdBlockOnce(2, 200))
+	require.NoError(t, db.WriteForkIdBlockOnce(3, 300))
+	require.NoError(t, db.WriteForkIdBlockOnce(4, 400))
+
+	forkBlocks, err := db.GetAllForkBlocks()
+	require.NoError(t, err)
+	assert.Len(t, forkBlocks, 4)
+
+	require.NoError(t, db.DeleteForkIdBlock(200, 300))
+
+	forkBlocks, err = db.GetAllForkBlocks()
+	require.NoError(t, err)
+	assert.Len(t, forkBlocks, 2)
+
+	blockNum, found, err := db.GetForkIdBlock(1)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, uint64(100), blockNum)
+
+	_, found, err = db.GetForkIdBlock(2)
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	_, found, err = db.GetForkIdBlock(3)
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	blockNum, found, err = db.GetForkIdBlock(4)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, uint64(400), blockNum)
+}
+
+func TestDeleteForkIdBlockEmptyRange(t *testing.T) {
+	tx, cleanup := GetDbTx()
+	defer cleanup()
+	db := NewHermezDb(tx)
+
+	require.NoError(t, db.WriteForkIdBlockOnce(1, 100))
+	require.NoError(t, db.WriteForkIdBlockOnce(2, 200))
+
+	require.NoError(t, db.DeleteForkIdBlock(500, 600))
+
+	forkBlocks, err := db.GetAllForkBlocks()
+	require.NoError(t, err)
+	assert.Len(t, forkBlocks, 2)
+}
+
+func TestDeleteForkIdBlockSingleMatch(t *testing.T) {
+	tx, cleanup := GetDbTx()
+	defer cleanup()
+	db := NewHermezDb(tx)
+
+	require.NoError(t, db.WriteForkIdBlockOnce(1, 100))
+	require.NoError(t, db.WriteForkIdBlockOnce(2, 200))
+	require.NoError(t, db.WriteForkIdBlockOnce(3, 300))
+
+	require.NoError(t, db.DeleteForkIdBlock(200, 200))
+
+	forkBlocks, err := db.GetAllForkBlocks()
+	require.NoError(t, err)
+	assert.Len(t, forkBlocks, 2)
+
+	_, found, err := db.GetForkIdBlock(2)
+	require.NoError(t, err)
+	assert.False(t, found)
+}


### PR DESCRIPTION
## Issue

Fixes #1939

## Problem

The `DeleteForkIdBlock(fromBlockNo, toBlockNo uint64)` function was incorrectly using `deleteFromBucketWithUintKeysRange` which iterates by key (forkId), but the function parameters are block number ranges.

The `FORKID_BLOCK` bucket has:
- **Key:** forkId (uint64)
- **Value:** blockNum (uint64)

So passing block numbers as the range was deleting the wrong records (or nothing at all).

## Solution

The fix iterates through all entries in the bucket, checks if the **value** (block number) falls within the specified range `[fromBlockNo, toBlockNo]`, and deletes matching entries.

## Changes

- `zk/hermez_db/db.go`: Fixed `DeleteForkIdBlock` to iterate by value instead of key
- `zk/hermez_db/db_forkid_test.go`: Added comprehensive tests for the fix

## Testing

All tests pass:
```
=== RUN   TestDeleteForkIdBlock
--- PASS: TestDeleteForkIdBlock (0.01s)
=== RUN   TestDeleteForkIdBlockEmptyRange
--- PASS: TestDeleteForkIdBlockEmptyRange (0.01s)
=== RUN   TestDeleteForkIdBlockSingleMatch
--- PASS: TestDeleteForkIdBlockSingleMatch (0.01s)
PASS
```