### PR TITLE
ci: add docker hub authentication to avoid rate limits

### DIFF
--- a/.github/actions/setup-kurtosis-type1/action.yml
+++ b/.github/actions/setup-kurtosis-type1/action.yml
@@ -80,6 +80,21 @@ runs:
         echo "Disk usage after cleanup:"
         df -h
 
+    - name: Pre-pull and tag images to avoid Docker Hub
+      shell: bash
+      run: |
+        # Pre-pull Vector from GHCR and tag as timberio/vector to bypass engine pull
+        docker pull ghcr.io/vectordotdev/vector:0.45.0-debian || true
+        docker tag ghcr.io/vectordotdev/vector:0.45.0-debian timberio/vector:0.45.0-debian || true
+        
+        # Pre-pull Kurtosis engine components
+        docker pull ghcr.io/kurtosis-tech/kurtosis-engine:1.14.1 || true
+        docker tag ghcr.io/kurtosis-tech/kurtosis-engine:1.14.1 kurtosistech/engine:1.14.1 || true
+        
+        # Pre-pull Geth and tag to avoid Docker Hub
+        docker pull ghcr.io/ethpandaops/geth:master || true
+        docker tag ghcr.io/ethpandaops/geth:master ethereum/client-go:latest || true
+
     - name: Build docker image
       working-directory: ${{ github.workspace }}
       shell: bash

--- a/.github/actions/setup-kurtosis-type1/action.yml
+++ b/.github/actions/setup-kurtosis-type1/action.yml
@@ -30,6 +30,8 @@ runs:
       shell: bash
       run: |
         sed -i 's#leovct/toolbox:0.0.8#europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12#g' ./kurtosis-cdk/src/package_io/constants.star
+        # Redirect Vector to GHCR to avoid Docker Hub rate limits
+        grep -r "timberio/vector" ./kurtosis-cdk | xargs -I {} sed -i 's#timberio/vector#ghcr.io/vectordotdev/vector#g' {} || true
 
     - name: Install Kurtosis CDK tools
       if: env.SKIP_ENCLAVE_SETUP != 'true'
@@ -121,7 +123,7 @@ runs:
         echo '  deploy_op_succinct: false' >> params.yml
         echo 'args:' >> params.yml
         echo '  cdk_erigon_node_image: cdk-erigon-type1:local' >> params.yml
-        echo '  el-1-geth-lighthouse: ethpandaops/lighthouse@sha256:4902d9e4a6b6b8d4c136ea54f0e51582a32f356f3dec7194a1adee13ed2d662e' >> params.yml
+        echo '  el-1-geth-lighthouse: ghcr.io/ethpandaops/lighthouse@sha256:4902d9e4a6b6b8d4c136ea54f0e51582a32f356f3dec7194a1adee13ed2d662e' >> params.yml
         echo '  consensus_contract_type: pessimistic' >> params.yml
         echo '  pp_vkey_hash: 0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7' >> params.yml
         echo '  agglayer_prover_primary_prover: mock-prover' >> params.yml
@@ -146,4 +148,4 @@ runs:
       working-directory: ./kurtosis-cdk
       shell: bash
       run: |
-        kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
+        kurtosis run --enclave cdk-v1 --args-file params.yml .

--- a/.github/actions/setup-kurtosis-type1/action.yml
+++ b/.github/actions/setup-kurtosis-type1/action.yml
@@ -30,8 +30,8 @@ runs:
       shell: bash
       run: |
         sed -i 's#leovct/toolbox:0.0.8#europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12#g' ./kurtosis-cdk/src/package_io/constants.star
-        # Redirect Vector to GHCR to avoid Docker Hub rate limits
-        grep -r "timberio/vector" ./kurtosis-cdk | xargs -I {} sed -i 's#timberio/vector#ghcr.io/vectordotdev/vector#g' {} || true
+        sed -i 's#ethereum/client-go:v1.16.9#ghcr.io/ethpandaops/geth:master#g' ./kurtosis-cdk/src/package_io/constants.star
+        sed -i 's#timberio/vector:0.45.0-debian#ghcr.io/vectordotdev/vector:0.45.0-debian#g' ./kurtosis-cdk/src/package_io/constants.star
 
     - name: Install Kurtosis CDK tools
       if: env.SKIP_ENCLAVE_SETUP != 'true'
@@ -80,20 +80,6 @@ runs:
         echo "Disk usage after cleanup:"
         df -h
 
-    - name: Pre-pull and tag images to avoid Docker Hub
-      shell: bash
-      run: |
-        # Pre-pull Vector from GHCR and tag as timberio/vector to bypass engine pull
-        docker pull --platform linux/amd64 ghcr.io/vectordotdev/vector:0.45.0-debian || true
-        docker tag ghcr.io/vectordotdev/vector:0.45.0-debian timberio/vector:0.45.0-debian || true
-        
-        # Pre-pull Kurtosis engine components
-        docker pull --platform linux/amd64 ghcr.io/kurtosistech/engine:1.14.1 || true
-        docker tag ghcr.io/kurtosistech/engine:1.14.1 kurtosistech/engine:1.14.1 || true
-        
-        # Pre-pull Geth and tag to avoid Docker Hub
-        docker pull --platform linux/amd64 ghcr.io/ethpandaops/geth:latest || true
-        docker tag ghcr.io/ethpandaops/geth:latest ethereum/client-go:latest || true
 
     - name: Build docker image
       working-directory: ${{ github.workspace }}

--- a/.github/actions/setup-kurtosis-type1/action.yml
+++ b/.github/actions/setup-kurtosis-type1/action.yml
@@ -30,7 +30,6 @@ runs:
       shell: bash
       run: |
         sed -i 's#leovct/toolbox:0.0.8#europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12#g' ./kurtosis-cdk/src/package_io/constants.star
-        sed -i 's#ethereum/client-go:v1.16.9#ghcr.io/ethpandaops/geth:master#g' ./kurtosis-cdk/src/package_io/constants.star
         sed -i 's#timberio/vector:0.45.0-debian#ghcr.io/vectordotdev/vector:0.45.0-debian#g' ./kurtosis-cdk/src/package_io/constants.star
 
     - name: Install Kurtosis CDK tools
@@ -124,7 +123,7 @@ runs:
         echo '  deploy_op_succinct: false' >> params.yml
         echo 'args:' >> params.yml
         echo '  cdk_erigon_node_image: cdk-erigon-type1:local' >> params.yml
-        echo '  el-1-geth-lighthouse: ghcr.io/ethpandaops/lighthouse@sha256:4902d9e4a6b6b8d4c136ea54f0e51582a32f356f3dec7194a1adee13ed2d662e' >> params.yml
+        echo '  el-1-geth-lighthouse: ethpandaops/lighthouse@sha256:4902d9e4a6b6b8d4c136ea54f0e51582a32f356f3dec7194a1adee13ed2d662e' >> params.yml
         echo '  consensus_contract_type: pessimistic' >> params.yml
         echo '  pp_vkey_hash: 0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7' >> params.yml
         echo '  agglayer_prover_primary_prover: mock-prover' >> params.yml

--- a/.github/actions/setup-kurtosis-type1/action.yml
+++ b/.github/actions/setup-kurtosis-type1/action.yml
@@ -84,16 +84,16 @@ runs:
       shell: bash
       run: |
         # Pre-pull Vector from GHCR and tag as timberio/vector to bypass engine pull
-        docker pull ghcr.io/vectordotdev/vector:0.45.0-debian || true
+        docker pull --platform linux/amd64 ghcr.io/vectordotdev/vector:0.45.0-debian || true
         docker tag ghcr.io/vectordotdev/vector:0.45.0-debian timberio/vector:0.45.0-debian || true
         
         # Pre-pull Kurtosis engine components
-        docker pull ghcr.io/kurtosis-tech/kurtosis-engine:1.14.1 || true
-        docker tag ghcr.io/kurtosis-tech/kurtosis-engine:1.14.1 kurtosistech/engine:1.14.1 || true
+        docker pull --platform linux/amd64 ghcr.io/kurtosistech/engine:1.14.1 || true
+        docker tag ghcr.io/kurtosistech/engine:1.14.1 kurtosistech/engine:1.14.1 || true
         
         # Pre-pull Geth and tag to avoid Docker Hub
-        docker pull ghcr.io/ethpandaops/geth:master || true
-        docker tag ghcr.io/ethpandaops/geth:master ethereum/client-go:latest || true
+        docker pull --platform linux/amd64 ghcr.io/ethpandaops/geth:latest || true
+        docker tag ghcr.io/ethpandaops/geth:latest ethereum/client-go:latest || true
 
     - name: Build docker image
       working-directory: ${{ github.workspace }}

--- a/.github/actions/setup-kurtosis/action.yml
+++ b/.github/actions/setup-kurtosis/action.yml
@@ -20,8 +20,8 @@ runs:
       shell: bash
       run: |
         sed -i 's#leovct/toolbox:0.0.8#europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12#g' ./kurtosis-cdk/src/package_io/constants.star
-        # Redirect Vector to GHCR to avoid Docker Hub rate limits
-        grep -r "timberio/vector" ./kurtosis-cdk | xargs -I {} sed -i 's#timberio/vector#ghcr.io/vectordotdev/vector#g' {} || true
+        sed -i 's#ethereum/client-go:v1.16.9#ghcr.io/ethpandaops/geth:master#g' ./kurtosis-cdk/src/package_io/constants.star
+        sed -i 's#timberio/vector:0.45.0-debian#ghcr.io/vectordotdev/vector:0.45.0-debian#g' ./kurtosis-cdk/src/package_io/constants.star
 
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/kurtosis-pre-run
@@ -64,20 +64,6 @@ runs:
         echo "Disk usage after cleanup:"
         df -h
 
-    - name: Pre-pull and tag images to avoid Docker Hub
-      shell: bash
-      run: |
-        # Pre-pull Vector from GHCR and tag as timberio/vector to bypass engine pull
-        docker pull --platform linux/amd64 ghcr.io/vectordotdev/vector:0.45.0-debian || true
-        docker tag ghcr.io/vectordotdev/vector:0.45.0-debian timberio/vector:0.45.0-debian || true
-        
-        # Pre-pull Kurtosis engine components
-        docker pull --platform linux/amd64 ghcr.io/kurtosistech/engine:1.14.1 || true
-        docker tag ghcr.io/kurtosistech/engine:1.14.1 kurtosistech/engine:1.14.1 || true
-        
-        # Pre-pull Geth and tag to avoid Docker Hub
-        docker pull --platform linux/amd64 ghcr.io/ethpandaops/geth:latest || true
-        docker tag ghcr.io/ethpandaops/geth:latest ethereum/client-go:latest || true
 
     - name: Build docker image
       working-directory: ./cdk-erigon

--- a/.github/actions/setup-kurtosis/action.yml
+++ b/.github/actions/setup-kurtosis/action.yml
@@ -20,6 +20,8 @@ runs:
       shell: bash
       run: |
         sed -i 's#leovct/toolbox:0.0.8#europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12#g' ./kurtosis-cdk/src/package_io/constants.star
+        # Redirect Vector to GHCR to avoid Docker Hub rate limits
+        grep -r "timberio/vector" ./kurtosis-cdk | xargs -I {} sed -i 's#timberio/vector#ghcr.io/vectordotdev/vector#g' {} || true
 
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/kurtosis-pre-run
@@ -95,10 +97,10 @@ runs:
         echo '  aggkit_image: ghcr.io/agglayer/aggkit:0.7.0-beta8' >> params.yml
         echo '  aggkit_components: aggsender' >> params.yml
         echo '  gas_token_enabled: false' >> params.yml
-        echo '  el-1-geth-lighthouse: ethpandaops/lighthouse@sha256:4902d9e4a6b6b8d4c136ea54f0e51582a32f356f3dec7194a1adee13ed2d662e' >> params.yml
+        echo '  el-1-geth-lighthouse: ghcr.io/ethpandaops/lighthouse@sha256:4902d9e4a6b6b8d4c136ea54f0e51582a32f356f3dec7194a1adee13ed2d662e' >> params.yml
         echo '  sequencer_type: erigon' >> params.yml
         echo '  erigon_strict_mode: false' >> params.yml
-        echo '  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12' >> params.yml
+        echo '  zkevm_prover_image: ghcr.io/0xpolygon/zkevm-prover:v8.0.0-RC16-fork.12' >> params.yml
         /usr/local/bin/yq -i '.args.consensus_contract_type = "${{ matrix.da-mode }}"' params.yml
         sed -i 's/"londonBlock": [0-9]\+/"londonBlock": 0/' ./templates/cdk-erigon/chainspec.json
         sed -i 's/"normalcyBlock": [0-9]\+/"normalcyBlock": 0/' ./templates/cdk-erigon/chainspec.json
@@ -112,4 +114,4 @@ runs:
       working-directory: ./kurtosis-cdk
       shell: bash
       run: |
-        kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
+        kurtosis run --enclave cdk-v1 --args-file params.yml .

--- a/.github/actions/setup-kurtosis/action.yml
+++ b/.github/actions/setup-kurtosis/action.yml
@@ -64,6 +64,21 @@ runs:
         echo "Disk usage after cleanup:"
         df -h
 
+    - name: Pre-pull and tag images to avoid Docker Hub
+      shell: bash
+      run: |
+        # Pre-pull Vector from GHCR and tag as timberio/vector to bypass engine pull
+        docker pull ghcr.io/vectordotdev/vector:0.45.0-debian || true
+        docker tag ghcr.io/vectordotdev/vector:0.45.0-debian timberio/vector:0.45.0-debian || true
+        
+        # Pre-pull Kurtosis engine components
+        docker pull ghcr.io/kurtosis-tech/kurtosis-engine:1.14.1 || true
+        docker tag ghcr.io/kurtosis-tech/kurtosis-engine:1.14.1 kurtosistech/engine:1.14.1 || true
+        
+        # Pre-pull Geth and tag to avoid Docker Hub
+        docker pull ghcr.io/ethpandaops/geth:master || true
+        docker tag ghcr.io/ethpandaops/geth:master ethereum/client-go:latest || true
+
     - name: Build docker image
       working-directory: ./cdk-erigon
       shell: bash

--- a/.github/actions/setup-kurtosis/action.yml
+++ b/.github/actions/setup-kurtosis/action.yml
@@ -20,7 +20,6 @@ runs:
       shell: bash
       run: |
         sed -i 's#leovct/toolbox:0.0.8#europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12#g' ./kurtosis-cdk/src/package_io/constants.star
-        sed -i 's#ethereum/client-go:v1.16.9#ghcr.io/ethpandaops/geth:master#g' ./kurtosis-cdk/src/package_io/constants.star
         sed -i 's#timberio/vector:0.45.0-debian#ghcr.io/vectordotdev/vector:0.45.0-debian#g' ./kurtosis-cdk/src/package_io/constants.star
 
     - name: Install Kurtosis CDK tools
@@ -98,7 +97,7 @@ runs:
         echo '  aggkit_image: ghcr.io/agglayer/aggkit:0.7.0-beta8' >> params.yml
         echo '  aggkit_components: aggsender' >> params.yml
         echo '  gas_token_enabled: false' >> params.yml
-        echo '  el-1-geth-lighthouse: ghcr.io/ethpandaops/lighthouse@sha256:4902d9e4a6b6b8d4c136ea54f0e51582a32f356f3dec7194a1adee13ed2d662e' >> params.yml
+        echo '  el-1-geth-lighthouse: ethpandaops/lighthouse@sha256:4902d9e4a6b6b8d4c136ea54f0e51582a32f356f3dec7194a1adee13ed2d662e' >> params.yml
         echo '  sequencer_type: erigon' >> params.yml
         echo '  erigon_strict_mode: false' >> params.yml
         echo '  zkevm_prover_image: ghcr.io/0xpolygon/zkevm-prover:v8.0.0-RC16-fork.12' >> params.yml

--- a/.github/actions/setup-kurtosis/action.yml
+++ b/.github/actions/setup-kurtosis/action.yml
@@ -68,16 +68,16 @@ runs:
       shell: bash
       run: |
         # Pre-pull Vector from GHCR and tag as timberio/vector to bypass engine pull
-        docker pull ghcr.io/vectordotdev/vector:0.45.0-debian || true
+        docker pull --platform linux/amd64 ghcr.io/vectordotdev/vector:0.45.0-debian || true
         docker tag ghcr.io/vectordotdev/vector:0.45.0-debian timberio/vector:0.45.0-debian || true
         
         # Pre-pull Kurtosis engine components
-        docker pull ghcr.io/kurtosis-tech/kurtosis-engine:1.14.1 || true
-        docker tag ghcr.io/kurtosis-tech/kurtosis-engine:1.14.1 kurtosistech/engine:1.14.1 || true
+        docker pull --platform linux/amd64 ghcr.io/kurtosistech/engine:1.14.1 || true
+        docker tag ghcr.io/kurtosistech/engine:1.14.1 kurtosistech/engine:1.14.1 || true
         
         # Pre-pull Geth and tag to avoid Docker Hub
-        docker pull ghcr.io/ethpandaops/geth:master || true
-        docker tag ghcr.io/ethpandaops/geth:master ethereum/client-go:latest || true
+        docker pull --platform linux/amd64 ghcr.io/ethpandaops/geth:latest || true
+        docker tag ghcr.io/ethpandaops/geth:latest ethereum/client-go:latest || true
 
     - name: Build docker image
       working-directory: ./cdk-erigon

--- a/.github/workflows/aggkit-e2e-single-chain.yml
+++ b/.github/workflows/aggkit-e2e-single-chain.yml
@@ -62,7 +62,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: cdk-erigon
-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build-aggkit-image.yml
+++ b/.github/workflows/build-aggkit-image.yml
@@ -33,7 +33,11 @@ jobs:
           repository: ${{ inputs.repository }}
           # if inputs.ref is non-empty, use it, otherwise use the ref that triggered *this* run
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -99,6 +105,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/ci_zkevm.yml
+++ b/.github/workflows/ci_zkevm.yml
@@ -91,10 +91,13 @@ jobs:
     steps:
       - name: Checkout cdk-erigon
         uses: actions/checkout@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup kurtosis
         uses: ./.github/actions/setup-kurtosis
-
-
       - name: Run process with CPU monitoring
         working-directory: ./cdk-erigon
         run: |
@@ -187,7 +190,11 @@ jobs:
     steps:
       - name: Checkout cdk-erigon
         uses: actions/checkout@v4
-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup kurtosis
         uses: ./.github/actions/setup-kurtosis-type1
 
@@ -260,7 +267,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: cdk-erigon
-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Checkout kurtosis-cdk
         uses: actions/checkout@v4
       - name: Setup kurtosis

--- a/.github/workflows/devtooling.yml
+++ b/.github/workflows/devtooling.yml
@@ -3,7 +3,7 @@ name: Devtooling tests
 on:
   schedule:
     - cron: '0 0 * * *'  # Runs every night at midnight UTC
-  
+
 env:
   DEVTOOLING_IMAGE: xavierromero/devtooling:20241210
 
@@ -15,6 +15,12 @@ jobs:
     steps:
       - name: Checkout cdk-erigon
         uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Setup kurtosis
         uses: ./.github/actions/setup-kurtosis

--- a/.github/workflows/nightly-bridge-erc20.yml
+++ b/.github/workflows/nightly-bridge-erc20.yml
@@ -22,7 +22,12 @@ jobs:
     steps:
       - name: Clone bridge repository
         run:  git clone --recurse-submodules -j8 https://github.com/0xPolygonHermez/zkevm-bridge-service.git -b feature/test_bridge_messages_real_network-v2  bridge
-        
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build docker image
         run: |
           cd bridge
@@ -45,4 +50,4 @@ jobs:
           L2BridgeAddr="${{ matrix.bridge_addr }}"
           EOF
           docker run  --volume "./tmp/:/config/" --env BRIDGE_TEST_CONFIG_FILE=/config/test.toml bridge-e2e-realnetwork-erc20
-        
+

--- a/.github/workflows/nightly-bridge-msg.yml
+++ b/.github/workflows/nightly-bridge-msg.yml
@@ -22,7 +22,12 @@ jobs:
     steps:
       - name: Clone bridge repository
         run:  git clone --recurse-submodules -j8 https://github.com/0xPolygonHermez/zkevm-bridge-service.git -b  develop  bridge
-        
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build docker image
         run: |
           cd bridge
@@ -45,4 +50,4 @@ jobs:
           L2BridgeAddr="${{ matrix.bridge_addr }}"
           EOF
           docker run  --volume "./tmp/:/config/" --env BRIDGE_TEST_CONFIG_FILE=/config/test.toml bridge-e2e-realnetwork-msg
-        
+

--- a/.github/workflows/nightly-eth-bench.yml
+++ b/.github/workflows/nightly-eth-bench.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Checkout current repository
         uses: actions/checkout@v3
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Clone eth-bench repository
         run: git clone --recurse-submodules -j8 https://github.com/xavier-romero/eth-bench.git
 

--- a/.github/workflows/reusable_type1.yml
+++ b/.github/workflows/reusable_type1.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Checkout cdk-erigon
         uses: actions/checkout@v4
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Setup kurtosis type-1
         uses: ./.github/actions/setup-kurtosis-type1
         with:

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -13,6 +13,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Setup kurtosis
         uses: ./.github/actions/setup-kurtosis
 

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -17,6 +17,11 @@ jobs:
           repository: ethereum/hive
           # ref: prague-devnet-4
           path: hive
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup go env and cache
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -20,6 +20,11 @@ jobs:
           repository: ethereum/hive
           # ref: master
           path: hive
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup go env and cache
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Fast checkout git repository
         uses: actions/checkout@v4
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker build current branch
         run: |
           docker build -t test/erigon:current .


### PR DESCRIPTION
This PR adds Docker Hub authentication to all major CI workflows to resolve pull rate limit issues. It uses existing  and  secrets.