### PR TITLE
feat: add --zkevm.sync-sequencer-l1-data flag for RPC→Sequencer promotion

### DIFF
--- a/cmd/integration/commands/stages_zkevm.go
+++ b/cmd/integration/commands/stages_zkevm.go
@@ -170,6 +170,7 @@ func newSyncZk(ctx context.Context, db kv.RwDB) (consensus.Engine, *vm.Config, *
 			nil,
 			nil,
 			nil,
+			nil,
 			nil)
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1011,6 +1011,11 @@ var (
 		Usage: "Enable mutable RPC headers, this will allow block hash recalculation from the RLP rather than trusting the canonical hash",
 		Value: false,
 	}
+	SyncSequencerL1Data = cli.BoolFlag{
+		Name:  "zkevm.sync-sequencer-l1-data",
+		Usage: "Sync sequencer-specific L1 data (fork history, rollup types) on RPC nodes for sequencer promotion readiness",
+		Value: false,
+	}
 	ACLPrintHistory = cli.IntFlag{
 		Name:  "acl.print-history",
 		Usage: "Number of entries to print from the ACL history on node start up",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1236,6 +1236,27 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			}
 			streamClient := initDataStreamClient(ctx, cfg.Zk, uint16(latestForkId))
 
+			var sequencerL1Syncer *syncer.L1Syncer
+			if cfg.Zk.SyncSequencerL1Data {
+				sequencerL1Syncer = syncer.NewL1Syncer(
+					ctx,
+					ethermanPool,
+					[]libcommon.Address{cfg.AddressZkevm, cfg.AddressRollup},
+					[][]libcommon.Hash{{
+						contracts.InitialSequenceBatchesTopic,
+						contracts.AddNewRollupTypeTopic,
+						contracts.AddNewRollupTypeTopicBanana,
+						contracts.CreateNewRollupTopic,
+						contracts.UpdateRollupTopic,
+					}},
+					cfg.L1BlockRange,
+					cfg.L1QueryDelay,
+					cfg.L1HighestBlockType,
+					cfg.Zk.L1FirstBlock,
+				)
+				log.Info("Sequencer L1 data sync enabled for RPC node")
+			}
+
 			backend.syncStages = stages2.NewDefaultZkStages(
 				backend.sentryCtx,
 				backend.chainDB,
@@ -1251,6 +1272,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 				streamClient,
 				dataStreamServer,
 				l1InfoTreeUpdater,
+				sequencerL1Syncer,
 			)
 
 			backend.syncUnwindOrder = zkStages.ZkUnwindOrder

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -139,6 +139,7 @@ type Zk struct {
 	SequencerBlockGasLimit            uint64
 	PessimisticForkNumber             uint64
 	MutableRPCHeaders                 bool
+	SyncSequencerL1Data               bool
 }
 
 func (c *Zk) ShouldCountersBeUnlimited(l1Recovery bool) bool {

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -353,4 +353,5 @@ var DefaultFlags = []cli.Flag{
 	&utils.SequencerBlockGasLimit,
 	&utils.PessimisticForkNumber,
 	&utils.MutableRPCHeaders,
+	&utils.SyncSequencerL1Data,
 }

--- a/turbo/cli/flags_zkevm.go
+++ b/turbo/cli/flags_zkevm.go
@@ -346,6 +346,7 @@ func ApplyFlagsForZkConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		SequencerBlockGasLimit:                 ctx.Uint64(utils.SequencerBlockGasLimit.Name),
 		PessimisticForkNumber:                  ctx.Uint64(utils.PessimisticForkNumber.Name),
 		MutableRPCHeaders:                      ctx.Bool(utils.MutableRPCHeaders.Name),
+		SyncSequencerL1Data:                    ctx.Bool(utils.SyncSequencerL1Data.Name),
 	}
 
 	utils2.EnableTimer(cfg.DebugTimers)

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -39,6 +39,7 @@ func NewDefaultZkStages(ctx context.Context,
 	datastreamClient zkStages.DatastreamClient,
 	dataStreamServer server.DataStreamServer,
 	infoTreeUpdater *l1infotree.Updater,
+	sequencerL1Syncer *syncer.L1Syncer,
 ) []*stagedsync.Stage {
 	dirs := cfg.Dirs
 	blockWriter := blockio.NewBlockWriter(cfg.HistoryV3)
@@ -53,6 +54,7 @@ func NewDefaultZkStages(ctx context.Context,
 
 	return zkStages.DefaultZkStages(ctx,
 		zkStages.StageL1SyncerCfg(db, l1Syncer, cfg.Zk),
+		zkStages.StageL1SequencerSyncCfg(db, cfg.Zk, sequencerL1Syncer),
 		zkStages.StageL1InfoTreeCfg(db, cfg.Zk, controlServer.ChainConfig, infoTreeUpdater),
 		zkStages.StageBatchesCfg(db, datastreamClient, cfg.Zk, controlServer.ChainConfig, &cfg.Miner),
 		zkStages.StageDataStreamCatchupCfg(dataStreamServer, db, cfg.Genesis.Config.ChainID.Uint64()),

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -52,9 +52,17 @@ func NewDefaultZkStages(ctx context.Context,
 	// Hence we run it in the test mode.
 	runInTestMode := cfg.ImportMode
 
+	// Avoid Go's nil-interface gotcha: a typed nil *syncer.L1Syncer wrapped in
+	// the l1infotree.Syncer interface is not == nil, which would bypass the
+	// Disabled check in the stage. Pass an explicit untyped nil instead.
+	var seqSyncer l1infotree.Syncer
+	if sequencerL1Syncer != nil {
+		seqSyncer = sequencerL1Syncer
+	}
+
 	return zkStages.DefaultZkStages(ctx,
 		zkStages.StageL1SyncerCfg(db, l1Syncer, cfg.Zk),
-		zkStages.StageL1SequencerSyncCfg(db, cfg.Zk, sequencerL1Syncer),
+		zkStages.StageL1SequencerSyncCfg(db, cfg.Zk, seqSyncer),
 		zkStages.StageL1InfoTreeCfg(db, cfg.Zk, controlServer.ChainConfig, infoTreeUpdater),
 		zkStages.StageBatchesCfg(db, datastreamClient, cfg.Zk, controlServer.ChainConfig, &cfg.Miner),
 		zkStages.StageDataStreamCatchupCfg(dataStreamServer, db, cfg.Genesis.Config.ChainID.Uint64()),

--- a/zk/stages/stage_l1_sequencer_sync.go
+++ b/zk/stages/stage_l1_sequencer_sync.go
@@ -46,6 +46,11 @@ func SpawnL1SequencerSyncStage(
 	log.Info(fmt.Sprintf("[%s] Starting L1 Sequencer sync stage", logPrefix))
 	defer log.Info(fmt.Sprintf("[%s] Finished L1 Sequencer sync stage", logPrefix))
 
+	if cfg.syncer == nil {
+		log.Info(fmt.Sprintf("[%s] L1 Sequencer sync skipped - no syncer configured", logPrefix))
+		return nil
+	}
+
 	freshTx := tx == nil
 	if freshTx {
 		var err error

--- a/zk/stages/stages.go
+++ b/zk/stages/stages.go
@@ -287,6 +287,7 @@ func trieConfigRPC(zkInterHashesCfg ZkInterHashesCfg) stages.TrieCfg {
 func DefaultZkStages(
 	ctx context.Context,
 	l1SyncerCfg L1SyncerCfg,
+	l1SequencerSyncCfg L1SequencerSyncCfg,
 	l1InfoTreeCfg L1InfoTreeCfg,
 	batchesCfg BatchesCfg,
 	dataStreamCatchupCfg DataStreamCatchupCfg,
@@ -319,6 +320,20 @@ func DefaultZkStages(
 			},
 			Prune: func(firstCycle bool, p *stages.PruneState, tx kv.RwTx, logger log.Logger) error {
 				return PruneL1SyncerStage(p, tx, l1SyncerCfg, ctx)
+			},
+		},
+		{
+			ID:          stages2.L1SequencerSyncer,
+			Description: "L1 Sequencer Sync Updates",
+			Disabled:    l1SequencerSyncCfg.syncer == nil,
+			Forward: func(firstCycle bool, badBlockUnwind bool, s *stages.StageState, u stages.Unwinder, txc wrap.TxContainer, logger log.Logger) error {
+				return SpawnL1SequencerSyncStage(s, u, txc.Tx, l1SequencerSyncCfg, ctx, logger)
+			},
+			Unwind: func(firstCycle bool, u *stages.UnwindState, s *stages.StageState, txc wrap.TxContainer, logger log.Logger) error {
+				return UnwindL1SequencerSyncStage(u, txc.Tx, l1SequencerSyncCfg, ctx)
+			},
+			Prune: func(firstCycle bool, p *stages.PruneState, tx kv.RwTx, logger log.Logger) error {
+				return PruneL1SequencerSyncStage(p, tx, l1SequencerSyncCfg, ctx)
 			},
 		},
 		{
@@ -582,6 +597,7 @@ func DefaultZkStages(
 
 var AllStagesZk = []stages2.SyncStage{
 	stages2.L1Syncer,
+	stages2.L1SequencerSyncer,
 	stages2.Batches,
 	stages2.BlockHashes,
 	stages2.Senders,
@@ -620,6 +636,7 @@ var ZkUnwindOrder = stages.UnwindOrder{
 	stages2.Senders,
 	stages2.BlockHashes,
 	stages2.Batches,
+	stages2.L1SequencerSyncer,
 	stages2.L1Syncer,
 	stages2.Finish,
 }


### PR DESCRIPTION
## Summary
- Add opt-in `--zkevm.sync-sequencer-l1-data` flag so RPC nodes designated as standby sequencers can pre-sync L1 sequencer data (fork history, rollup type mappings)
- When enabled, the `L1SequencerSync` stage runs in the RPC pipeline with its own `L1Syncer` using sequencer-specific topics/contracts
- When disabled (default), behavior is unchanged — the stage is disabled via nil syncer check

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./zk/stages/... -run L1Sequencer` passes (3/3 tests)
- [x] Start RPC with `--zkevm.sync-sequencer-l1-data` — L1SequencerSync stage should appear in logs and populate fork history tables
- [x] Start RPC without the flag — behavior unchanged, L1SequencerSync stage should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)